### PR TITLE
Fix for JsonParser.getValueAsLong()

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/JsonParser.java
+++ b/src/main/java/com/fasterxml/jackson/core/JsonParser.java
@@ -1067,7 +1067,7 @@ public abstract class JsonParser
      * default value of <b>0</b> will be returned; no exceptions are thrown.
      */
     public long getValueAsLong() throws IOException, JsonParseException {
-        return getValueAsInt(0);
+        return getValueAsLong(0);
     }
     
     /**


### PR DESCRIPTION
It was defaulting to calling getValueAsInt(), which meant that (unless you
specified a default value) getValueAsLong() was actually returning integers.

For fixing issue #11.
