### PR TITLE
Add Feature for generating JSONP compliant output

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/JsonGenerator.java
+++ b/src/main/java/com/fasterxml/jackson/core/JsonGenerator.java
@@ -162,6 +162,17 @@ public abstract class JsonGenerator
          * @since 2.3
          */
         STRICT_DUPLICATE_DETECTION(false),
+
+        /**
+         * Feature that specifies that Unicode newline characters U+2028
+         * and U+2029 must be explicitly escaped in JSON output. This
+         * ensures that the JSON output can be used as JSONP.
+         *<p>
+         * Feature is disabled by default.
+         *
+         * @since 2.4
+         */
+        JSONP_COMPLIANT(false),
             ;
 
         private final boolean _defaultState;
@@ -429,6 +440,10 @@ public abstract class JsonGenerator
      *   if defined; or -1 to indicate no additional escaping is performed.
      */
     public int getHighestEscapedChar() { return 0; }
+
+    public JsonGenerator setJsonpCompliantOutput(boolean escape) { return this; }
+
+    public boolean getJsonpCompliantOutput() { return false; }
 
     /**
      * Method for accessing custom escapes factory uses for {@link JsonGenerator}s

--- a/src/main/java/com/fasterxml/jackson/core/base/GeneratorBase.java
+++ b/src/main/java/com/fasterxml/jackson/core/base/GeneratorBase.java
@@ -91,6 +91,8 @@ public abstract class GeneratorBase extends JsonGenerator
             _cfgNumbersAsStrings = true;
         } else if (f == Feature.ESCAPE_NON_ASCII) {
             setHighestNonEscapedChar(127);
+        } else if (f == Feature.JSONP_COMPLIANT) {
+            setJsonpCompliantOutput(true);
         }
         return this;
     }
@@ -102,6 +104,8 @@ public abstract class GeneratorBase extends JsonGenerator
             _cfgNumbersAsStrings = false;
         } else if (f == Feature.ESCAPE_NON_ASCII) {
             setHighestNonEscapedChar(0);
+        } else if (f == Feature.JSONP_COMPLIANT) {
+            setJsonpCompliantOutput(false);
         }
         return this;
     }

--- a/src/main/java/com/fasterxml/jackson/core/json/JsonGeneratorImpl.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/JsonGeneratorImpl.java
@@ -97,6 +97,9 @@ public abstract class JsonGeneratorImpl extends GeneratorBase
         if (isEnabled(Feature.ESCAPE_NON_ASCII)) {
             setHighestNonEscapedChar(127);
         }
+        if (isEnabled(Feature.JSONP_COMPLIANT)) {
+            setJsonpCompliantOutput(true);
+        }
     }
 
     /*
@@ -114,6 +117,22 @@ public abstract class JsonGeneratorImpl extends GeneratorBase
     @Override
     public int getHighestEscapedChar() {
         return _maximumNonEscapedChar;
+    }
+
+    @Override
+    public JsonGenerator setJsonpCompliantOutput(boolean escape) {
+        if (escape) {
+            _characterEscapes = new JsonpCharacterEscapes();
+        } else if (getJsonpCompliantOutput()) {
+            _characterEscapes = null;
+        }
+
+        return this;
+    }
+
+    @Override
+    public boolean getJsonpCompliantOutput() {
+        return _characterEscapes instanceof JsonpCharacterEscapes;
     }
 
     @Override

--- a/src/main/java/com/fasterxml/jackson/core/json/JsonpCharacterEscapes.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/JsonpCharacterEscapes.java
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.core.io.SerializedString;
 
 /**
  * Character escapes for producing json that can be safely used for JSONP.
- * {@link com.fasterxml.jackson.core.JsonParser.Feature#ALLOW_UNQUOTED_FIELD_NAMES}
+ * Used when {@link com.fasterxml.jackson.core.JsonGenerator.Feature#JSONP_COMPLIANT}
  * is enabled.
  */
 public class JsonpCharacterEscapes extends CharacterEscapes

--- a/src/main/java/com/fasterxml/jackson/core/json/JsonpCharacterEscapes.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/JsonpCharacterEscapes.java
@@ -1,0 +1,36 @@
+package com.fasterxml.jackson.core.json;
+
+import com.fasterxml.jackson.core.SerializableString;
+import com.fasterxml.jackson.core.io.CharacterEscapes;
+import com.fasterxml.jackson.core.io.SerializedString;
+
+/**
+ * Character escapes for producing json that can be safely used for JSONP.
+ * {@link com.fasterxml.jackson.core.JsonParser.Feature#ALLOW_UNQUOTED_FIELD_NAMES}
+ * is enabled.
+ */
+public class JsonpCharacterEscapes extends CharacterEscapes
+{
+    private static final int[] asciiEscapes = CharacterEscapes.standardAsciiEscapesForJSON();
+    private static final SerializedString escapeFor2028 = new SerializedString("\\u2028");
+    private static final SerializedString escapeFor2029 = new SerializedString("\\u2029");
+
+    @Override
+    public SerializableString getEscapeSequence(int ch)
+    {
+        switch (ch) {
+            case 0x2028:
+                return escapeFor2028;
+            case 0x2029:
+                return escapeFor2029;
+            default:
+                return null;
+        }
+    }
+
+    @Override
+    public int[] getEscapeCodesForAscii()
+    {
+        return asciiEscapes;
+    }
+}

--- a/src/test/java/com/fasterxml/jackson/core/json/TestJsonFactory.java
+++ b/src/test/java/com/fasterxml/jackson/core/json/TestJsonFactory.java
@@ -69,18 +69,22 @@ public class TestJsonFactory
         assertTrue(jf.isEnabled(JsonFactory.Feature.INTERN_FIELD_NAMES));
         assertFalse(jf.isEnabled(JsonParser.Feature.ALLOW_COMMENTS));
         assertFalse(jf.isEnabled(JsonGenerator.Feature.ESCAPE_NON_ASCII));
+        assertFalse(jf.isEnabled(JsonGenerator.Feature.JSONP_COMPLIANT));
         jf.disable(JsonFactory.Feature.INTERN_FIELD_NAMES);
         jf.enable(JsonParser.Feature.ALLOW_COMMENTS);
         jf.enable(JsonGenerator.Feature.ESCAPE_NON_ASCII);
+        jf.enable(JsonGenerator.Feature.JSONP_COMPLIANT);
         // then change, verify that changes "stick"
         assertFalse(jf.isEnabled(JsonFactory.Feature.INTERN_FIELD_NAMES));
         assertTrue(jf.isEnabled(JsonParser.Feature.ALLOW_COMMENTS));
         assertTrue(jf.isEnabled(JsonGenerator.Feature.ESCAPE_NON_ASCII));
+        assertTrue(jf.isEnabled(JsonGenerator.Feature.JSONP_COMPLIANT));
 
         JsonFactory jf2 = jf.copy();
         assertFalse(jf2.isEnabled(JsonFactory.Feature.INTERN_FIELD_NAMES));
         assertTrue(jf.isEnabled(JsonParser.Feature.ALLOW_COMMENTS));
         assertTrue(jf.isEnabled(JsonGenerator.Feature.ESCAPE_NON_ASCII));
+        assertTrue(jf.isEnabled(JsonGenerator.Feature.JSONP_COMPLIANT));
     }
 }
 

--- a/src/test/java/com/fasterxml/jackson/core/json/TestJsonGeneratorFeatures.java
+++ b/src/test/java/com/fasterxml/jackson/core/json/TestJsonGeneratorFeatures.java
@@ -84,6 +84,23 @@ public class TestJsonGeneratorFeatures
         jg.close();
         assertEquals("100", sw.toString());
     }
+
+    public void testJsonpCompliantOutput() throws IOException
+    {
+        JsonFactory jf = new JsonFactory();
+        // by default, escaping should be disabled
+        _testJsonpCompliantEscaping(jf, false);
+        // can enable it
+        jf.enable(JsonGenerator.Feature.JSONP_COMPLIANT);
+        _testJsonpCompliantEscaping(jf, true);
+        // and (re)disable:
+        jf.disable(JsonGenerator.Feature.JSONP_COMPLIANT);
+        _testJsonpCompliantEscaping(jf, false);
+    }
+
+    /**
+     * Testing for generating JSONP compliant output.
+     */
     
     private String _writeNumbers(JsonFactory jf) throws IOException
     {
@@ -148,6 +165,24 @@ public class TestJsonGeneratorFeatures
             assertEquals("{\"double\":\"NaN\"} {\"float\":\"NaN\"}", result);
         } else {
             assertEquals("{\"double\":NaN} {\"float\":NaN}", result);
+        }
+    }
+
+    private void _testJsonpCompliantEscaping(JsonFactory jf, boolean escaped)
+            throws IOException
+    {
+        StringWriter sw = new StringWriter();
+        JsonGenerator jg = jf.createGenerator(sw);
+        jg.writeStartObject();
+        jg.writeStringField("str", "foo\u2028bar\u2029");
+        jg.writeEndObject();
+        jg.close();
+
+        String result = sw.toString();
+        if (escaped) {
+            assertEquals("{\"str\":\"foo\\u2028bar\\u2029\"}", result);
+        } else {
+            assertEquals("{\"str\":\"foo\u2028bar\u2029\"}", result);
         }
     }
 }


### PR DESCRIPTION
I recently got bitten by the fact that JSON in some (rare) cases cannot be parsed directly as JavaScript, typically when using JSONP to perform cross domain requests. Since I found no straightforward option to have Jackson generate JSON escaped in a way that would also work for JSONP, I've added a Feature that, when enabled, causes some special CharacterEscapes to be used to escape the Unicode newline characters \u2028 and \u2029. The output remains perfectly valid and equivalent JSON.

I tried to code that in a way that seems to agree with how the lib is built; do not hesitate to ask if you'd prefer it to be done differently (or none at all).