### PR TITLE
Properly close JSON String when an IOException is thrown because the first byte can't be read

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/json/UTF8JsonGenerator.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/UTF8JsonGenerator.java
@@ -766,12 +766,12 @@ public class UTF8JsonGenerator
             }
         } finally {
             _ioContext.releaseBase64Buffer(encodingBuffer);
+            // and closing quotes
+            if (_outputTail >= _outputEnd) {
+                _flushBuffer();
+            }
+            _outputBuffer[_outputTail++] = BYTE_QUOTE;
         }
-        // and closing quotes
-        if (_outputTail >= _outputEnd) {
-            _flushBuffer();
-        }
-        _outputBuffer[_outputTail++] = BYTE_QUOTE;
         return bytes;
     }
     


### PR DESCRIPTION
If the first byte from reading an InputStream can't be read, an IOException will be thrown and the resulting JSON string will not have the ending '"'.
