### PR TITLE
Fix Android 2.2 compatibility

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/io/CharacterEscapes.java
+++ b/src/main/java/com/fasterxml/jackson/core/io/CharacterEscapes.java
@@ -1,8 +1,7 @@
 package com.fasterxml.jackson.core.io;
 
-import java.util.Arrays;
-
 import com.fasterxml.jackson.core.SerializableString;
+import com.fasterxml.jackson.core.util.ArraysCompat;
 
 /**
  * Abstract base class that defines interface for customizing character
@@ -66,6 +65,6 @@ public abstract class CharacterEscapes
     public static int[] standardAsciiEscapesForJSON()
     {
         int[] esc = CharTypes.get7BitOutputEscapes();
-        return Arrays.copyOf(esc, esc.length);
+        return ArraysCompat.copyOf(esc, esc.length);
     }
 }

--- a/src/main/java/com/fasterxml/jackson/core/json/UTF8StreamJsonParser.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/UTF8StreamJsonParser.java
@@ -1,7 +1,6 @@
 package com.fasterxml.jackson.core.json;
 
 import java.io.*;
-import java.util.Arrays;
 
 import com.fasterxml.jackson.core.*;
 import com.fasterxml.jackson.core.base.ParserBase;
@@ -3129,7 +3128,7 @@ public class UTF8StreamJsonParser
         if (arr == null) {
             return new int[more];
         }
-        return Arrays.copyOf(arr, arr.length + more);
+        return ArraysCompat.copyOf(arr, arr.length + more);
     }
 
     /*

--- a/src/main/java/com/fasterxml/jackson/core/sym/BytesToNameCanonicalizer.java
+++ b/src/main/java/com/fasterxml/jackson/core/sym/BytesToNameCanonicalizer.java
@@ -3,6 +3,7 @@ package com.fasterxml.jackson.core.sym;
 import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicReference;
 
+import com.fasterxml.jackson.core.util.ArraysCompat;
 import com.fasterxml.jackson.core.util.InternCache;
 
 /**
@@ -997,7 +998,7 @@ public final class BytesToNameCanonicalizer
      */
     private void unshareMain() {
         final int[] old = _hash;
-        _hash = Arrays.copyOf(old, old.length);
+        _hash = ArraysCompat.copyOf(old, old.length);
         _hashShared = false;
     }
 
@@ -1006,20 +1007,20 @@ public final class BytesToNameCanonicalizer
         if (old == null) {
             _collList = new Bucket[INITIAL_COLLISION_LEN];
         } else {
-            _collList = Arrays.copyOf(old, old.length);
+            _collList = ArraysCompat.copyOf(old, old.length);
         }
         _collListShared = false;
     }
 
     private void unshareNames() {
         final Name[] old = _mainNames;
-        _mainNames = Arrays.copyOf(old, old.length);
+        _mainNames = ArraysCompat.copyOf(old, old.length);
         _namesShared = false;
     }
 
     private void expandCollision() {
         final Bucket[] old = _collList;
-        _collList = Arrays.copyOf(old, old.length * 2);
+        _collList = ArraysCompat.copyOf(old, old.length * 2);
     }
 
     /*

--- a/src/main/java/com/fasterxml/jackson/core/sym/CharsToNameCanonicalizer.java
+++ b/src/main/java/com/fasterxml/jackson/core/sym/CharsToNameCanonicalizer.java
@@ -2,6 +2,7 @@ package com.fasterxml.jackson.core.sym;
 
 import java.util.Arrays;
 
+import com.fasterxml.jackson.core.util.ArraysCompat;
 import com.fasterxml.jackson.core.util.InternCache;
 
 /**
@@ -548,9 +549,9 @@ public final class CharsToNameCanonicalizer
      */
     private void copyArrays() {
         final String[] oldSyms = _symbols;
-        _symbols = Arrays.copyOf(oldSyms, oldSyms.length);
+        _symbols = ArraysCompat.copyOf(oldSyms, oldSyms.length);
         final Bucket[] oldBuckets = _buckets;
-        _buckets = Arrays.copyOf(oldBuckets, oldBuckets.length);
+        _buckets = ArraysCompat.copyOf(oldBuckets, oldBuckets.length);
     }
 
     /**

--- a/src/main/java/com/fasterxml/jackson/core/util/ArraysCompat.java
+++ b/src/main/java/com/fasterxml/jackson/core/util/ArraysCompat.java
@@ -1,0 +1,487 @@
+package com.fasterxml.jackson.core.util;
+
+import java.lang.reflect.Array;
+
+/**
+ * ArraysCompat implements {@link java.util.Arrays} methods which are not available in Android 2.2 (FroYo).
+ */
+public class ArraysCompat {
+    /**
+     * Copies {@code newLength} elements from {@code original} into a new array.
+     * If {@code newLength} is greater than {@code original.length}, the result is padded
+     * with the value {@code false}.
+     *
+     * @param original the original array
+     * @param newLength the length of the new array
+     * @return the new array
+     * @throws NegativeArraySizeException if {@code newLength < 0}
+     * @throws NullPointerException if {@code original == null}
+     */
+    public static boolean[] copyOf(boolean[] original, int newLength) {
+        if (newLength < 0) {
+            throw new NegativeArraySizeException(Integer.toString(newLength));
+        }
+        return copyOfRange(original, 0, newLength);
+    }
+
+    /**
+     * Copies {@code newLength} elements from {@code original} into a new array.
+     * If {@code newLength} is greater than {@code original.length}, the result is padded
+     * with the value {@code (byte) 0}.
+     *
+     * @param original the original array
+     * @param newLength the length of the new array
+     * @return the new array
+     * @throws NegativeArraySizeException if {@code newLength < 0}
+     * @throws NullPointerException if {@code original == null}
+     */
+    public static byte[] copyOf(byte[] original, int newLength) {
+        if (newLength < 0) {
+            throw new NegativeArraySizeException(Integer.toString(newLength));
+        }
+        return copyOfRange(original, 0, newLength);
+    }
+
+    /**
+     * Copies {@code newLength} elements from {@code original} into a new array.
+     * If {@code newLength} is greater than {@code original.length}, the result is padded
+     * with the value {@code '\\u0000'}.
+     *
+     * @param original the original array
+     * @param newLength the length of the new array
+     * @return the new array
+     * @throws NegativeArraySizeException if {@code newLength < 0}
+     * @throws NullPointerException if {@code original == null}
+     */
+    public static char[] copyOf(char[] original, int newLength) {
+        if (newLength < 0) {
+            throw new NegativeArraySizeException(Integer.toString(newLength));
+        }
+        return copyOfRange(original, 0, newLength);
+    }
+
+    /**
+     * Copies {@code newLength} elements from {@code original} into a new array.
+     * If {@code newLength} is greater than {@code original.length}, the result is padded
+     * with the value {@code 0.0d}.
+     *
+     * @param original the original array
+     * @param newLength the length of the new array
+     * @return the new array
+     * @throws NegativeArraySizeException if {@code newLength < 0}
+     * @throws NullPointerException if {@code original == null}
+     */
+    public static double[] copyOf(double[] original, int newLength) {
+        if (newLength < 0) {
+            throw new NegativeArraySizeException(Integer.toString(newLength));
+        }
+        return copyOfRange(original, 0, newLength);
+    }
+
+    /**
+     * Copies {@code newLength} elements from {@code original} into a new array.
+     * If {@code newLength} is greater than {@code original.length}, the result is padded
+     * with the value {@code 0.0f}.
+     *
+     * @param original the original array
+     * @param newLength the length of the new array
+     * @return the new array
+     * @throws NegativeArraySizeException if {@code newLength < 0}
+     * @throws NullPointerException if {@code original == null}
+     */
+    public static float[] copyOf(float[] original, int newLength) {
+        if (newLength < 0) {
+            throw new NegativeArraySizeException(Integer.toString(newLength));
+        }
+        return copyOfRange(original, 0, newLength);
+    }
+
+    /**
+     * Copies {@code newLength} elements from {@code original} into a new array.
+     * If {@code newLength} is greater than {@code original.length}, the result is padded
+     * with the value {@code 0}.
+     *
+     * @param original the original array
+     * @param newLength the length of the new array
+     * @return the new array
+     * @throws NegativeArraySizeException if {@code newLength < 0}
+     * @throws NullPointerException if {@code original == null}
+     */
+    public static int[] copyOf(int[] original, int newLength) {
+        if (newLength < 0) {
+            throw new NegativeArraySizeException(Integer.toString(newLength));
+        }
+        return copyOfRange(original, 0, newLength);
+    }
+
+    /**
+     * Copies {@code newLength} elements from {@code original} into a new array.
+     * If {@code newLength} is greater than {@code original.length}, the result is padded
+     * with the value {@code 0L}.
+     *
+     * @param original the original array
+     * @param newLength the length of the new array
+     * @return the new array
+     * @throws NegativeArraySizeException if {@code newLength < 0}
+     * @throws NullPointerException if {@code original == null}
+     */
+    public static long[] copyOf(long[] original, int newLength) {
+        if (newLength < 0) {
+            throw new NegativeArraySizeException(Integer.toString(newLength));
+        }
+        return copyOfRange(original, 0, newLength);
+    }
+
+    /**
+     * Copies {@code newLength} elements from {@code original} into a new array.
+     * If {@code newLength} is greater than {@code original.length}, the result is padded
+     * with the value {@code (short) 0}.
+     *
+     * @param original the original array
+     * @param newLength the length of the new array
+     * @return the new array
+     * @throws NegativeArraySizeException if {@code newLength < 0}
+     * @throws NullPointerException if {@code original == null}
+     */
+    public static short[] copyOf(short[] original, int newLength) {
+        if (newLength < 0) {
+            throw new NegativeArraySizeException(Integer.toString(newLength));
+        }
+        return copyOfRange(original, 0, newLength);
+    }
+
+    /**
+     * Copies {@code newLength} elements from {@code original} into a new array.
+     * If {@code newLength} is greater than {@code original.length}, the result is padded
+     * with the value {@code null}.
+     *
+     * @param original the original array
+     * @param newLength the length of the new array
+     * @return the new array
+     * @throws NegativeArraySizeException if {@code newLength < 0}
+     * @throws NullPointerException if {@code original == null}
+     */
+    public static <T> T[] copyOf(T[] original, int newLength) {
+        if (original == null) {
+            throw new NullPointerException("original == null");
+        }
+        if (newLength < 0) {
+            throw new NegativeArraySizeException(Integer.toString(newLength));
+        }
+        return copyOfRange(original, 0, newLength);
+    }
+
+    /**
+     * Copies {@code newLength} elements from {@code original} into a new array.
+     * If {@code newLength} is greater than {@code original.length}, the result is padded
+     * with the value {@code null}.
+     *
+     * @param original the original array
+     * @param newLength the length of the new array
+     * @param newType the class of the new array
+     * @return the new array
+     * @throws NegativeArraySizeException if {@code newLength < 0}
+     * @throws NullPointerException if {@code original == null}
+     * @throws ArrayStoreException if a value in {@code original} is incompatible with T
+     */
+    public static <T, U> T[] copyOf(U[] original, int newLength, Class<? extends T[]> newType) {
+        // We use the null pointer check in copyOfRange for exception priority compatibility.
+        if (newLength < 0) {
+            throw new NegativeArraySizeException(Integer.toString(newLength));
+        }
+        return copyOfRange(original, 0, newLength, newType);
+    }
+
+    /**
+     * Copies elements from {@code original} into a new array, from indexes start (inclusive) to
+     * end (exclusive). The original order of elements is preserved.
+     * If {@code end} is greater than {@code original.length}, the result is padded
+     * with the value {@code false}.
+     *
+     * @param original the original array
+     * @param start the start index, inclusive
+     * @param end the end index, exclusive
+     * @return the new array
+     * @throws ArrayIndexOutOfBoundsException if {@code start < 0 || start > original.length}
+     * @throws IllegalArgumentException if {@code start > end}
+     * @throws NullPointerException if {@code original == null}
+     */
+    public static boolean[] copyOfRange(boolean[] original, int start, int end) {
+        if (start > end) {
+            throw new IllegalArgumentException();
+        }
+        int originalLength = original.length;
+        if (start < 0 || start > originalLength) {
+            throw new ArrayIndexOutOfBoundsException();
+        }
+        int resultLength = end - start;
+        int copyLength = Math.min(resultLength, originalLength - start);
+        boolean[] result = new boolean[resultLength];
+        System.arraycopy(original, start, result, 0, copyLength);
+        return result;
+    }
+
+    /**
+     * Copies elements from {@code original} into a new array, from indexes start (inclusive) to
+     * end (exclusive). The original order of elements is preserved.
+     * If {@code end} is greater than {@code original.length}, the result is padded
+     * with the value {@code (byte) 0}.
+     *
+     * @param original the original array
+     * @param start the start index, inclusive
+     * @param end the end index, exclusive
+     * @return the new array
+     * @throws ArrayIndexOutOfBoundsException if {@code start < 0 || start > original.length}
+     * @throws IllegalArgumentException if {@code start > end}
+     * @throws NullPointerException if {@code original == null}
+     */
+    public static byte[] copyOfRange(byte[] original, int start, int end) {
+        if (start > end) {
+            throw new IllegalArgumentException();
+        }
+        int originalLength = original.length;
+        if (start < 0 || start > originalLength) {
+            throw new ArrayIndexOutOfBoundsException();
+        }
+        int resultLength = end - start;
+        int copyLength = Math.min(resultLength, originalLength - start);
+        byte[] result = new byte[resultLength];
+        System.arraycopy(original, start, result, 0, copyLength);
+        return result;
+    }
+
+    /**
+     * Copies elements from {@code original} into a new array, from indexes start (inclusive) to
+     * end (exclusive). The original order of elements is preserved.
+     * If {@code end} is greater than {@code original.length}, the result is padded
+     * with the value {@code '\\u0000'}.
+     *
+     * @param original the original array
+     * @param start the start index, inclusive
+     * @param end the end index, exclusive
+     * @return the new array
+     * @throws ArrayIndexOutOfBoundsException if {@code start < 0 || start > original.length}
+     * @throws IllegalArgumentException if {@code start > end}
+     * @throws NullPointerException if {@code original == null}
+     */
+    public static char[] copyOfRange(char[] original, int start, int end) {
+        if (start > end) {
+            throw new IllegalArgumentException();
+        }
+        int originalLength = original.length;
+        if (start < 0 || start > originalLength) {
+            throw new ArrayIndexOutOfBoundsException();
+        }
+        int resultLength = end - start;
+        int copyLength = Math.min(resultLength, originalLength - start);
+        char[] result = new char[resultLength];
+        System.arraycopy(original, start, result, 0, copyLength);
+        return result;
+    }
+
+    /**
+     * Copies elements from {@code original} into a new array, from indexes start (inclusive) to
+     * end (exclusive). The original order of elements is preserved.
+     * If {@code end} is greater than {@code original.length}, the result is padded
+     * with the value {@code 0.0d}.
+     *
+     * @param original the original array
+     * @param start the start index, inclusive
+     * @param end the end index, exclusive
+     * @return the new array
+     * @throws ArrayIndexOutOfBoundsException if {@code start < 0 || start > original.length}
+     * @throws IllegalArgumentException if {@code start > end}
+     * @throws NullPointerException if {@code original == null}
+     */
+    public static double[] copyOfRange(double[] original, int start, int end) {
+        if (start > end) {
+            throw new IllegalArgumentException();
+        }
+        int originalLength = original.length;
+        if (start < 0 || start > originalLength) {
+            throw new ArrayIndexOutOfBoundsException();
+        }
+        int resultLength = end - start;
+        int copyLength = Math.min(resultLength, originalLength - start);
+        double[] result = new double[resultLength];
+        System.arraycopy(original, start, result, 0, copyLength);
+        return result;
+    }
+
+    /**
+     * Copies elements from {@code original} into a new array, from indexes start (inclusive) to
+     * end (exclusive). The original order of elements is preserved.
+     * If {@code end} is greater than {@code original.length}, the result is padded
+     * with the value {@code 0.0f}.
+     *
+     * @param original the original array
+     * @param start the start index, inclusive
+     * @param end the end index, exclusive
+     * @return the new array
+     * @throws ArrayIndexOutOfBoundsException if {@code start < 0 || start > original.length}
+     * @throws IllegalArgumentException if {@code start > end}
+     * @throws NullPointerException if {@code original == null}
+     */
+    public static float[] copyOfRange(float[] original, int start, int end) {
+        if (start > end) {
+            throw new IllegalArgumentException();
+        }
+        int originalLength = original.length;
+        if (start < 0 || start > originalLength) {
+            throw new ArrayIndexOutOfBoundsException();
+        }
+        int resultLength = end - start;
+        int copyLength = Math.min(resultLength, originalLength - start);
+        float[] result = new float[resultLength];
+        System.arraycopy(original, start, result, 0, copyLength);
+        return result;
+    }
+
+    /**
+     * Copies elements from {@code original} into a new array, from indexes start (inclusive) to
+     * end (exclusive). The original order of elements is preserved.
+     * If {@code end} is greater than {@code original.length}, the result is padded
+     * with the value {@code 0}.
+     *
+     * @param original the original array
+     * @param start the start index, inclusive
+     * @param end the end index, exclusive
+     * @return the new array
+     * @throws ArrayIndexOutOfBoundsException if {@code start < 0 || start > original.length}
+     * @throws IllegalArgumentException if {@code start > end}
+     * @throws NullPointerException if {@code original == null}
+     */
+    public static int[] copyOfRange(int[] original, int start, int end) {
+        if (start > end) {
+            throw new IllegalArgumentException();
+        }
+        int originalLength = original.length;
+        if (start < 0 || start > originalLength) {
+            throw new ArrayIndexOutOfBoundsException();
+        }
+        int resultLength = end - start;
+        int copyLength = Math.min(resultLength, originalLength - start);
+        int[] result = new int[resultLength];
+        System.arraycopy(original, start, result, 0, copyLength);
+        return result;
+    }
+
+    /**
+     * Copies elements from {@code original} into a new array, from indexes start (inclusive) to
+     * end (exclusive). The original order of elements is preserved.
+     * If {@code end} is greater than {@code original.length}, the result is padded
+     * with the value {@code 0L}.
+     *
+     * @param original the original array
+     * @param start the start index, inclusive
+     * @param end the end index, exclusive
+     * @return the new array
+     * @throws ArrayIndexOutOfBoundsException if {@code start < 0 || start > original.length}
+     * @throws IllegalArgumentException if {@code start > end}
+     * @throws NullPointerException if {@code original == null}
+     */
+    public static long[] copyOfRange(long[] original, int start, int end) {
+        if (start > end) {
+            throw new IllegalArgumentException();
+        }
+        int originalLength = original.length;
+        if (start < 0 || start > originalLength) {
+            throw new ArrayIndexOutOfBoundsException();
+        }
+        int resultLength = end - start;
+        int copyLength = Math.min(resultLength, originalLength - start);
+        long[] result = new long[resultLength];
+        System.arraycopy(original, start, result, 0, copyLength);
+        return result;
+    }
+
+    /**
+     * Copies elements from {@code original} into a new array, from indexes start (inclusive) to
+     * end (exclusive). The original order of elements is preserved.
+     * If {@code end} is greater than {@code original.length}, the result is padded
+     * with the value {@code (short) 0}.
+     *
+     * @param original the original array
+     * @param start the start index, inclusive
+     * @param end the end index, exclusive
+     * @return the new array
+     * @throws ArrayIndexOutOfBoundsException if {@code start < 0 || start > original.length}
+     * @throws IllegalArgumentException if {@code start > end}
+     * @throws NullPointerException if {@code original == null}
+     */
+    public static short[] copyOfRange(short[] original, int start, int end) {
+        if (start > end) {
+            throw new IllegalArgumentException();
+        }
+        int originalLength = original.length;
+        if (start < 0 || start > originalLength) {
+            throw new ArrayIndexOutOfBoundsException();
+        }
+        int resultLength = end - start;
+        int copyLength = Math.min(resultLength, originalLength - start);
+        short[] result = new short[resultLength];
+        System.arraycopy(original, start, result, 0, copyLength);
+        return result;
+    }
+
+    /**
+     * Copies elements from {@code original} into a new array, from indexes start (inclusive) to
+     * end (exclusive). The original order of elements is preserved.
+     * If {@code end} is greater than {@code original.length}, the result is padded
+     * with the value {@code null}.
+     *
+     * @param original the original array
+     * @param start the start index, inclusive
+     * @param end the end index, exclusive
+     * @return the new array
+     * @throws ArrayIndexOutOfBoundsException if {@code start < 0 || start > original.length}
+     * @throws IllegalArgumentException if {@code start > end}
+     * @throws NullPointerException if {@code original == null}
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> T[] copyOfRange(T[] original, int start, int end) {
+        int originalLength = original.length; // For exception priority compatibility.
+        if (start > end) {
+            throw new IllegalArgumentException();
+        }
+        if (start < 0 || start > originalLength) {
+            throw new ArrayIndexOutOfBoundsException();
+        }
+        int resultLength = end - start;
+        int copyLength = Math.min(resultLength, originalLength - start);
+        T[] result = (T[]) Array.newInstance(original.getClass().getComponentType(), resultLength);
+        System.arraycopy(original, start, result, 0, copyLength);
+        return result;
+    }
+
+    /**
+     * Copies elements from {@code original} into a new array, from indexes start (inclusive) to
+     * end (exclusive). The original order of elements is preserved.
+     * If {@code end} is greater than {@code original.length}, the result is padded
+     * with the value {@code null}.
+     *
+     * @param original the original array
+     * @param start the start index, inclusive
+     * @param end the end index, exclusive
+     * @return the new array
+     * @throws ArrayIndexOutOfBoundsException if {@code start < 0 || start > original.length}
+     * @throws IllegalArgumentException if {@code start > end}
+     * @throws NullPointerException if {@code original == null}
+     * @throws ArrayStoreException if a value in {@code original} is incompatible with T
+     */
+    @SuppressWarnings("unchecked")
+    public static <T, U> T[] copyOfRange(U[] original, int start, int end, Class<? extends T[]> newType) {
+        if (start > end) {
+            throw new IllegalArgumentException();
+        }
+        int originalLength = original.length;
+        if (start < 0 || start > originalLength) {
+            throw new ArrayIndexOutOfBoundsException();
+        }
+        int resultLength = end - start;
+        int copyLength = Math.min(resultLength, originalLength - start);
+        T[] result = (T[]) Array.newInstance(newType.getComponentType(), resultLength);
+        System.arraycopy(original, start, result, 0, copyLength);
+        return result;
+    }
+}

--- a/src/main/java/com/fasterxml/jackson/core/util/TextBuffer.java
+++ b/src/main/java/com/fasterxml/jackson/core/util/TextBuffer.java
@@ -2,7 +2,6 @@ package com.fasterxml.jackson.core.util;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
-import java.util.Arrays;
 
 import com.fasterxml.jackson.core.io.NumberInput;
 
@@ -584,7 +583,7 @@ public final class TextBuffer
         final int len = curr.length;
         // Must grow by at least 1 char, no matter what
         int newLen = (len == MAX_SEGMENT_LEN) ? (MAX_SEGMENT_LEN+1) : Math.min(MAX_SEGMENT_LEN, len + (len >> 1));
-        return (_currentSegment = Arrays.copyOf(curr, newLen));
+        return (_currentSegment = ArraysCompat.copyOf(curr, newLen));
     }
 
     /**
@@ -599,7 +598,7 @@ public final class TextBuffer
     public char[] expandCurrentSegment(int minSize) {
         char[] curr = _currentSegment;
         if (curr.length >= minSize) return curr;
-        _currentSegment = curr = Arrays.copyOf(curr, minSize);
+        _currentSegment = curr = ArraysCompat.copyOf(curr, minSize);
         return curr;
     }
 
@@ -687,9 +686,9 @@ public final class TextBuffer
             }
             final int start = _inputStart;
             if (start == 0) {
-                return Arrays.copyOf(_inputBuffer, len);
+                return ArraysCompat.copyOf(_inputBuffer, len);
             }
-            return Arrays.copyOfRange(_inputBuffer, start, start+len);
+            return ArraysCompat.copyOfRange(_inputBuffer, start, start+len);
         }
         // nope, not shared
         int size = size();


### PR DESCRIPTION
Android 2.2 (FroYo) doesn't support some of Arrays' functions, such as copyOf() and copyOfRange().

Version 2.3.0 worked properly on Android 2.2, but 2.3.1 broke things when it introduced the usage of `Arrays.copyOf()` and `Arrays.copyOfRange()`. I added a new class, ArraysCompat, which implements all variants of these methods. This way compatibility is ensured.

Also, I think it's OK to break compatibility with Android 2.2, as it's not massively used anymore, but I don't think it should be done on a point release (ie. from 2.3.0 to 2.3.1). Maybe in 2.4? :-)
