### PR TITLE
Fix incorrect @link in jackson.core package-info.

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/package-info.java
+++ b/src/main/java/com/fasterxml/jackson/core/package-info.java
@@ -4,7 +4,7 @@
  * used for constructing
  * JSON parser ({@link com.fasterxml.jackson.core.JsonParser})
  * and generator
- * ({@link com.fasterxml.jackson.core.JsonParser})
+ * ({@link com.fasterxml.jackson.core.JsonGenerator})
  * instances.
  * <p>
  * Public API of the higher-level mapping interfaces ("Mapping API")


### PR DESCRIPTION
Just a quick fix for a tiny error in the javadocs. The diff should be pretty self-explanatory.

Cheers!
Olly
