### PR TITLE
Add byte[] bypass methods to JsonGenerator

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/JsonGenerator.java
+++ b/src/main/java/com/fasterxml/jackson/core/JsonGenerator.java
@@ -21,6 +21,7 @@ import static com.fasterxml.jackson.core.JsonTokenId.ID_TRUE;
 import java.io.*;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.nio.charset.Charset;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
@@ -708,7 +709,49 @@ public abstract class JsonGenerator
     /* Public API, write methods, binary/raw content
     /**********************************************************
      */
-    
+
+    /**
+     * Method that will force generator to copy
+     * input text verbatim with <b>no</b> modifications (including
+     * that no escaping is done and no separators are added even
+     * if context [array, object] would otherwise require such).
+     * If such separators are desired, use
+     * {@link #writeRawValue(String)} instead.
+     *<p>
+     * Some generators (most notably the
+     * {@link com.fasterxml.jackson.core.json.UTF8JsonGenerator})
+     * do not perform re-encoding if the source text already
+     * matches the desired output encoding.
+     *<p>
+     * Note that not all generator implementations necessarily support
+     * such by-pass methods: those that do not will throw
+     * {@link UnsupportedOperationException}.
+     */
+    public void writeRaw(byte[] text, Charset encoding) throws IOException {
+        writeRaw(new String(text, encoding));
+    }
+
+    /**
+     * Method that will force generator to copy
+     * input text verbatim with <b>no</b> modifications (including
+     * that no escaping is done and no separators are added even
+     * if context [array, object] would otherwise require such).
+     * If such separators are desired, use
+     * {@link #writeRawValue(String)} instead.
+     *<p>
+     * Some generators (most notably the
+     * {@link com.fasterxml.jackson.core.json.UTF8JsonGenerator})
+     * do not perform re-encoding if the source text already
+     * matches the desired output encoding.
+     *<p>
+     * Note that not all generator implementations necessarily support
+     * such by-pass methods: those that do not will throw
+     * {@link UnsupportedOperationException}.
+     */
+    public void writeRaw(byte[] text, int offset, int len, Charset encoding) throws IOException {
+        writeRaw(new String(text, offset, len, encoding));
+    }
+
     /**
      * Method that will force generator to copy
      * input text verbatim with <b>no</b> modifications (including
@@ -801,6 +844,14 @@ public abstract class JsonGenerator
     public abstract void writeRawValue(String text, int offset, int len) throws IOException;
 
     public abstract void writeRawValue(char[] text, int offset, int len) throws IOException;
+
+    public void writeRawValue(byte[] text, Charset charset) throws IOException {
+        writeRawValue(new String(text, charset));
+    }
+
+    public void writeRawValue(byte[] text, int offset, int len, Charset charset) throws IOException {
+        writeRawValue(new String(text, offset, len, charset));
+    }
 
     /**
      * Method that will output given chunk of binary data as base64

--- a/src/main/java/com/fasterxml/jackson/core/base/GeneratorBase.java
+++ b/src/main/java/com/fasterxml/jackson/core/base/GeneratorBase.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.core.json.DupDetector;
 import com.fasterxml.jackson.core.json.JsonWriteContext;
 import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
 import com.fasterxml.jackson.core.util.VersionUtil;
+import java.nio.charset.Charset;
 
 /**
  * This base class implements part of API that a JSON generator exposes
@@ -202,6 +203,16 @@ public abstract class GeneratorBase extends JsonGenerator
     @Override public void writeRawValue(char[] text, int offset, int len) throws IOException {
         _verifyValueWrite("write raw value");
         writeRaw(text, offset, len);
+    }
+
+    @Override public void writeRawValue(byte[] text, Charset charset) throws IOException {
+        _verifyValueWrite("write raw value");
+        writeRaw(text, charset);
+    }
+
+    @Override public void writeRawValue(byte[] text, int offset, int len, Charset charset) throws IOException {
+        _verifyValueWrite("write raw value");
+        writeRaw(text, offset, len, charset);
     }
 
     @Override

--- a/src/main/java/com/fasterxml/jackson/core/json/UTF8JsonGenerator.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/UTF8JsonGenerator.java
@@ -3,6 +3,7 @@ package com.fasterxml.jackson.core.json;
 import java.io.*;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.nio.charset.Charset;
 
 import com.fasterxml.jackson.core.*;
 import com.fasterxml.jackson.core.io.*;
@@ -544,6 +545,24 @@ public class UTF8JsonGenerator
         }
         _outputBuffer[_outputTail++] = BYTE_QUOTE;
     }
+
+    @Override
+    public void writeRaw(byte[] text, Charset encoding) throws IOException {
+        if (JsonEncoding.UTF8.getJavaName().equals(encoding.name()) && text.length > 0) {
+            _writeBytes(text);
+        } else {
+            super.writeRaw(text, encoding);
+        }
+    }
+
+    @Override
+    public void writeRaw(byte[] text, int offset, int len, Charset encoding) throws IOException {
+        if (JsonEncoding.UTF8.getJavaName().equals(encoding.name()) && text.length > 0) {
+            _writeBytes(text, offset, len);
+        } else {
+            super.writeRaw(text, offset, len, encoding);
+        }
+    }
     
     /*
     /**********************************************************
@@ -591,7 +610,7 @@ public class UTF8JsonGenerator
             _writeBytes(raw);
         }
     }
-    
+
     // @TODO: rewrite for speed...
     @Override
     public final void writeRaw(char[] cbuf, int offset, int len)

--- a/src/main/java/com/fasterxml/jackson/core/util/JsonGeneratorDelegate.java
+++ b/src/main/java/com/fasterxml/jackson/core/util/JsonGeneratorDelegate.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.nio.charset.Charset;
 
 import com.fasterxml.jackson.core.*;
 import com.fasterxml.jackson.core.io.CharacterEscapes;
@@ -207,6 +208,12 @@ public class JsonGeneratorDelegate extends JsonGenerator
     @Override
     public void writeUTF8String(byte[] text, int offset, int length) throws IOException { delegate.writeUTF8String(text, offset, length); }
 
+    @Override
+    public void writeRaw(byte[] text, Charset encoding) throws IOException { delegate.writeRaw(text, encoding); }
+
+    @Override
+    public void writeRaw(byte[] text, int offset, int len, Charset encoding) throws IOException { delegate.writeRaw(text, offset, len, encoding); }
+
     /*
     /**********************************************************
     /* Public API, write methods, binary/raw content
@@ -236,6 +243,12 @@ public class JsonGeneratorDelegate extends JsonGenerator
 
     @Override
     public void writeRawValue(char[] text, int offset, int len) throws IOException { delegate.writeRawValue(text, offset, len); }
+
+    @Override
+    public void writeRawValue(byte[] text, Charset charset) throws IOException { delegate.writeRawValue(text, charset); }
+
+    @Override
+    public void writeRawValue(byte[] text, int offset, int len, Charset charset) throws IOException { delegate.writeRawValue(text, offset, len, charset); }
 
     @Override
     public void writeBinary(Base64Variant b64variant, byte[] data, int offset, int len) throws IOException { delegate.writeBinary(b64variant, data, offset, len); }

--- a/src/test/java/com/fasterxml/jackson/core/main/TestRawByteWriting.java
+++ b/src/test/java/com/fasterxml/jackson/core/main/TestRawByteWriting.java
@@ -1,0 +1,122 @@
+package com.fasterxml.jackson.core.main;
+
+import com.fasterxml.jackson.core.JsonEncoding;
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.core.util.BufferRecycler;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertArrayEquals;
+
+public class TestRawByteWriting extends com.fasterxml.jackson.core.BaseTest
+{
+
+    private static final Charset[] CHARSETS;
+
+    static {
+        List<Charset> charsets = new ArrayList<Charset>();
+
+        for (JsonEncoding enc : JsonEncoding.values()) {
+            charsets.add(Charset.forName(enc.getJavaName()));
+        }
+        charsets.add(Charset.forName("ISO-8859-7"));
+        charsets.add(Charset.forName("windows-1253"));
+
+        CHARSETS = charsets.toArray(new Charset[charsets.size()]);
+    }
+
+
+    /**
+     * Test for direct byte writing when the value is known to be well-formed utf-8 encoded JSON.
+     *
+     * Tests the cartesian product of CHARSETS with JsonEncoding.values() for input and output encodings respectively.
+     */
+    public void testDirectByteWrites() throws Exception
+    {
+        String value = "εδλ";
+        assertTrue("Check that `value` has some non-trivial code points", value.length() < value.getBytes("utf8").length);
+
+        String rawStringValue = '"' + value + '"';
+        ByteArrayOutputStream[] outs = new ByteArrayOutputStream[JsonEncoding.values().length];
+        JsonFactory jf = new JsonFactory();
+        List<JsonGenerator> generators = makeGenerators(jf, outs);
+
+        for (JsonGenerator jgen : generators) {
+            jgen.writeStartArray();
+            for (Charset charset : CHARSETS) {
+                final byte[] valueBytes = rawStringValue.getBytes(charset);
+                // should be ignored
+                jgen.writeRaw(new byte[0], charset);
+
+                // valid writes
+                jgen.writeRawValue(valueBytes, charset);
+                jgen.writeRawValue(Arrays.copyOf(valueBytes, valueBytes.length + 2), 0, valueBytes.length, charset);
+            }
+            jgen.writeEndArray();
+            jgen.close();
+        }
+
+        for (int i = 0; i < outs.length; i++) {
+            final JsonEncoding output = JsonEncoding.values()[i];
+            byte[] json = outs[i].toByteArray();
+
+            // Ok: let's verify that stuff was written out ok
+            JsonParser jp = jf.createParser(json);
+            assertToken(JsonToken.START_ARRAY, jp.nextToken());
+
+            for (Charset input : CHARSETS) {
+                assertToken(JsonToken.VALUE_STRING, jp.nextToken());
+                assertEquals(String.format("failed to write string to output encoding %s with input encoding %s", output, input), value, jp.getText());
+
+                assertToken(JsonToken.VALUE_STRING, jp.nextToken());
+                assertEquals(String.format("failed to write string to output encoding %s with input encoding %s (using offset+len)", output, input), value, jp.getText());
+            }
+
+            assertToken(JsonToken.END_ARRAY, jp.nextToken());
+            jp.close();
+        }
+    }
+
+    public void testWriterFlushesCharset() throws IOException {
+        // This seems to be the only charset that implements a real CharsetDecoder#flush method
+        final Charset charset = Charset.forName("ISCII91");
+        String longValue = new String(new BufferRecycler().allocCharBuffer(BufferRecycler.CHAR_CONCAT_BUFFER)).replace("\0", "a")  + "ऋ";
+
+        ByteArrayOutputStream[] outs = new ByteArrayOutputStream[JsonEncoding.values().length];
+        JsonFactory jf = new JsonFactory();
+        List<JsonGenerator> generators = makeGenerators(jf, outs);
+
+        for (JsonGenerator jgen : generators) {
+            jgen.writeRaw('"');
+            jgen.flush();
+            jgen.writeRawValue(longValue.getBytes(charset), charset);
+            jgen.writeRaw('"');
+            jgen.close();
+        }
+
+        for (ByteArrayOutputStream out : outs) {
+            byte[] json = out.toByteArray();
+
+            JsonParser jp = jf.createParser(json);
+
+            assertToken(JsonToken.VALUE_STRING, jp.nextToken());
+            assertArrayEquals(longValue.toCharArray(), jp.getText().toCharArray());
+        }
+    }
+
+    private static List<JsonGenerator> makeGenerators(JsonFactory jf, ByteArrayOutputStream[] outs) throws IOException {
+        if (JsonEncoding.values().length != outs.length) throw new IllegalArgumentException("wrong number of outputs");
+        JsonGenerator[] jgens = new JsonGenerator[outs.length];
+        for (int i = 0; i < outs.length; i++) {
+            jgens[i] = jf.createGenerator((outs[i] = new ByteArrayOutputStream(16000)), JsonEncoding.values()[i]);
+        }
+        return Arrays.asList(jgens);
+    }
+}


### PR DESCRIPTION
Allows users with some known combination of byte[] and Charset to avoid unnecessary copies if the output generator supports doing so. Provides an easy API in other cases.

These methods take an explicit java.nio.Charset instead of a JsonEncoding or attempting autodetection to allow users to pass in fragments or encodings that compose/transcode to valid json but are not json on their own.