### PR TITLE
Javadocs fixes in JsonToken

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/JsonToken.java
+++ b/src/main/java/com/fasterxml/jackson/core/JsonToken.java
@@ -32,19 +32,19 @@ public enum JsonToken
     START_OBJECT("{"),
         
     /**
-     * START_OBJECT is returned when encountering '}'
+     * END_OBJECT is returned when encountering '}'
      * which signals ending of an Object value
      */
     END_OBJECT("}"),
         
     /**
-     * START_OBJECT is returned when encountering '['
+     * START_ARRAY is returned when encountering '['
      * which signals starting of an Array value
      */
     START_ARRAY("["),
 
     /**
-     * START_OBJECT is returned when encountering ']'
+     * END_ARRAY is returned when encountering ']'
      * which signals ending of an Array value
      */
     END_ARRAY("]"),


### PR DESCRIPTION
Looks like this one's been there since at least 1.0.1: http://jackson.codehaus.org/1.0.1/javadoc/org/codehaus/jackson/JsonToken.html
