### PR TITLE
Fixed issue #37

### DIFF
--- a/src/test/java/com/fasterxml/jackson/core/json/TestLocation.java
+++ b/src/test/java/com/fasterxml/jackson/core/json/TestLocation.java
@@ -79,17 +79,13 @@ public class TestLocation extends com.fasterxml.jackson.core.BaseTest
         p.close();
     }
 
-    public void testOffsetWithObjectFields() throws Exception
+    public void testOffsetWithObjectFieldsUsingUTF8() throws Exception
     {
         final JsonFactory f = new JsonFactory();
         JsonLocation loc;
         JsonParser p;
-        JsonToken t;
-        String s;
-        // 3 spaces before, 2 after, just for padding
         byte[] b = "{\"f1\":\"v1\",\"f2\":{\"f3\":\"v3\"},\"f4\":[true,false],\"f5\":5}".getBytes("UTF-8");
         //            1      6      11    16 17    22      28    33 34 39      46    51
-        // and then peel them off
         p = f.createParser(b);
 
         assertEquals(JsonToken.START_OBJECT, p.nextToken());
@@ -126,6 +122,54 @@ public class TestLocation extends com.fasterxml.jackson.core.BaseTest
         assertEquals(46L, p.getTokenLocation().getByteOffset());
         assertEquals(JsonToken.VALUE_NUMBER_INT, p.nextToken());
         assertEquals(51L, p.getTokenLocation().getByteOffset());
+        assertEquals(JsonToken.END_OBJECT, p.nextToken());
+
+        p.close();
+    }
+
+    public void testOffsetWithObjectFieldsUsingReader() throws Exception
+    {
+        final JsonFactory f = new JsonFactory();
+        JsonLocation loc;
+        JsonParser p;
+        char[] c = "{\"f1\":\"v1\",\"f2\":{\"f3\":\"v3\"},\"f4\":[true,false],\"f5\":5}".toCharArray();
+        //            1      6      11    16 17    22      28    33 34 39      46    51
+        p = f.createParser(c);
+
+        assertEquals(JsonToken.START_OBJECT, p.nextToken());
+
+        assertEquals(JsonToken.FIELD_NAME, p.nextToken());
+        assertEquals(1L, p.getTokenLocation().getCharOffset());
+        assertEquals(JsonToken.VALUE_STRING, p.nextToken());
+        assertEquals(6L, p.getTokenLocation().getCharOffset());
+
+        assertEquals("f2", p.nextFieldName());
+        assertEquals(11L, p.getTokenLocation().getCharOffset());
+        assertEquals(JsonToken.START_OBJECT, p.nextValue());
+        assertEquals(16L, p.getTokenLocation().getCharOffset());
+
+        assertEquals("f3", p.nextFieldName());
+        assertEquals(17L, p.getTokenLocation().getCharOffset());
+        assertEquals(JsonToken.VALUE_STRING, p.nextValue());
+        assertEquals(22L, p.getTokenLocation().getCharOffset());
+        assertEquals(JsonToken.END_OBJECT, p.nextToken());
+
+        assertEquals("f4", p.nextFieldName());
+        assertEquals(28L, p.getTokenLocation().getCharOffset());
+        assertEquals(JsonToken.START_ARRAY, p.nextValue());
+        assertEquals(33L, p.getTokenLocation().getCharOffset());
+
+        assertEquals(JsonToken.VALUE_TRUE, p.nextValue());
+        assertEquals(34L, p.getTokenLocation().getCharOffset());
+
+        assertEquals(JsonToken.VALUE_FALSE, p.nextValue());
+        assertEquals(39L, p.getTokenLocation().getCharOffset());
+        assertEquals(JsonToken.END_ARRAY, p.nextToken());
+
+        assertEquals("f5", p.nextFieldName());
+        assertEquals(46L, p.getTokenLocation().getCharOffset());
+        assertEquals(JsonToken.VALUE_NUMBER_INT, p.nextToken());
+        assertEquals(51L, p.getTokenLocation().getCharOffset());
         assertEquals(JsonToken.END_OBJECT, p.nextToken());
 
         p.close();

--- a/src/test/java/com/fasterxml/jackson/core/json/TestLocation.java
+++ b/src/test/java/com/fasterxml/jackson/core/json/TestLocation.java
@@ -22,7 +22,7 @@ public class TestLocation extends com.fasterxml.jackson.core.BaseTest
         assertEquals(0L, loc.getCharOffset());
         assertEquals(1, loc.getLineNr());
         assertEquals(1, loc.getColumnNr());
-        
+
         loc = p.getCurrentLocation();
         assertEquals(-1L, loc.getByteOffset());
         assertEquals(1L, loc.getCharOffset());
@@ -32,7 +32,7 @@ public class TestLocation extends com.fasterxml.jackson.core.BaseTest
         p.close();
 
         // then byte-based
-        
+
         p = f.createParser(DOC.getBytes("UTF-8"));
         assertToken(JsonToken.START_OBJECT, p.nextToken());
 
@@ -41,7 +41,7 @@ public class TestLocation extends com.fasterxml.jackson.core.BaseTest
         assertEquals(-1L, loc.getCharOffset());
         assertEquals(1, loc.getLineNr());
         assertEquals(1, loc.getColumnNr());
-        
+
         loc = p.getCurrentLocation();
         assertEquals(1L, loc.getByteOffset());
         assertEquals(-1L, loc.getCharOffset());
@@ -69,12 +69,64 @@ public class TestLocation extends com.fasterxml.jackson.core.BaseTest
         assertEquals(-1L, loc.getCharOffset());
         assertEquals(1, loc.getLineNr());
         assertEquals(1, loc.getColumnNr());
-        
+
         loc = p.getCurrentLocation();
         assertEquals(1L, loc.getByteOffset());
         assertEquals(-1L, loc.getCharOffset());
         assertEquals(1, loc.getLineNr());
         assertEquals(2, loc.getColumnNr());
+
+        p.close();
+    }
+
+    public void testOffsetWithObjectFields() throws Exception
+    {
+        final JsonFactory f = new JsonFactory();
+        JsonLocation loc;
+        JsonParser p;
+        JsonToken t;
+        String s;
+        // 3 spaces before, 2 after, just for padding
+        byte[] b = "{\"f1\":\"v1\",\"f2\":{\"f3\":\"v3\"},\"f4\":[true,false],\"f5\":5}".getBytes("UTF-8");
+        //            1      6      11    16 17    22      28    33 34 39      46    51
+        // and then peel them off
+        p = f.createParser(b);
+
+        assertEquals(JsonToken.START_OBJECT, p.nextToken());
+
+        assertEquals(JsonToken.FIELD_NAME, p.nextToken());
+        assertEquals(1L, p.getTokenLocation().getByteOffset());
+        assertEquals(JsonToken.VALUE_STRING, p.nextToken());
+        assertEquals(6L, p.getTokenLocation().getByteOffset());
+
+        assertEquals("f2", p.nextFieldName());
+        assertEquals(11L, p.getTokenLocation().getByteOffset());
+        assertEquals(JsonToken.START_OBJECT, p.nextValue());
+        assertEquals(16L, p.getTokenLocation().getByteOffset());
+
+        assertEquals("f3", p.nextFieldName());
+        assertEquals(17L, p.getTokenLocation().getByteOffset());
+        assertEquals(JsonToken.VALUE_STRING, p.nextValue());
+        assertEquals(22L, p.getTokenLocation().getByteOffset());
+        assertEquals(JsonToken.END_OBJECT, p.nextToken());
+
+        assertEquals("f4", p.nextFieldName());
+        assertEquals(28L, p.getTokenLocation().getByteOffset());
+        assertEquals(JsonToken.START_ARRAY, p.nextValue());
+        assertEquals(33L, p.getTokenLocation().getByteOffset());
+
+        assertEquals(JsonToken.VALUE_TRUE, p.nextValue());
+        assertEquals(34L, p.getTokenLocation().getByteOffset());
+
+        assertEquals(JsonToken.VALUE_FALSE, p.nextValue());
+        assertEquals(39L, p.getTokenLocation().getByteOffset());
+        assertEquals(JsonToken.END_ARRAY, p.nextToken());
+
+        assertEquals("f5", p.nextFieldName());
+        assertEquals(46L, p.getTokenLocation().getByteOffset());
+        assertEquals(JsonToken.VALUE_NUMBER_INT, p.nextToken());
+        assertEquals(51L, p.getTokenLocation().getByteOffset());
+        assertEquals(JsonToken.END_OBJECT, p.nextToken());
 
         p.close();
     }


### PR DESCRIPTION
This is a fix for Issue #37 (location not updating properly when parsing objects). The basic issue was that the UTF8StreamParser was aggressively pre-parsing the value portion of object fields and caching that token, but not caching the corresponding parse location as well. Also, the parse position was not being properly updated in all locations.