### PR TITLE
Support for parsing versions from maven pom.properties files

### DIFF
--- a/src/test/java/com/fasterxml/jackson/core/util/TestVersionUtil.java
+++ b/src/test/java/com/fasterxml/jackson/core/util/TestVersionUtil.java
@@ -1,7 +1,6 @@
 package com.fasterxml.jackson.core.util;
 
 import com.fasterxml.jackson.core.Version;
-import com.fasterxml.jackson.core.util.VersionUtil;
 
 public class TestVersionUtil extends com.fasterxml.jackson.test.BaseTest
 {
@@ -15,5 +14,10 @@ public class TestVersionUtil extends com.fasterxml.jackson.test.BaseTest
     public void testVersionParsing()
     {
         assertEquals(new Version(1, 2, 15, "foo"), VersionUtil.parseVersion("1.2.15-foo"));
+    }
+
+    public void testMavenVersionParsing() {
+        assertEquals(new Version(1, 2, 3, "SNAPSHOT", "foo.bar", "foo-bar"),
+                VersionUtil.mavenVersionFor(TestVersionUtil.class.getClassLoader(), "foo.bar", "foo-bar"));
     }
 }

--- a/src/test/resources/META-INF/maven/foo/bar/foo-bar/pom.properties
+++ b/src/test/resources/META-INF/maven/foo/bar/foo-bar/pom.properties
@@ -1,0 +1,3 @@
+groupId=foo.bar
+artifactId=foo-bar
+version=1.2.3-SNAPSHOT


### PR DESCRIPTION
I implemented this in my own project, and then thought it would be more useful in jackson-core.  Maven puts version info by default in META-INF/maven/groupId/artifactId/pom.properties, so it makes sense that jackson-core should provide a convenience method for loading Version objects from it that jackson modules can use.  The method also accepts a classloader, which should ensure it works in OSGi environments.
