### PR TITLE
#248 - fix VerisonUti.versionFor() unintended to return null instead …

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/util/VersionUtil.java
+++ b/src/main/java/com/fasterxml/jackson/core/util/VersionUtil.java
@@ -71,7 +71,8 @@ public class VersionUtil
      */
     public static Version versionFor(Class<?> cls)
     {
-        return packageVersionFor(cls);
+        Version version = packageVersionFor(cls);
+        return version == null ? Version.unknownVersion() : version;
     }
 
     /**

--- a/src/test/java/com/fasterxml/jackson/core/util/TestVersionUtil.java
+++ b/src/test/java/com/fasterxml/jackson/core/util/TestVersionUtil.java
@@ -28,4 +28,9 @@ public class TestVersionUtil extends com.fasterxml.jackson.core.BaseTest
     public void testPackageVersionMatches() {
         assertEquals(PackageVersion.VERSION, VersionUtil.versionFor(UTF8JsonGenerator.class));
     }
+
+    public void testVersionForUnknownVersion() {
+        // expecting return version.unknownVersion() instead of null
+        assertEquals(Version.unknownVersion(), VersionUtil.versionFor(TestVersionUtil.class));
+    }
 }


### PR DESCRIPTION
…of Version.unknownVersion() after commit 88c296c67391f6dea4c1581caa82d801c5d94535