### PR TITLE
Specify version of maven-surefire-plugin in POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,7 @@ com.fasterxml.jackson.core.*;version=${project.version}
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.18.1</version>
         <configuration>
           <redirectTestOutputToFile>${surefire.redirectTestOutputToFile}</redirectTestOutputToFile>
           <excludes>


### PR DESCRIPTION
This solves the following warning:
```
[INFO] --- versions-maven-plugin:2.1:display-plugin-updates (default-cli) @ jackson-core ---
[INFO]
[WARNING] The following plugins do not have their version specified:
[WARNING]   maven-surefire-plugin ..................................... 2.18.1
```