### PR TITLE
Force Unix LF for indent test

### DIFF
--- a/src/test/java/com/fasterxml/jackson/core/util/TestDefaultPrettyPrinter.java
+++ b/src/test/java/com/fasterxml/jackson/core/util/TestDefaultPrettyPrinter.java
@@ -37,7 +37,7 @@ public class TestDefaultPrettyPrinter extends BaseTest
     public void testWithIndent() throws IOException
     {
         PrettyPrinter pp = new DefaultPrettyPrinter()
-        .withObjectIndenter(new DefaultIndenter().withIndent(" "));
+        .withObjectIndenter(new DefaultIndenter().withLinefeed("\n").withIndent(" "));
         String EXP = "{\n" +
             " \"name\" : \"John Doe\",\n" +
             " \"age\" : 3.14\n" +


### PR DESCRIPTION
The indent test fails to pass on windows, because the DefaultIndenter uses the system linefeed, but the test is written using unix line feeds.