### PR TITLE
fix failure parsing -Infinity on buffer boundary

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,7 @@ com.fasterxml.jackson.core.*;version=${project.version}
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
+          <argLine>-Xmx128m</argLine>
           <redirectTestOutputToFile>${surefire.redirectTestOutputToFile}</redirectTestOutputToFile>
           <excludes>
             <exclude>**/failing/*.java</exclude>

--- a/src/main/java/com/fasterxml/jackson/core/json/ReaderBasedJsonParser.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/ReaderBasedJsonParser.java
@@ -1047,7 +1047,7 @@ public class ReaderBasedJsonParser // final in 2.3, earlier
         }
         // Also, integer part is not optional
         if (intLen == 0) {
-            reportInvalidNumber("Missing integer part (next char "+_getCharDesc(c)+")");
+            return _handleInvalidNumberStart(c, neg);
         }
 
         int fractLen = 0;

--- a/src/test/java/com/fasterxml/jackson/core/json/TestNumericValues.java
+++ b/src/test/java/com/fasterxml/jackson/core/json/TestNumericValues.java
@@ -446,10 +446,12 @@ public class TestNumericValues
         };
         for (int i = 0; i < values.length; ++i) {
             int COUNT = 4096;
-            int VCOUNT = 8 * COUNT;
+
+            // Don't see the failure with a multiple of 1
+            int VCOUNT = 2 * COUNT;
             String arrayJson = toJsonArray(values[i], VCOUNT);
 
-            StringBuilder sb = new StringBuilder(COUNT * arrayJson.length() + 20);
+            StringBuilder sb = new StringBuilder(COUNT + arrayJson.length() + 20);
             for (int j = 0; j < COUNT; ++j) {
                 sb.append(' ');
             }

--- a/src/test/java/com/fasterxml/jackson/core/json/TestNumericValues.java
+++ b/src/test/java/com/fasterxml/jackson/core/json/TestNumericValues.java
@@ -422,6 +422,61 @@ public class TestNumericValues
         }
     }
 
+    private String toJsonArray(double v, int n) {
+        StringBuilder sb = new StringBuilder().append('[').append(v);
+        for (int i = 1; i < n; ++i) {
+            sb.append(',').append(v);
+        }
+        return sb.append(']').toString();
+    }
+
+    /**
+     * Method that tries to test that number parsing works in cases where
+     * input is split between buffer boundaries.
+     */
+    public void testParsingOfLongerSequencesWithNonNumeric()
+        throws Exception
+    {
+        JsonFactory factory = new JsonFactory();
+        factory.enable(JsonParser.Feature.ALLOW_NON_NUMERIC_NUMBERS);
+
+        double[] values = new double[] {
+          0.01, -10.5, 2.1e9, 4.0e-8,
+          Double.NaN, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY
+        };
+        for (int i = 0; i < values.length; ++i) {
+            int COUNT = 4096;
+            int VCOUNT = 8 * COUNT;
+            String arrayJson = toJsonArray(values[i], VCOUNT);
+
+            StringBuilder sb = new StringBuilder(COUNT * arrayJson.length() + 20);
+            for (int j = 0; j < COUNT; ++j) {
+                sb.append(' ');
+            }
+
+            sb.append(arrayJson);
+            String DOC = sb.toString();
+
+            for (int input = 0; input < 2; ++input) {
+                JsonParser jp;
+
+                if (input == 0) {
+                    jp = createParserUsingStream(factory, DOC, "UTF-8");
+                } else {
+                    jp = factory.createParser(DOC);
+                }
+
+                assertToken(JsonToken.START_ARRAY, jp.nextToken());
+                for (int j = 0; j < VCOUNT; ++j) {
+                    assertToken(JsonToken.VALUE_NUMBER_FLOAT, jp.nextToken());
+                    assertEquals(values[i], jp.getDoubleValue());
+                }
+                assertToken(JsonToken.END_ARRAY, jp.nextToken());
+                jp.close();
+            }
+        }
+    }
+
     // [jackson-core#157]
     public void testLongNumbers() throws Exception
     {


### PR DESCRIPTION
In cases where a -Infinity value gets split due to a buffer
boundary an exception was thrown indicating an invalid numeric
value. With the test case added to TestNumericValues I get an
exception:

```
testParsingOfLongerSequencesWithNonNumeric(com.fasterxml.jackson.core.json.TestNumericValues)  Time elapsed: 5.306 sec  <<< ERROR!
com.fasterxml.jackson.core.JsonParseException: Invalid numeric value: Missing integer part (next char 'I' (code 73))
 at [Source: java.io.StringReader@164b3e4f; line: 1, column: 50690]
	at com.fasterxml.jackson.core.JsonParser._constructError(JsonParser.java:1501)
	at com.fasterxml.jackson.core.base.ParserMinimalBase._reportError(ParserMinimalBase.java:522)
	at com.fasterxml.jackson.core.base.ParserBase.reportInvalidNumber(ParserBase.java:1025)
	at com.fasterxml.jackson.core.json.ReaderBasedJsonParser._parseNumber2(ReaderBasedJsonParser.java:1050)
	at com.fasterxml.jackson.core.json.ReaderBasedJsonParser._parseNegNumber(ReaderBasedJsonParser.java:964)
	at com.fasterxml.jackson.core.json.ReaderBasedJsonParser.nextToken(ReaderBasedJsonParser.java:668)
	at com.fasterxml.jackson.core.json.TestNumericValues.testParsingOfLongerSequencesWithNonNumeric(TestNumericValues.java:470)
```

I don't know if it is the best fix or not, but it was fairly
easy to fix the problem I was seeing by changing ReaderBasedJsonParser
to call `_handleInvalidNumberStart` instead of `reportInvalidNumber`.