### PR TITLE
fix typo in javadoc for JsonParser.Feature

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/JsonParser.java
+++ b/src/main/java/com/fasterxml/jackson/core/JsonParser.java
@@ -127,7 +127,7 @@ public abstract class JsonParser
 
         /**
          * Feature that can be enabled to accept quoting of all character
-         * using backslash qooting mechanism: if not enabled, only characters
+         * using backslash quoting mechanism: if not enabled, only characters
          * that are explicitly listed by JSON specification can be thus
          * escaped (see JSON spec for small list of these characters)
          *<p>


### PR DESCRIPTION
"qooting" - > "quoting"

Noticed here: http://fasterxml.github.io/jackson-core/javadoc/2.4/com/fasterxml/jackson/core/JsonParser.Feature.html
