### PR TITLE
Code quality - Constructors should only call non-overridable methods

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/json/JsonGeneratorImpl.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/JsonGeneratorImpl.java
@@ -106,7 +106,7 @@ public abstract class JsonGeneratorImpl extends GeneratorBase
      */
 
     @Override
-    public JsonGenerator setHighestNonEscapedChar(int charCode) {
+    public final JsonGenerator setHighestNonEscapedChar(int charCode) {
         _maximumNonEscapedChar = (charCode < 0) ? 0 : charCode;
         return this;
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of rules: 
squid:S1699 - Constructors should only call non-overridable methods

You can find more information about the issue here:
http://dev.eclipse.org/sonar/rules/show/squid:S1699

Please let me know if you have any questions.

Faisal