### PR TITLE
Issue #86 - Adding request body to the JsonParseException on demand

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/JsonParser.java
+++ b/src/main/java/com/fasterxml/jackson/core/JsonParser.java
@@ -260,6 +260,20 @@ public abstract class JsonParser
      * are enabled.
      */
     protected int _features;
+    
+    /**
+     * Boolean field to include the request body in the exception
+     * default value is false
+     */
+    protected boolean addRequestBodyOnError;
+    
+    public boolean isaddRequestBodyOnError() {
+		return addRequestBodyOnError;
+	}
+	public void addRequestBodyOnError(boolean addRequestBodyOnError) {
+		this.addRequestBodyOnError = addRequestBodyOnError;
+	}
+	
 
     /*
     /**********************************************************
@@ -1177,7 +1191,7 @@ public abstract class JsonParser
         if (t == JsonToken.VALUE_TRUE) return true;
         if (t == JsonToken.VALUE_FALSE) return false;
         throw new JsonParseException(this,
-                String.format("Current token (%s) not of boolean type", t));
+                String.format("Current token (%s) not of boolean type", t),addRequestBodyOnError);
     }
 
     /**
@@ -1583,7 +1597,7 @@ public abstract class JsonParser
      * based on current state of the parser
      */
     protected JsonParseException _constructError(String msg) {
-        return new JsonParseException(this, msg);
+        return new JsonParseException(this, msg, addRequestBodyOnError);
     }
 
     /**

--- a/src/test/java/com/fasterxml/jackson/core/json/TestRequestBodyOnParseException.java
+++ b/src/test/java/com/fasterxml/jackson/core/json/TestRequestBodyOnParseException.java
@@ -1,0 +1,62 @@
+package com.fasterxml.jackson.core.json;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.BaseTest;
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+
+public class TestRequestBodyOnParseException extends BaseTest {
+	
+	/**
+	 * Tests for Request body data on parsing error
+	 * @throws Exception
+	 */
+	public void testRequestBodyOnParseException() throws Exception{
+		testRequestBodyOnParseExceptionInternal(true,"nul");
+		testRequestBodyOnParseExceptionInternal(false,"nul");
+	}
+	
+	/**
+	 * Tests for no Request body data on parsing error
+	 * @throws Exception
+	 */
+	public void testNoRequestBodyOnParseException() throws Exception{
+		testNoRequestBodyOnParseExceptionInternal(true,"nul");
+		testNoRequestBodyOnParseExceptionInternal(false,"nul");
+	}
+	
+	/*
+	 * *******************Private Methods*************************
+	 */
+	private void testRequestBodyOnParseExceptionInternal(boolean isStream, String value) throws Exception{
+		final String doc = "{ \"key1\" : "+value+" }";
+	     JsonParser jp = isStream ? createParserUsingStream(doc, "UTF-8")
+	                : createParserUsingReader(doc);
+	     jp.addRequestBodyOnError(true);
+	     assertToken(JsonToken.START_OBJECT, jp.nextToken());
+	     try{
+	    	 jp.nextToken();
+	    	 fail("Expecting parsing exception");
+	     }
+	     catch(JsonParseException ex){
+	    	 assertEquals("Request body data should match", doc, ex.getRequestBody());
+	     }
+	}
+
+	private void testNoRequestBodyOnParseExceptionInternal(boolean isStream, String value) throws Exception{
+		final String doc = "{ \"key1\" : "+value+" }";
+	     JsonParser jp = isStream ? createParserUsingStream(doc, "UTF-8")
+	                : createParserUsingReader(doc);
+	     jp.addRequestBodyOnError(false);
+	     assertToken(JsonToken.START_OBJECT, jp.nextToken());
+	     try{
+	    	 jp.nextToken();
+	    	 fail("Expecting parsing exception");
+	     }
+	     catch(JsonParseException ex){
+	    	 assertEquals("Request body data should be null", null, ex.getRequestBody());
+	     }
+	}
+}


### PR DESCRIPTION
This commit adds the request body(issue #86 ) to the JsonParseException on demand.
By setting the property addRequestBodyOnError in JsonParser, the request body is added to JsonParseException. 
The request body is added as a separate property to the JsonParseException which can be retrieved using JsonParseException.getRequestBody()

By default the request body will not be added to the JsonParseException as the flag is turned off, it can be turned on by using JsonParser.addRequestBodyOnError(true);
