### PR TITLE
missing delegation in JsonParserDelegate

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/util/JsonParserDelegate.java
+++ b/src/main/java/com/fasterxml/jackson/core/util/JsonParserDelegate.java
@@ -218,6 +218,26 @@ public class JsonParserDelegate extends JsonParser
     public Number getNumberValue() throws IOException, JsonParseException {
         return delegate.getNumberValue();
     }
+    
+    /*
+    /**********************************************************
+    /* Public API, access to token information, other
+    /**********************************************************
+     */
+    
+    @Override
+    public boolean getBooleanValue()
+        throws IOException, JsonParseException
+    {
+        return delegate.getBooleanValue();
+    }
+
+    @Override
+    public Object getEmbeddedObject()
+        throws IOException, JsonParseException
+    {
+        return delegate.getEmbeddedObject();
+    }
 
     @Override
     public byte[] getBinaryValue(Base64Variant b64variant) throws IOException, JsonParseException {


### PR DESCRIPTION
implementing delegation of methods getEmbeddedObject() and
getBooleanValue() in JsonParserDelegate

just discovered that you are now on github, see JIRA ticked JACKSON-753 at codehaus.org
