### PR TITLE
Code quality fix - final classes should not have "protected" members.

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/Base64Variant.java
+++ b/src/main/java/com/fasterxml/jackson/core/Base64Variant.java
@@ -78,17 +78,17 @@ public final class Base64Variant
      * Note that this is the only non-transient field; used when reading
      * back from serialized state
      */
-    protected final String _name;
+    final String _name;
 
     /**
      * Whether this variant uses padding or not.
      */
-    protected final transient boolean _usesPadding;
+    final transient boolean _usesPadding;
 
     /**
      * Characted used for padding, if any ({@link #PADDING_CHAR_NONE} if not).
      */
-    protected final transient char _paddingChar;
+    final transient char _paddingChar;
     
     /**
      * Maximum number of encoded base64 characters to output during encoding
@@ -98,7 +98,7 @@ public final class Base64Variant
      * Note: for some output modes (when writing attributes) linefeeds may
      * need to be avoided, and this value ignored.
      */
-    protected final transient int _maxLineLength;
+    final transient int _maxLineLength;
 
     /*
     /**********************************************************
@@ -176,7 +176,7 @@ public final class Base64Variant
      * Method used to "demote" deserialized instances back to 
      * canonical ones
      */
-    protected Object readResolve() {
+    Object readResolve() {
         return Base64Variants.valueOf(_name);
     }
     
@@ -566,7 +566,7 @@ public final class Base64Variant
      * @param bindex Relative index within base64 character unit; between 0
      *   and 3 (as unit has exactly 4 characters)
      */
-    protected void _reportInvalidBase64(char ch, int bindex, String msg)
+    void _reportInvalidBase64(char ch, int bindex, String msg)
         throws IllegalArgumentException
     {
         String base;
@@ -586,7 +586,7 @@ public final class Base64Variant
         throw new IllegalArgumentException(base);
     }
 
-    protected void _reportBase64EOF() throws IllegalArgumentException {
+    void _reportBase64EOF() throws IllegalArgumentException {
         throw new IllegalArgumentException("Unexpected end-of-String in base64 content");
     }
 }

--- a/src/main/java/com/fasterxml/jackson/core/io/JsonStringEncoder.java
+++ b/src/main/java/com/fasterxml/jackson/core/io/JsonStringEncoder.java
@@ -34,25 +34,25 @@ public final class JsonStringEncoder
      * to a {@link BufferRecycler} used to provide a low-cost
      * buffer recycling between reader and writer instances.
      */
-    final protected static ThreadLocal<SoftReference<JsonStringEncoder>> _threadEncoder
+    final static ThreadLocal<SoftReference<JsonStringEncoder>> _threadEncoder
         = new ThreadLocal<SoftReference<JsonStringEncoder>>();
 
     /**
      * Lazily constructed text buffer used to produce JSON encoded Strings
      * as characters (without UTF-8 encoding)
      */
-    protected TextBuffer _text;
+    TextBuffer _text;
 
     /**
      * Lazily-constructed builder used for UTF-8 encoding of text values
      * (quoted and unquoted)
      */
-    protected ByteArrayBuilder _bytes;
+    ByteArrayBuilder _bytes;
     
     /**
      * Temporary buffer used for composing quote/escape sequences
      */
-    protected final char[] _qbuf;
+    final char[] _qbuf;
     
     /*
     /**********************************************************

--- a/src/main/java/com/fasterxml/jackson/core/io/SegmentedStringWriter.java
+++ b/src/main/java/com/fasterxml/jackson/core/io/SegmentedStringWriter.java
@@ -15,7 +15,7 @@ import com.fasterxml.jackson.core.util.TextBuffer;
  */
 public final class SegmentedStringWriter extends Writer
 {
-    final protected TextBuffer _buffer;
+    final TextBuffer _buffer;
 
     public SegmentedStringWriter(BufferRecycler br) {
         super();

--- a/src/main/java/com/fasterxml/jackson/core/io/UTF8Writer.java
+++ b/src/main/java/com/fasterxml/jackson/core/io/UTF8Writer.java
@@ -353,7 +353,7 @@ public final class UTF8Writer extends Writer
     /**
      * Method called to calculate UTF codepoint, from a surrogate pair.
      */
-    protected int convertSurrogate(int secondPart)
+    int convertSurrogate(int secondPart)
         throws IOException
     {
         int firstPart = _surrogate;
@@ -366,11 +366,11 @@ public final class UTF8Writer extends Writer
         return 0x10000 + ((firstPart - SURR1_FIRST) << 10) + (secondPart - SURR2_FIRST);
     }
     
-    protected static void illegalSurrogate(int code) throws IOException {
+    static void illegalSurrogate(int code) throws IOException {
         throw new IOException(illegalSurrogateDesc(code));
     }
     
-    protected static String illegalSurrogateDesc(int code)
+    static String illegalSurrogateDesc(int code)
     {
         if (code > 0x10FFFF) { // over max?
             return "Illegal character point (0x"+Integer.toHexString(code)+") to output; max is 0x10FFFF as per RFC 4627";

--- a/src/main/java/com/fasterxml/jackson/core/json/ByteSourceJsonBootstrapper.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/ByteSourceJsonBootstrapper.java
@@ -28,9 +28,9 @@ public final class ByteSourceJsonBootstrapper
     /**********************************************************
      */
 
-    protected final IOContext _context;
+    final IOContext _context;
 
-    protected final InputStream _in;
+    final InputStream _in;
 
     /*
     /**********************************************************
@@ -38,7 +38,7 @@ public final class ByteSourceJsonBootstrapper
     /**********************************************************
      */
 
-    protected final byte[] _inputBuffer;
+    final byte[] _inputBuffer;
 
     private int _inputPtr;
 
@@ -63,7 +63,7 @@ public final class ByteSourceJsonBootstrapper
      *<p>
      * Note: includes possible BOMs, if those were part of the input.
      */
-    protected int _inputProcessed;
+    int _inputProcessed;
 
     /*
     /**********************************************************
@@ -71,9 +71,9 @@ public final class ByteSourceJsonBootstrapper
     /**********************************************************
      */
 
-    protected boolean _bigEndian = true;
+    boolean _bigEndian = true;
 
-    protected int _bytesPerChar = 0; // 0 means "dunno yet"
+    int _bytesPerChar = 0; // 0 means "dunno yet"
 
     /*
     /**********************************************************
@@ -475,7 +475,7 @@ public final class ByteSourceJsonBootstrapper
     /**********************************************************
      */
 
-    protected boolean ensureLoaded(int minimum) throws IOException {
+    boolean ensureLoaded(int minimum) throws IOException {
         /* Let's assume here buffer has enough room -- this will always
          * be true for the limited used this method gets
          */

--- a/src/main/java/com/fasterxml/jackson/core/json/JsonReadContext.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/JsonReadContext.java
@@ -15,11 +15,11 @@ public final class JsonReadContext extends JsonStreamContext
     /**
      * Parent context for this context; null for root context.
      */
-    protected final JsonReadContext _parent;
+    final JsonReadContext _parent;
     
     // // // Optional duplicate detection
 
-    protected DupDetector _dups;
+    DupDetector _dups;
 
     /*
     /**********************************************************
@@ -30,7 +30,7 @@ public final class JsonReadContext extends JsonStreamContext
     /**********************************************************
      */
 
-    protected JsonReadContext _child = null;
+    JsonReadContext _child = null;
 
     /*
     /**********************************************************
@@ -38,15 +38,15 @@ public final class JsonReadContext extends JsonStreamContext
     /**********************************************************
      */
 
-    protected String _currentName;
+    String _currentName;
 
     /**
      * @since 2.5
      */
-    protected Object _currentValue;
+    Object _currentValue;
     
-    protected int _lineNr;
-    protected int _columnNr;
+    int _lineNr;
+    int _columnNr;
 
     /*
     /**********************************************************
@@ -64,7 +64,7 @@ public final class JsonReadContext extends JsonStreamContext
         _index = -1;
     }
 
-    protected void reset(int type, int lineNr, int colNr) {
+    void reset(int type, int lineNr, int colNr) {
         _type = type;
         _index = -1;
         _lineNr = lineNr;

--- a/src/main/java/com/fasterxml/jackson/core/json/WriterBasedJsonGenerator.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/WriterBasedJsonGenerator.java
@@ -14,9 +14,9 @@ import com.fasterxml.jackson.core.io.*;
 public final class WriterBasedJsonGenerator
     extends JsonGeneratorImpl
 {
-    final protected static int SHORT_WRITE = 32;
+    final static int SHORT_WRITE = 32;
 
-    final protected static char[] HEX_CHARS = CharTypes.copyHexChars();
+    final static char[] HEX_CHARS = CharTypes.copyHexChars();
     
     /*
     /**********************************************************
@@ -24,42 +24,42 @@ public final class WriterBasedJsonGenerator
     /**********************************************************
      */
 
-    final protected Writer _writer;
+    final Writer _writer;
     
     /**
      * Intermediate buffer in which contents are buffered before
      * being written using {@link #_writer}.
      */
-    protected char[] _outputBuffer;
+    char[] _outputBuffer;
 
     /**
      * Pointer to the first buffered character to output
      */
-    protected int _outputHead = 0;
+    int _outputHead = 0;
 
     /**
      * Pointer to the position right beyond the last character to output
      * (end marker; may point to position right beyond the end of the buffer)
      */
-    protected int _outputTail = 0;
+    int _outputTail = 0;
 
     /**
      * End marker of the output buffer; one past the last valid position
      * within the buffer.
      */
-    protected int _outputEnd;
+    int _outputEnd;
 
     /**
      * Short (14 char) temporary buffer allocated if needed, for constructing
      * escape sequences
      */
-    protected char[] _entityBuffer;
+    char[] _entityBuffer;
 
     /**
      * When custom escapes are used, this member variable is used
      * internally to hold a reference to currently used escape
      */
-    protected SerializableString _currentEscape;
+    SerializableString _currentEscape;
     
     
     /*
@@ -192,7 +192,7 @@ public final class WriterBasedJsonGenerator
         _writeContext = _writeContext.getParent();
     }
 
-    protected void _writeFieldName(String name, boolean commaBefore) throws IOException
+    void _writeFieldName(String name, boolean commaBefore) throws IOException
     {
         if (_cfgPrettyPrinter != null) {
             _writePPFieldName(name, commaBefore);
@@ -225,7 +225,7 @@ public final class WriterBasedJsonGenerator
         _outputBuffer[_outputTail++] = '"';
     }
 
-    protected void _writeFieldName(SerializableString name, boolean commaBefore) throws IOException
+    void _writeFieldName(SerializableString name, boolean commaBefore) throws IOException
     {
         if (_cfgPrettyPrinter != null) {
             _writePPFieldName(name, commaBefore);
@@ -268,7 +268,7 @@ public final class WriterBasedJsonGenerator
      * Specialized version of <code>_writeFieldName</code>, off-lined
      * to keep the "fast path" as simple (and hopefully fast) as possible.
      */
-    protected void _writePPFieldName(String name, boolean commaBefore)
+    void _writePPFieldName(String name, boolean commaBefore)
         throws IOException, JsonGenerationException
     {
         if (commaBefore) {
@@ -292,7 +292,7 @@ public final class WriterBasedJsonGenerator
         }
     }
 
-    protected void _writePPFieldName(SerializableString name, boolean commaBefore)
+    void _writePPFieldName(SerializableString name, boolean commaBefore)
         throws IOException, JsonGenerationException
     {
         if (commaBefore) {
@@ -797,7 +797,7 @@ public final class WriterBasedJsonGenerator
         ++_outputTail;
     }
 
-    protected void _verifyPrettyValueWrite(String typeMsg) throws IOException
+    void _verifyPrettyValueWrite(String typeMsg) throws IOException
     {
         final int status = _writeContext.writeValue();
         if (status == JsonWriteContext.STATUS_EXPECT_NAME) {
@@ -1422,7 +1422,7 @@ public final class WriterBasedJsonGenerator
     /**********************************************************
      */
     
-    protected void _writeBinary(Base64Variant b64variant, byte[] input, int inputPtr, final int inputEnd)
+    void _writeBinary(Base64Variant b64variant, byte[] input, int inputPtr, final int inputEnd)
         throws IOException, JsonGenerationException
     {
         // Encoding is by chunks of 3 input, 4 output chars, so:
@@ -1464,7 +1464,7 @@ public final class WriterBasedJsonGenerator
     }
 
     // write-method called when length is definitely known
-    protected int _writeBinary(Base64Variant b64variant,
+    int _writeBinary(Base64Variant b64variant,
             InputStream data, byte[] readBuffer, int bytesLeft)
         throws IOException, JsonGenerationException
     {
@@ -1524,7 +1524,7 @@ public final class WriterBasedJsonGenerator
     }
     
     // write method when length is unknown
-    protected int _writeBinary(Base64Variant b64variant,
+    int _writeBinary(Base64Variant b64variant,
             InputStream data, byte[] readBuffer)
         throws IOException, JsonGenerationException
     {
@@ -1879,7 +1879,7 @@ public final class WriterBasedJsonGenerator
         return buf;
     }
     
-    protected void _flushBuffer() throws IOException
+    void _flushBuffer() throws IOException
     {
         int len = _outputTail - _outputHead;
         if (len > 0) {

--- a/src/main/java/com/fasterxml/jackson/core/sym/ByteQuadsCanonicalizer.java
+++ b/src/main/java/com/fasterxml/jackson/core/sym/ByteQuadsCanonicalizer.java
@@ -56,7 +56,7 @@ public final class ByteQuadsCanonicalizer
      * Reference to the root symbol table, for child tables, so
      * that they can merge table information back as necessary.
      */
-    final protected ByteQuadsCanonicalizer _parent;
+    final ByteQuadsCanonicalizer _parent;
 
     /**
      * Member that is only used by the root table instance: root
@@ -64,7 +64,7 @@ public final class ByteQuadsCanonicalizer
      * may return new state if they add entries to the table.
      * Child tables do NOT use the reference.
      */
-    final protected AtomicReference<TableInfo> _tableInfo;
+    final AtomicReference<TableInfo> _tableInfo;
     
     /**
      * Seed value we use as the base to make hash codes non-static between
@@ -88,7 +88,7 @@ public final class ByteQuadsCanonicalizer
      * NOTE: non-final to allow disabling intern()ing in case of excessive
      * collisions.
      */
-    protected boolean _intern;
+    boolean _intern;
 
     /**
      * Flag that indicates whether we should throw an exception if enough 
@@ -96,7 +96,7 @@ public final class ByteQuadsCanonicalizer
      * 
      * @since 2.4
      */
-    protected final boolean _failOnDoS;
+    final boolean _failOnDoS;
     
     /*
     /**********************************************************
@@ -110,7 +110,7 @@ public final class ByteQuadsCanonicalizer
      * structure (details of which may be tweaked depending on expected rates
      * of collisions).
      */
-    protected int[] _hashArea;
+    int[] _hashArea;
 
     /**
      * Number of slots for primary entries within {@link #_hashArea}; which is
@@ -118,17 +118,17 @@ public final class ByteQuadsCanonicalizer
      * primary covers only half of the area; plus, additional area for longer
      * symbols after hash area).
      */
-    protected int _hashSize;
+    int _hashSize;
 
     /**
      * Offset within {@link #_hashArea} where secondary entries start
      */
-    protected int _secondaryStart;
+    int _secondaryStart;
 
     /**
      * Offset within {@link #_hashArea} where tertiary entries start
      */
-    protected int _tertiaryStart;
+    int _tertiaryStart;
     
     /**
      * Constant that determines size of buckets for tertiary entries:
@@ -139,12 +139,12 @@ public final class ByteQuadsCanonicalizer
      * Default value is 2, for buckets of 4 slots; grows bigger with
      * bigger table sizes.
      */
-    protected int _tertiaryShift;
+    int _tertiaryShift;
 
     /**
      * Total number of Strings in the symbol table; only used for child tables.
      */
-    protected int _count;
+    int _count;
 
     /**
      * Array that contains <code>String</code> instances matching
@@ -152,7 +152,7 @@ public final class ByteQuadsCanonicalizer
      * Contains nulls for unused entries. Note that this size is twice
      * that of {@link #_hashArea}
      */
-    protected String[] _names;
+    String[] _names;
 
     /*
     /**********************************************************
@@ -165,7 +165,7 @@ public final class ByteQuadsCanonicalizer
      * for more spilled over entries (if any).
      * Spill over area is within fixed-size portion of {@link #_hashArea}.
      */
-    protected int _spilloverEnd;
+    int _spilloverEnd;
 
     /**
      * Offset within {@link #_hashArea} that follows main slots and contains
@@ -175,7 +175,7 @@ public final class ByteQuadsCanonicalizer
      * Note that long name area follows immediately after the fixed-size
      * main hash area ({@link #_hashArea}).
      */
-    protected int _longNameOffset;
+    int _longNameOffset;
 
     /**
      * This flag is set if, after adding a new entry, it is deemed
@@ -295,7 +295,7 @@ public final class ByteQuadsCanonicalizer
      * Factory method that should only be called from unit tests, where seed
      * value should remain the same.
      */
-    protected static ByteQuadsCanonicalizer createRoot(int seed) {
+    static ByteQuadsCanonicalizer createRoot(int seed) {
         return new ByteQuadsCanonicalizer(DEFAULT_T_SIZE, true, seed, true);
     }
     
@@ -1178,7 +1178,7 @@ public final class ByteQuadsCanonicalizer
         return (offset << 3) - offset;
     }
 
-    protected void _reportTooManyCollisions()
+    void _reportTooManyCollisions()
     {
         // First: do not fuzz about small symbol tables; may get balanced by doubling up
         if (_hashSize <= 1024) { // would have spill-over area of 128 entries

--- a/src/main/java/com/fasterxml/jackson/core/sym/CharsToNameCanonicalizer.java
+++ b/src/main/java/com/fasterxml/jackson/core/sym/CharsToNameCanonicalizer.java
@@ -58,14 +58,14 @@ public final class CharsToNameCanonicalizer
      * reuse factories it doesn't matter either way; but when
      * recreating factories often, initial overhead may dominate.
      */
-    protected static final int DEFAULT_T_SIZE = 64;
+    static final int DEFAULT_T_SIZE = 64;
 
     /**
      * Let's not expand symbol tables past some maximum size;
      * this should protected against OOMEs caused by large documents
      * with unique (~= random) names.
      */
-    protected static final int MAX_T_SIZE = 0x10000; // 64k entries == 256k mem
+    static final int MAX_T_SIZE = 0x10000; // 64k entries == 256k mem
 
     /**
      * Let's only share reasonably sized symbol tables. Max size set to 3/4 of 16k;
@@ -104,7 +104,7 @@ public final class CharsToNameCanonicalizer
      * defined, and child instance is released (call to <code>release</code>),
      * parent's shared tables may be updated from the child instance.
      */
-    protected CharsToNameCanonicalizer _parent;
+    CharsToNameCanonicalizer _parent;
 
     /**
      * Seed value we use as the base to make hash codes non-static between
@@ -117,13 +117,13 @@ public final class CharsToNameCanonicalizer
      */
     final private int _hashSeed;
 
-    final protected int _flags;
+    final int _flags;
     
     /**
      * Whether any canonicalization should be attempted (whether using
      * intern or not)
      */
-    protected boolean _canonicalize;
+    boolean _canonicalize;
     
     /*
     /**********************************************************
@@ -135,7 +135,7 @@ public final class CharsToNameCanonicalizer
      * Primary matching symbols; it's expected most match occur from
      * here.
      */
-    protected String[] _symbols;
+    String[] _symbols;
 
     /**
      * Overflow buckets; if primary doesn't match, lookup is done
@@ -144,27 +144,27 @@ public final class CharsToNameCanonicalizer
      * Note: Number of buckets is half of number of symbol entries, on
      * assumption there's less need for buckets.
      */
-    protected Bucket[] _buckets;
+    Bucket[] _buckets;
 
     /**
      * Current size (number of entries); needed to know if and when
      * rehash.
      */
-    protected int _size;
+    int _size;
 
     /**
      * Limit that indicates maximum size this instance can hold before
      * it needs to be expanded and rehashed. Calculated using fill
      * factor passed in to constructor.
      */
-    protected int _sizeThreshold;
+    int _sizeThreshold;
 
     /**
      * Mask used to get index from hash values; equal to
      * <code>_buckets.length - 1</code>, when _buckets.length is
      * a power of two.
      */
-    protected int _indexMask;
+    int _indexMask;
 
     /**
      * We need to keep track of the longest collision list; this is needed
@@ -173,7 +173,7 @@ public final class CharsToNameCanonicalizer
      * 
      * @since 2.1
      */
-    protected int _longestCollisionList;
+    int _longestCollisionList;
     
     /*
     /**********************************************************
@@ -187,7 +187,7 @@ public final class CharsToNameCanonicalizer
      * (first) change is made, and potentially if updated bucket list
      * is to be resync'ed back to master instance.
      */
-    protected boolean _dirty;
+    boolean _dirty;
 
     /*
     /**********************************************************
@@ -203,7 +203,7 @@ public final class CharsToNameCanonicalizer
      * 
      * @since 2.4
      */
-    protected BitSet _overflows;
+    BitSet _overflows;
     
     /*
     /**********************************************************
@@ -226,7 +226,7 @@ public final class CharsToNameCanonicalizer
         return createRoot(seed);
     }
     
-    protected static CharsToNameCanonicalizer createRoot(int hashSeed) {
+    static CharsToNameCanonicalizer createRoot(int hashSeed) {
         return sBootstrapSymbolTable.makeOrphan(hashSeed);
     }
 
@@ -696,7 +696,7 @@ public final class CharsToNameCanonicalizer
     /**
      * @since 2.1
      */
-    protected void reportTooManyCollisions(int maxLen) {
+    void reportTooManyCollisions(int maxLen) {
         throw new IllegalStateException("Longest collision chain in symbol table (of size "+_size
                 +") now exceeds maximum, "+maxLen+" -- suspect a DoS attack based on hash collisions");
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of rule: 
squid:S2156 - final classes should not have "protected" members.

You can find more information about the issue here:
http://dev.eclipse.org/sonar/rules/show/squid:S2156

Please let me know if you have any questions.

Faisal