### PR TITLE
Set Accept header on ObjectMapper.readTree for HTTP URLs

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/JsonFactory.java
+++ b/src/main/java/com/fasterxml/jackson/core/JsonFactory.java
@@ -7,6 +7,7 @@ package com.fasterxml.jackson.core;
 import java.io.*;
 import java.lang.ref.SoftReference;
 import java.net.URL;
+import java.net.URLConnection;
 
 import com.fasterxml.jackson.core.format.InputAccessor;
 import com.fasterxml.jackson.core.format.MatchStrength;
@@ -1465,6 +1466,10 @@ public class JsonFactory
                 }
                 // otherwise, let's fall through and let URL decoder do its magic
             }
+        } else if (url.getProtocol().startsWith("http")) {
+            final URLConnection connection = url.openConnection();
+            connection.setRequestProperty("Accept", "application/json");
+            return connection.getInputStream();
         }
         return url.openStream();
     }

--- a/src/test/java/com/fasterxml/jackson/core/json/JsonFactoryTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/json/JsonFactoryTest.java
@@ -1,6 +1,9 @@
 package com.fasterxml.jackson.core.json;
 
 import java.io.*;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URL;
 
 import com.fasterxml.jackson.core.*;
 
@@ -108,6 +111,15 @@ public class JsonFactoryTest
 
         // ok, delete once we are done
         file.delete();
+    }
+    
+    public void testJsonWithHttp() throws Exception
+    {
+        final JsonFactory f = new JsonFactory();
+        final JsonParser jp = f.createParser(URI.create("https://api.github.com/repos/FasterXML/jackson-core/branches").toURL());
+        assertNotNull(jp);
+        
+        jp.close();
     }
 
     // #72


### PR DESCRIPTION
When using ObjectMapper.readTree(URL) for a HTTP URL the `Accept: application/json` header is not supplied. If a service produces multiple outputs for the same URL and the accept header is not supplied it appears to default to `Accept: text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2`
