### PR TITLE
enable site generation + deploy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,7 @@
   </prerequisites>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <surefire.version>2.12</surefire.version>
   </properties>
 
   <!-- Licensing -->
@@ -118,6 +119,19 @@
                     </execution>
           </executions>
         </plugin>
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-site-plugin</artifactId>
+            <version>3.0</version>
+        </plugin>
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <version>${surefire.version}</version>
+            <configuration>
+                <redirectTestOutputToFile>${surefire.redirectTestOutputToFile}</redirectTestOutputToFile>
+            </configuration>
+        </plugin>
 
         <!-- Plus, let's make jars OSGi bundles as well  -->
         <plugin>
@@ -147,7 +161,77 @@ com.fasterxml.jackson.core.util
           </configuration>
         </plugin>
     </plugins>
+    <extensions>
+        <!-- Enabling the use of SSH -->
+        <extension>
+            <groupId>org.apache.maven.wagon</groupId>
+            <artifactId>wagon-ssh-external</artifactId>
+            <version>1.0-beta-6</version>
+        </extension>
+        <extension>
+            <groupId>org.apache.maven.scm</groupId>
+            <artifactId>maven-scm-provider-gitexe</artifactId>
+            <version>1.6</version>
+        </extension>
+        <extension>
+            <groupId>org.apache.maven.scm</groupId>
+            <artifactId>maven-scm-manager-plexus</artifactId>
+            <version>1.6</version>
+        </extension>
+        <extension>
+            <groupId>org.kathrynhuxtable.maven.wagon</groupId>
+            <artifactId>wagon-gitsite</artifactId>
+            <version>0.3.1</version>
+        </extension>
+    </extensions>
   </build>
+
+  <reporting>
+    <plugins>
+      <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-javadoc-plugin</artifactId>
+          <version>2.8.1</version>
+          <configuration>
+              <aggregate>true</aggregate>
+              <source>1.6</source>
+              <encoding>UTF-8</encoding>
+              <maxmemory>1g</maxmemory>
+              <links>
+                  <link>http://java.sun.com/javase/6/docs/api/</link>
+              </links>
+              <excludePackageNames>${javadoc.package.exclude}</excludePackageNames>
+              <bootclasspath>${sun.boot.class.path}</bootclasspath>
+              <doclet>com.google.doclava.Doclava</doclet>
+              <useStandardDocletOptions>false</useStandardDocletOptions>
+              <additionalJOption>-J-Xmx1024m</additionalJOption>
+              <docletArtifact>
+                  <groupId>com.google.doclava</groupId>
+                  <artifactId>doclava</artifactId>
+                  <version>1.0.3</version>
+              </docletArtifact>
+              <additionalparam>
+                  -hdf project.name "${project.name} ${project.version}"
+                  -d ${project.reporting.outputDirectory}/apidocs
+              </additionalparam>
+          </configuration>
+          <reportSets>
+              <reportSet>
+                  <id>default</id>
+                  <reports>
+                      <report>javadoc</report>
+                  </reports>
+              </reportSet>
+          </reportSets>
+      </plugin>
+      <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-report-plugin</artifactId>
+          <version>${surefire.version}</version>
+      </plugin>
+    </plugins>
+  </reporting>
+
   <profiles>
         <profile>
             <id>release-sign-artifacts</id>

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/DECORATION/1.1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/DECORATION/1.1.0 http://maven.apache.org/xsd/decoration-1.1.0.xsd"
+  name="${project.name}">
+
+  <skin>
+    <groupId>org.apache.maven.skins</groupId>
+    <artifactId>maven-fluido-skin</artifactId>
+    <version>1.1</version>
+  </skin>
+
+  <custom>
+    <fluidoSkin>
+      <topBarEnabled>true</topBarEnabled>
+      <sideBarEnabled>false</sideBarEnabled>
+      <twitter>
+        <user>cowtowncoder</user>
+        <showUser>true</showUser>
+        <showFollowers>true</showFollowers>
+      </twitter>
+    </fluidoSkin>
+  </custom>
+
+  <publishDate format="dd MMMM yyyy" position="left" />
+  <version position="left" />
+
+  <body>
+    <menu name="User guide">
+      <!-- TODO -->
+    </menu>
+
+    <menu ref="reports" inherit="bottom" />
+  </body>
+</project>


### PR DESCRIPTION
with the few proposed modifications, you can simply run `mvn site-deploy` and site will be generated and pushed on http://FasterXML.github.com/jackson-core
Just run `mvn clean site && open target/site/index.html` first to see the result.

Site will be decorated using the maven-fluido-skin, javadoc are enhanced via google doclava - it will reproduce the site exactly as AsyncHttpClient site is: http://sonatype.github.com/async-http-client/

Anyway I'd suggest you to write a corporate parent pom to avoid repeating same stuff in every project - hope I can do something for you in the next days!

Don't hesitate to ping me for anything needs to be clarified!
all the best,
-Simo
