### PR TITLE
JsonGenerator - support passing opaque datatypes

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/JsonGenerator.java
+++ b/src/main/java/com/fasterxml/jackson/core/JsonGenerator.java
@@ -1236,6 +1236,17 @@ public abstract class JsonGenerator
         throw new JsonGenerationException("No native support for writing Type Ids", this);
     }
 
+    /**
+     * Method that can be called on backends that support passing opaque datatypes of
+     * non-JSON formats
+     *
+     * @since 2.8
+     */
+    public void writeEmbeddedObject(Object object) throws IOException {
+        throw new JsonGenerationException("No native support for writing embedded objects",
+                this);
+    }
+
     /*
     /**********************************************************
     /* Public API, write methods, serializing Java objects

--- a/src/main/java/com/fasterxml/jackson/core/util/JsonGeneratorDelegate.java
+++ b/src/main/java/com/fasterxml/jackson/core/util/JsonGeneratorDelegate.java
@@ -326,6 +326,9 @@ public class JsonGeneratorDelegate extends JsonGenerator
     
     @Override
     public void writeTypeId(Object id) throws IOException { delegate.writeTypeId(id); }
+
+    @Override
+    public void writeEmbeddedObject(Object object) throws IOException { delegate.writeEmbeddedObject(object); }
     
     /*
     /**********************************************************


### PR DESCRIPTION
Fixes #243 
An other fix in jackson-databind will follow for TokenBuffer