### PR TITLE
Added support for parsing 'Infinity' when feature ALLOW_NON_NUMERIC_NUMBERS is on.

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/json/ReaderBasedJsonParser.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/ReaderBasedJsonParser.java
@@ -1368,6 +1368,13 @@ public final class ReaderBasedJsonParser
             }
             _reportError("Non-standard token 'NaN': enable JsonParser.Feature.ALLOW_NON_NUMERIC_NUMBERS to allow");
             break;
+        case 'I':
+            _matchToken("Infinity", 1);
+            if (isEnabled(Feature.ALLOW_NON_NUMERIC_NUMBERS)) {
+                return resetAsNaN("Infinity", Double.POSITIVE_INFINITY);
+            }
+            _reportError("Non-standard token 'Infinity': enable JsonParser.Feature.ALLOW_NON_NUMERIC_NUMBERS to allow");
+            break;
         case '+': // note: '-' is taken as number
             if (_inputPtr >= _inputEnd) {
                 if (!loadMore()) {

--- a/src/main/java/com/fasterxml/jackson/core/json/UTF8StreamJsonParser.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/UTF8StreamJsonParser.java
@@ -2260,6 +2260,13 @@ public final class UTF8StreamJsonParser
             }
             _reportError("Non-standard token 'NaN': enable JsonParser.Feature.ALLOW_NON_NUMERIC_NUMBERS to allow");
             break;
+        case 'I':
+            _matchToken("Infinity", 1);
+            if (isEnabled(Feature.ALLOW_NON_NUMERIC_NUMBERS)) {
+                return resetAsNaN("Infinity", Double.POSITIVE_INFINITY);
+            }
+            _reportError("Non-standard token 'Infinity': enable JsonParser.Feature.ALLOW_NON_NUMERIC_NUMBERS to allow");
+            break;
         case '+': // note: '-' is taken as number
             if (_inputPtr >= _inputEnd) {
                 if (!loadMore()) {

--- a/src/test/java/com/fasterxml/jackson/core/json/TestParserNonStandard.java
+++ b/src/test/java/com/fasterxml/jackson/core/json/TestParserNonStandard.java
@@ -398,7 +398,7 @@ public class TestParserNonStandard
 
     private void _testAllowInf(boolean useStream) throws Exception
     {
-        final String JSON = "[ -INF, +INF, +Infinity,-Infinity ]";
+        final String JSON = "[ -INF, +INF, +Infinity, Infinity, -Infinity ]";
         JsonFactory f = new JsonFactory();
         assertFalse(f.isEnabled(JsonParser.Feature.ALLOW_NON_NUMERIC_NUMBERS));
 
@@ -419,7 +419,7 @@ public class TestParserNonStandard
         f.configure(JsonParser.Feature.ALLOW_NON_NUMERIC_NUMBERS, true);
         jp = useStream ? createParserUsingStream(f, JSON, "UTF-8")
                 : createParserUsingReader(f, JSON);
-        
+
         assertToken(JsonToken.START_ARRAY, jp.nextToken());
 
         assertToken(JsonToken.VALUE_NUMBER_FLOAT, jp.nextToken());
@@ -439,7 +439,13 @@ public class TestParserNonStandard
         assertEquals("+Infinity", jp.getText());
         assertTrue(Double.isInfinite(d));
         assertTrue(d == Double.POSITIVE_INFINITY);
-        
+
+        assertToken(JsonToken.VALUE_NUMBER_FLOAT, jp.nextToken());
+        d = jp.getDoubleValue();
+        assertEquals("Infinity", jp.getText());
+        assertTrue(Double.isInfinite(d));
+        assertTrue(d == Double.POSITIVE_INFINITY);
+
         assertToken(JsonToken.VALUE_NUMBER_FLOAT, jp.nextToken());
         d = jp.getDoubleValue();
         assertEquals("-Infinity", jp.getText());
@@ -455,6 +461,7 @@ public class TestParserNonStandard
                 : createParserUsingReader(f, JSON);
 
         assertToken(JsonToken.START_ARRAY, jp.nextToken());
+        assertToken(JsonToken.VALUE_NUMBER_FLOAT, jp.nextToken());
         assertToken(JsonToken.VALUE_NUMBER_FLOAT, jp.nextToken());
         assertToken(JsonToken.VALUE_NUMBER_FLOAT, jp.nextToken());
         assertToken(JsonToken.VALUE_NUMBER_FLOAT, jp.nextToken());


### PR DESCRIPTION
This fixes a bug wherein converting a Node to string and then back fails, because
.toString() writes Double.POSITIVE_INFINITY as Infinity, but the current functionality
only supports +Infinity.
