### PR TITLE
JsonParser, ObjectCodec: javadoc: empty docs to return null

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/JsonParser.java
+++ b/src/main/java/com/fasterxml/jackson/core/JsonParser.java
@@ -1390,7 +1390,9 @@ public abstract class JsonParser
      * represented by root {@link TreeNode} of resulting model.
      * For JSON Arrays it will an array node (with child nodes),
      * for objects object node (with child nodes), and for other types
-     * matching leaf node type
+     * matching leaf node type. Empty or whitespace documents are null.
+     *
+     * @return root of the document, or null if empty or whitespace.
      */
     @SuppressWarnings("unchecked")
     public <T extends TreeNode> T readValueAsTree() throws IOException {

--- a/src/main/java/com/fasterxml/jackson/core/ObjectCodec.java
+++ b/src/main/java/com/fasterxml/jackson/core/ObjectCodec.java
@@ -113,7 +113,10 @@ public abstract class ObjectCodec
      * using set of {@link TreeNode} instances. Returns
      * root of the resulting tree (where root can consist
      * of just a single node if the current event is a
-     * value event, not container).
+     * value event, not container). Empty or whitespace
+     * documents return null.
+     *
+     * @return next tree from jp, or null if empty.
      */
     @Override
     public abstract <T extends TreeNode> T readTree(JsonParser jp)


### PR DESCRIPTION
I found it surprising that calling readValueAsTree returned null for empty or whitespace documents. This makes sense (there is no document), but having that explicitly mentioned in the Javadoc would be useful.
