### PR TITLE
Support for shorts in JsonGenerator

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/JsonGenerator.java
+++ b/src/main/java/com/fasterxml/jackson/core/JsonGenerator.java
@@ -786,6 +786,16 @@ public abstract class JsonGenerator
      * Additional white space may be added around the value
      * if pretty-printing is enabled.
      */
+    public abstract void writeNumber(short v)
+        throws IOException, JsonGenerationException;
+
+    /**
+     * Method for outputting given value as Json number.
+     * Can be called in any context where a value is expected
+     * (Array value, Object field value, root-level value).
+     * Additional white space may be added around the value
+     * if pretty-printing is enabled.
+     */
     public abstract void writeNumber(int v)
         throws IOException, JsonGenerationException;
 

--- a/src/main/java/com/fasterxml/jackson/core/io/NumberOutput.java
+++ b/src/main/java/com/fasterxml/jackson/core/io/NumberOutput.java
@@ -62,6 +62,14 @@ public final class NumberOutput
     /**********************************************************
      */
 
+    public static int outputShort(int value, char[] buffer, int offset) {
+    	return outputInt(value, buffer, offset);
+    }
+
+    public static int outputShort(int value, byte[] buffer, int offset) {
+    	return outputInt(value, buffer, offset);
+    }
+    
     /**
      * @return Offset within buffer after outputting int
      */

--- a/src/main/java/com/fasterxml/jackson/core/json/UTF8JsonGenerator.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/UTF8JsonGenerator.java
@@ -772,6 +772,31 @@ public class UTF8JsonGenerator
      */
 
     @Override
+    public void writeNumber(short s)
+        throws IOException, JsonGenerationException
+    {
+        _verifyValueWrite("write number");
+        // up to 5 digits and possible minus sign
+        if ((_outputTail + 6) >= _outputEnd) {
+            _flushBuffer();
+        }
+        if (_cfgNumbersAsStrings) {
+            _writeQuotedShort(s);
+            return;
+        }
+        _outputTail = NumberOutput.outputShort(s, _outputBuffer, _outputTail);
+    }
+    
+    private void _writeQuotedShort(short s) throws IOException {
+        if ((_outputTail + 8) >= _outputEnd) {
+            _flushBuffer();
+        }
+        _outputBuffer[_outputTail++] = BYTE_QUOTE;
+        _outputTail = NumberOutput.outputShort(s, _outputBuffer, _outputTail);
+        _outputBuffer[_outputTail++] = BYTE_QUOTE;
+    } 
+    
+    @Override
     public void writeNumber(int i)
         throws IOException, JsonGenerationException
     {

--- a/src/main/java/com/fasterxml/jackson/core/json/WriterBasedJsonGenerator.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/WriterBasedJsonGenerator.java
@@ -577,6 +577,31 @@ public final class WriterBasedJsonGenerator
      */
 
     @Override
+    public void writeNumber(short s)
+        throws IOException, JsonGenerationException
+    {
+        _verifyValueWrite("write number");
+        if (_cfgNumbersAsStrings) {
+            _writeQuotedShort(s);
+            return;
+        }
+        // up to 5 digits and possible minus sign
+        if ((_outputTail + 6) >= _outputEnd) {
+            _flushBuffer();
+        }
+        _outputTail = NumberOutput.outputShort(s, _outputBuffer, _outputTail);
+    }
+
+    private void _writeQuotedShort(short s) throws IOException {
+        if ((_outputTail + 8) >= _outputEnd) {
+            _flushBuffer();
+        }
+        _outputBuffer[_outputTail++] = '"';
+        _outputTail = NumberOutput.outputShort(s, _outputBuffer, _outputTail);
+        _outputBuffer[_outputTail++] = '"';
+    }    
+
+    @Override
     public void writeNumber(int i)
         throws IOException, JsonGenerationException
     {

--- a/src/main/java/com/fasterxml/jackson/core/util/JsonGeneratorDelegate.java
+++ b/src/main/java/com/fasterxml/jackson/core/util/JsonGeneratorDelegate.java
@@ -281,6 +281,11 @@ public class JsonGeneratorDelegate extends JsonGenerator
      */
 
     @Override
+    public void writeNumber(short v) throws IOException, JsonGenerationException {
+        delegate.writeNumber(v);
+    }
+
+    @Override
     public void writeNumber(int v) throws IOException, JsonGenerationException {
         delegate.writeNumber(v);
     }


### PR DESCRIPTION
Output support for datatype short in jackson-core. See related commits and issue 205 in jackson-databind.
