### PR TITLE
Issue86 - Adding request body to the JsonParseException

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/JsonParseException.java
+++ b/src/main/java/com/fasterxml/jackson/core/JsonParseException.java
@@ -13,6 +13,8 @@ import java.io.StringWriter;
 import java.nio.CharBuffer;
 import java.nio.charset.Charset;
 
+import com.fasterxml.jackson.core.util.RequestPayloadWrapper;
+
 /**
  * Exception type for parsing problems, used when non-well-formed content
  * (content that does not conform to JSON syntax as per specification)
@@ -22,8 +24,7 @@ public class JsonParseException extends JsonProcessingException {
     private static final long serialVersionUID = 2L; // 2.7
 
     protected JsonParser _processor;
-    protected byte[] requestBody;
-    protected String requestBodyCharset;
+    protected RequestPayloadWrapper requestPayload;
 
     @Deprecated // since 2.7
     public JsonParseException(String msg, JsonLocation loc) {
@@ -76,28 +77,24 @@ public class JsonParseException extends JsonProcessingException {
      Extended Constructors for setting the Request Body in the exception
      *******************************************************************
      */
-    public JsonParseException(JsonParser p, String msg, byte[] requestBody, String requestBodyCharset) {
+    public JsonParseException(JsonParser p, String msg, RequestPayloadWrapper requestPayload) {
         this(p, msg);
-        this.requestBody = requestBody;
-        this.requestBodyCharset = requestBodyCharset;
+        this.requestPayload = requestPayload;
     }
 
-    public JsonParseException(JsonParser p, String msg, Throwable root, byte[] requestBody, String requestBodyCharset) {
+    public JsonParseException(JsonParser p, String msg, Throwable root, RequestPayloadWrapper requestPayload) {
         this(p, msg, root);
-        this.requestBody = requestBody;
-        this.requestBodyCharset = requestBodyCharset;
+        this.requestPayload = requestPayload;
     }
 
-    public JsonParseException(JsonParser p, String msg, JsonLocation loc, byte[] requestBody, String requestBodyCharset) {
+    public JsonParseException(JsonParser p, String msg, JsonLocation loc, RequestPayloadWrapper requestPayload) {
         this(p, msg, loc);
-        this.requestBody = requestBody;
-        this.requestBodyCharset = requestBodyCharset;
+        this.requestPayload = requestPayload;
     }
     
-    public JsonParseException(JsonParser p, String msg, JsonLocation loc, Throwable root, byte[] requestBody, String requestBodyCharset) {
+    public JsonParseException(JsonParser p, String msg, JsonLocation loc, Throwable root, RequestPayloadWrapper requestPayload) {
         this(p, msg, loc, root);
-        this.requestBody = requestBody;
-        this.requestBodyCharset = requestBodyCharset;
+        this.requestPayload = requestPayload;
     }
 
     /**
@@ -117,15 +114,11 @@ public class JsonParseException extends JsonProcessingException {
     }
 
     /**
-     * Method to get the request body as string
+     * Method to get the request payload as string if present
      * @return request body
      */
-    public String getRequestBody(){
-    	String requestBodyStr = "";
-    	if(requestBody != null){
-    		requestBodyStr = new String(requestBody, Charset.forName(requestBodyCharset));
-    	}
-    	return requestBodyStr;
+    public String getRequestPayload(){
+    	return requestPayload != null ? requestPayload.toString() : null;
     }
     
     /**
@@ -134,7 +127,7 @@ public class JsonParseException extends JsonProcessingException {
     @Override 
     public String getMessage() {
     	String msg = super.getMessage();
-    	return requestBody != null ? (msg + "\nRequest Body : " + getRequestBody()) : msg;
+    	return requestPayload != null ? (msg + "\nRequest Payload : " + getRequestPayload()) : msg;
     }
 
     

--- a/src/main/java/com/fasterxml/jackson/core/JsonParseException.java
+++ b/src/main/java/com/fasterxml/jackson/core/JsonParseException.java
@@ -5,6 +5,14 @@
 
 package com.fasterxml.jackson.core;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Reader;
+import java.io.StringWriter;
+import java.nio.CharBuffer;
+import java.nio.charset.Charset;
+
 /**
  * Exception type for parsing problems, used when non-well-formed content
  * (content that does not conform to JSON syntax as per specification)
@@ -14,6 +22,8 @@ public class JsonParseException extends JsonProcessingException {
     private static final long serialVersionUID = 2L; // 2.7
 
     protected JsonParser _processor;
+    protected byte[] requestBody;
+    protected String requestBodyCharset;
 
     @Deprecated // since 2.7
     public JsonParseException(String msg, JsonLocation loc) {
@@ -60,6 +70,35 @@ public class JsonParseException extends JsonProcessingException {
         super(msg, loc, root);
         _processor = p;
     }
+    
+    /*
+     *******************************************************************
+     Extended Constructors for setting the Request Body in the exception
+     *******************************************************************
+     */
+    public JsonParseException(JsonParser p, String msg, byte[] requestBody, String requestBodyCharset) {
+        this(p, msg);
+        this.requestBody = requestBody;
+        this.requestBodyCharset = requestBodyCharset;
+    }
+
+    public JsonParseException(JsonParser p, String msg, Throwable root, byte[] requestBody, String requestBodyCharset) {
+        this(p, msg, root);
+        this.requestBody = requestBody;
+        this.requestBodyCharset = requestBodyCharset;
+    }
+
+    public JsonParseException(JsonParser p, String msg, JsonLocation loc, byte[] requestBody, String requestBodyCharset) {
+        this(p, msg, loc);
+        this.requestBody = requestBody;
+        this.requestBodyCharset = requestBodyCharset;
+    }
+    
+    public JsonParseException(JsonParser p, String msg, JsonLocation loc, Throwable root, byte[] requestBody, String requestBodyCharset) {
+        this(p, msg, loc, root);
+        this.requestBody = requestBody;
+        this.requestBodyCharset = requestBodyCharset;
+    }
 
     /**
      * Fluent method that may be used to assign originating {@link JsonParser},
@@ -76,4 +115,27 @@ public class JsonParseException extends JsonProcessingException {
     public JsonParser getProcessor() {
         return _processor;
     }
+
+    /**
+     * Method to get the request body as string
+     * @return request body
+     */
+    public String getRequestBody(){
+    	String requestBodyStr = "";
+    	if(requestBody != null){
+    		requestBodyStr = new String(requestBody, Charset.forName(requestBodyCharset));
+    	}
+    	return requestBodyStr;
+    }
+    
+    /**
+     * Overriding the getMessage() to include the request body
+     */
+    @Override 
+    public String getMessage() {
+    	String msg = super.getMessage();
+    	return requestBody != null ? (msg + "\nRequest Body : " + getRequestBody()) : msg;
+    }
+
+    
 }

--- a/src/main/java/com/fasterxml/jackson/core/JsonParseException.java
+++ b/src/main/java/com/fasterxml/jackson/core/JsonParseException.java
@@ -112,12 +112,25 @@ public class JsonParseException extends JsonProcessingException {
     public JsonParser getProcessor() {
         return _processor;
     }
+    
+    /**
+     * Method to get the raw request payload
+     * The raw payload will be in either byte[] or String
+     * 
+     * @return raw request payload object either in bytes or in string
+     */
+    public Object getRawRequestPayload() {
+        return requestPayload != null ? requestPayload.getRawRequestPayload() : null;
+    }
 
     /**
-     * Method to get the request payload as string if present
-     * @return request body
+     * The method returns the String representation of the request payload
+     * The raw request payload could be in String or in byte[], the method 
+     * returns the raw request payload in String format
+     * 
+     * @return request body as String
      */
-    public String getRequestPayload(){
+    public String getRequestPayload() {
     	return requestPayload != null ? requestPayload.toString() : null;
     }
     

--- a/src/main/java/com/fasterxml/jackson/core/JsonParser.java
+++ b/src/main/java/com/fasterxml/jackson/core/JsonParser.java
@@ -11,6 +11,7 @@ import java.math.BigInteger;
 import java.util.Iterator;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.core.util.RequestPayloadWrapper;
 
 /**
  * Base class that defines public API for reading JSON content.
@@ -262,22 +263,17 @@ public abstract class JsonParser
     protected int _features;
     
     /**
-     * Byte[] to be included as the request body in case of error
+     * Wrapper object holding the request payload which will be displayed on json parsing error
      */
-    protected byte[] requestBodyOnError;
+    protected RequestPayloadWrapper requestPayloadWrapper;
     
     /**
-     * Charset for the request body in case of error
+     * Sets the byte[] request payload and the charset
+     * @param requestPayloadOnError
+     * @param charset
      */
-    protected String requestBodyCharset;
-    
-    /**
-     * Sets the byte[] request body and the charset
-     * @param requestBodyOnError
-     */
-	public void setRequestBodyOnError(byte[] requestBodyOnError, String charset) {
-		this.requestBodyOnError = requestBodyOnError;
-		this.requestBodyCharset = charset;
+	public void setRequestPayloadOnError(byte[] requestPayloadOnError, String charset) {
+		this.requestPayloadWrapper = new RequestPayloadWrapper(requestPayloadOnError, charset);
 	}
 	
 
@@ -1197,7 +1193,7 @@ public abstract class JsonParser
         if (t == JsonToken.VALUE_TRUE) return true;
         if (t == JsonToken.VALUE_FALSE) return false;
         throw new JsonParseException(this,
-                String.format("Current token (%s) not of boolean type", t), requestBodyOnError, requestBodyCharset);
+                String.format("Current token (%s) not of boolean type", t), requestPayloadWrapper);
     }
 
     /**
@@ -1603,7 +1599,7 @@ public abstract class JsonParser
      * based on current state of the parser
      */
     protected JsonParseException _constructError(String msg) {
-        return new JsonParseException(this, msg, requestBodyOnError, requestBodyCharset);
+        return new JsonParseException(this, msg, requestPayloadWrapper);
     }
 
     /**

--- a/src/main/java/com/fasterxml/jackson/core/JsonParser.java
+++ b/src/main/java/com/fasterxml/jackson/core/JsonParser.java
@@ -260,6 +260,26 @@ public abstract class JsonParser
      * are enabled.
      */
     protected int _features;
+    
+    /**
+     * Byte[] to be included as the request body in case of error
+     */
+    protected byte[] requestBodyOnError;
+    
+    /**
+     * Charset for the request body in case of error
+     */
+    protected String requestBodyCharset;
+    
+    /**
+     * Sets the byte[] request body and the charset
+     * @param requestBodyOnError
+     */
+	public void setRequestBodyOnError(byte[] requestBodyOnError, String charset) {
+		this.requestBodyOnError = requestBodyOnError;
+		this.requestBodyCharset = charset;
+	}
+	
 
     /*
     /**********************************************************
@@ -1177,7 +1197,7 @@ public abstract class JsonParser
         if (t == JsonToken.VALUE_TRUE) return true;
         if (t == JsonToken.VALUE_FALSE) return false;
         throw new JsonParseException(this,
-                String.format("Current token (%s) not of boolean type", t));
+                String.format("Current token (%s) not of boolean type", t), requestBodyOnError, requestBodyCharset);
     }
 
     /**
@@ -1583,7 +1603,7 @@ public abstract class JsonParser
      * based on current state of the parser
      */
     protected JsonParseException _constructError(String msg) {
-        return new JsonParseException(this, msg);
+        return new JsonParseException(this, msg, requestBodyOnError, requestBodyCharset);
     }
 
     /**

--- a/src/main/java/com/fasterxml/jackson/core/JsonParser.java
+++ b/src/main/java/com/fasterxml/jackson/core/JsonParser.java
@@ -269,12 +269,23 @@ public abstract class JsonParser
     
     /**
      * Sets the byte[] request payload and the charset
+     *
      * @param requestPayloadOnError
      * @param charset
      */
 	public void setRequestPayloadOnError(byte[] requestPayloadOnError, String charset) {
 		this.requestPayloadWrapper = new RequestPayloadWrapper(requestPayloadOnError, charset);
 	}
+	
+    /**
+     * Sets the String request payload
+     *
+     * @param requestPayloadOnError
+     * @param charset
+     */
+    public void setRequestPayloadOnError(String requestPayloadOnError) {
+        this.requestPayloadWrapper = new RequestPayloadWrapper(requestPayloadOnError);
+    }
 	
 
     /*

--- a/src/main/java/com/fasterxml/jackson/core/util/RequestPayloadWrapper.java
+++ b/src/main/java/com/fasterxml/jackson/core/util/RequestPayloadWrapper.java
@@ -3,37 +3,67 @@ package com.fasterxml.jackson.core.util;
 import java.nio.charset.Charset;
 
 /**
- * Request payload wrapper class, which returns the payload object as string
- * The class converts the byte[] to String based on the charset defined for the payload object
+ * Request payload wrapper class, which returns the payload object
+ * The wrapper class can hold the request payload bytes or directly the string representation of the payload
+ * The class converts the byte[] to String, based on the request source type i.e, bytes or String
  */
 public class RequestPayloadWrapper {
-	
+	//default charset
 	private static final String DEFAULT_CHARSET = "UTF-8";
-	private byte[] requestPayload;
+	
+	//request payload as byte[]
+	private byte[] requestPayloadAsBytes;
+	
+	//request payload as String
+	private String requestPayloadAsString;
+	
+	//Charset if the request payload is set in bytes
 	private String charset;
 	
-	public RequestPayloadWrapper(byte[] requestPayload, String charset){
-		this.requestPayload = requestPayload;
+	public RequestPayloadWrapper(byte[] requestPayloadAsBytes, String charset) {
+		this.requestPayloadAsBytes = requestPayloadAsBytes;
 		this.charset = charset;
+	}
+	
+	public RequestPayloadWrapper(String requestPayloadAsString) {
+        this.requestPayloadAsString = requestPayloadAsString;
+    }
+	
+	/**
+	 * Returns the raw request payload object i.e, either byte[] or String
+	 * 
+	 * @return Object which is a raw request payload i.e, either byte[] or String
+	 */
+	public Object getRawRequestPayload() {
+	    if(this.requestPayloadAsBytes != null) {
+	        return this.requestPayloadAsBytes;
+	    }
+	    
+	    return this.requestPayloadAsString;
 	}
 
 	@Override
 	public String toString() {
 		//if request payload is null, return
-		if(requestPayload == null){
+		if(requestPayloadAsBytes == null && requestPayloadAsString == null){
 			return null;
 		}
 		
-		//check if charset is present, if not use the default charset
-		Charset charsetObj = null;
-		if(charset == null || "".equals(charset.trim())){
-			charsetObj = Charset.forName(DEFAULT_CHARSET);
-		}
-		else{
-			charsetObj = Charset.forName(charset);
+		if(requestPayloadAsBytes != null) {
+    		//check if charset is present, if not use the default charset
+    		Charset charsetObj = null;
+    		if(charset == null || "".equals(charset.trim())){
+    			charsetObj = Charset.forName(DEFAULT_CHARSET);
+    		}
+    		else{
+    			charsetObj = Charset.forName(charset);
+    		}
+    		
+    		return (new String(requestPayloadAsBytes, charsetObj));
 		}
 		
-		return (new String(requestPayload, charsetObj));
+		return requestPayloadAsString;
+		
 	}
 	
 	

--- a/src/main/java/com/fasterxml/jackson/core/util/RequestPayloadWrapper.java
+++ b/src/main/java/com/fasterxml/jackson/core/util/RequestPayloadWrapper.java
@@ -21,7 +21,7 @@ public class RequestPayloadWrapper {
 	public String toString() {
 		//if request payload is null, return
 		if(requestPayload == null){
-			return "";
+			return null;
 		}
 		
 		//check if charset is present, if not use the default charset

--- a/src/main/java/com/fasterxml/jackson/core/util/RequestPayloadWrapper.java
+++ b/src/main/java/com/fasterxml/jackson/core/util/RequestPayloadWrapper.java
@@ -3,69 +3,68 @@ package com.fasterxml.jackson.core.util;
 import java.nio.charset.Charset;
 
 /**
- * Request payload wrapper class, which returns the payload object
- * The wrapper class can hold the request payload bytes or directly the string representation of the payload
- * The class converts the byte[] to String, based on the request source type i.e, bytes or String
+ * Request payload wrapper class, which returns the payload object The wrapper
+ * class can hold the request payload bytes or directly the string
+ * representation of the payload The class converts the byte[] to String, based
+ * on the request source type i.e, bytes or String
  */
 public class RequestPayloadWrapper {
-	//default charset
-	private static final String DEFAULT_CHARSET = "UTF-8";
-	
-	//request payload as byte[]
-	private byte[] requestPayloadAsBytes;
-	
-	//request payload as String
-	private String requestPayloadAsString;
-	
-	//Charset if the request payload is set in bytes
-	private String charset;
-	
-	public RequestPayloadWrapper(byte[] requestPayloadAsBytes, String charset) {
-		this.requestPayloadAsBytes = requestPayloadAsBytes;
-		this.charset = charset;
-	}
-	
-	public RequestPayloadWrapper(String requestPayloadAsString) {
+    // default charset
+    private static final String DEFAULT_CHARSET = "UTF-8";
+
+    // request payload as byte[]
+    private byte[] requestPayloadAsBytes;
+
+    // request payload as String
+    private String requestPayloadAsString;
+
+    // Charset if the request payload is set in bytes
+    private String charset;
+
+    public RequestPayloadWrapper(byte[] requestPayloadAsBytes, String charset) {
+        this.requestPayloadAsBytes = requestPayloadAsBytes;
+        this.charset = charset;
+    }
+
+    public RequestPayloadWrapper(String requestPayloadAsString) {
         this.requestPayloadAsString = requestPayloadAsString;
     }
-	
-	/**
-	 * Returns the raw request payload object i.e, either byte[] or String
-	 * 
-	 * @return Object which is a raw request payload i.e, either byte[] or String
-	 */
-	public Object getRawRequestPayload() {
-	    if(this.requestPayloadAsBytes != null) {
-	        return this.requestPayloadAsBytes;
-	    }
-	    
-	    return this.requestPayloadAsString;
-	}
 
-	@Override
-	public String toString() {
-		//if request payload is null, return
-		if(requestPayloadAsBytes == null && requestPayloadAsString == null){
-			return null;
-		}
-		
-		if(requestPayloadAsBytes != null) {
-    		//check if charset is present, if not use the default charset
-    		Charset charsetObj = null;
-    		if(charset == null || "".equals(charset.trim())){
-    			charsetObj = Charset.forName(DEFAULT_CHARSET);
-    		}
-    		else{
-    			charsetObj = Charset.forName(charset);
-    		}
-    		
-    		return (new String(requestPayloadAsBytes, charsetObj));
-		}
-		
-		return requestPayloadAsString;
-		
-	}
-	
-	
+    /**
+     * Returns the raw request payload object i.e, either byte[] or String
+     * 
+     * @return Object which is a raw request payload i.e, either byte[] or
+     *         String
+     */
+    public Object getRawRequestPayload() {
+        if (this.requestPayloadAsBytes != null) {
+            return this.requestPayloadAsBytes;
+        }
+
+        return this.requestPayloadAsString;
+    }
+
+    @Override
+    public String toString() {
+        // if request payload is null, return
+        if (requestPayloadAsBytes == null && requestPayloadAsString == null) {
+            return null;
+        }
+
+        if (requestPayloadAsBytes != null) {
+            // check if charset is present, if not use the default charset
+            Charset charsetObj = null;
+            if (charset == null || "".equals(charset.trim())) {
+                charsetObj = Charset.forName(DEFAULT_CHARSET);
+            } else {
+                charsetObj = Charset.forName(charset);
+            }
+
+            return (new String(requestPayloadAsBytes, charsetObj));
+        }
+
+        return requestPayloadAsString;
+
+    }
 
 }

--- a/src/main/java/com/fasterxml/jackson/core/util/RequestPayloadWrapper.java
+++ b/src/main/java/com/fasterxml/jackson/core/util/RequestPayloadWrapper.java
@@ -1,0 +1,30 @@
+package com.fasterxml.jackson.core.util;
+
+import java.nio.charset.Charset;
+
+/**
+ * Request payload wrapper class, which returns the payload object as string
+ * The class converts the byte[] to String based on the charset defined for the payload object
+ */
+public class RequestPayloadWrapper {
+	
+	private byte[] requestPayload;
+	private String charset;
+	
+	public RequestPayloadWrapper(byte[] requestPayload, String charset){
+		this.requestPayload = requestPayload;
+		this.charset = charset;
+	}
+
+	@Override
+	public String toString() {
+		String requestPayloadStr = "";
+		if(requestPayload != null){
+			requestPayloadStr = new String(requestPayload, Charset.forName(charset));
+		}
+		return requestPayloadStr;
+	}
+	
+	
+
+}

--- a/src/main/java/com/fasterxml/jackson/core/util/RequestPayloadWrapper.java
+++ b/src/main/java/com/fasterxml/jackson/core/util/RequestPayloadWrapper.java
@@ -8,6 +8,7 @@ import java.nio.charset.Charset;
  */
 public class RequestPayloadWrapper {
 	
+	private static final String DEFAULT_CHARSET = "UTF-8";
 	private byte[] requestPayload;
 	private String charset;
 	
@@ -18,11 +19,21 @@ public class RequestPayloadWrapper {
 
 	@Override
 	public String toString() {
-		String requestPayloadStr = "";
-		if(requestPayload != null){
-			requestPayloadStr = new String(requestPayload, Charset.forName(charset));
+		//if request payload is null, return
+		if(requestPayload == null){
+			return "";
 		}
-		return requestPayloadStr;
+		
+		//check if charset is present, if not use the default charset
+		Charset charsetObj = null;
+		if(charset == null || "".equals(charset.trim())){
+			charsetObj = Charset.forName(DEFAULT_CHARSET);
+		}
+		else{
+			charsetObj = Charset.forName(charset);
+		}
+		
+		return (new String(requestPayload, charsetObj));
 	}
 	
 	

--- a/src/test/java/com/fasterxml/jackson/core/json/TestRequestBodyOnParseException.java
+++ b/src/test/java/com/fasterxml/jackson/core/json/TestRequestBodyOnParseException.java
@@ -1,0 +1,62 @@
+package com.fasterxml.jackson.core.json;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.BaseTest;
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+
+public class TestRequestBodyOnParseException extends BaseTest {
+	
+	/**
+	 * Tests for Request body data on parsing error
+	 * @throws Exception
+	 */
+	public void testRequestBodyOnParseException() throws Exception{
+		testRequestBodyOnParseExceptionInternal(true,"nul");
+		testRequestBodyOnParseExceptionInternal(false,"nul");
+	}
+	
+	/**
+	 * Tests for no Request body data on parsing error
+	 * @throws Exception
+	 */
+	public void testNoRequestBodyOnParseException() throws Exception{
+		testNoRequestBodyOnParseExceptionInternal(true,"nul");
+		testNoRequestBodyOnParseExceptionInternal(false,"nul");
+	}
+	
+	/*
+	 * *******************Private Methods*************************
+	 */
+	private void testRequestBodyOnParseExceptionInternal(boolean isStream, String value) throws Exception{
+		final String doc = "{ \"key1\" : "+value+" }";
+	     JsonParser jp = isStream ? createParserUsingStream(doc, "UTF-8")
+	                : createParserUsingReader(doc);
+	     jp.setRequestBodyOnError(doc.getBytes(), "UTF-8");
+	     assertToken(JsonToken.START_OBJECT, jp.nextToken());
+	     try{
+	    	 jp.nextToken();
+	    	 fail("Expecting parsing exception");
+	     }
+	     catch(JsonParseException ex){
+	    	 assertEquals("Request body data should match", doc, ex.getRequestBody());
+	    	 assertTrue("Message contains request body", ex.getMessage().contains("Request Body : "+doc));
+	     }
+	}
+
+	private void testNoRequestBodyOnParseExceptionInternal(boolean isStream, String value) throws Exception{
+		final String doc = "{ \"key1\" : "+value+" }";
+	     JsonParser jp = isStream ? createParserUsingStream(doc, "UTF-8")
+	                : createParserUsingReader(doc);
+	     assertToken(JsonToken.START_OBJECT, jp.nextToken());
+	     try{
+	    	 jp.nextToken();
+	    	 fail("Expecting parsing exception");
+	     }
+	     catch(JsonParseException ex){
+	    	 assertEquals("Request body data should be empty", "", ex.getRequestBody());
+	     }
+	}
+}

--- a/src/test/java/com/fasterxml/jackson/core/json/TestRequestPayloadOnParseException.java
+++ b/src/test/java/com/fasterxml/jackson/core/json/TestRequestPayloadOnParseException.java
@@ -10,37 +10,61 @@ import com.fasterxml.jackson.core.JsonToken;
 public class TestRequestPayloadOnParseException extends BaseTest {
 	
 	/**
-	 * Tests for Request payload data on parsing error
+	 * Tests for Request payload data (bytes) on parsing error
+	 * 
 	 * @throws Exception
 	 */
-	public void testRequestPayloadOnParseException() throws Exception{
-		testRequestPayloadOnParseExceptionInternal(true,"nul");
-		testRequestPayloadOnParseExceptionInternal(false,"nul");
+	public void testRequestPayloadAsBytesOnParseException() throws Exception {
+	    testRequestPayloadAsBytesOnParseExceptionInternal(true,"nul");
+	    testRequestPayloadAsBytesOnParseExceptionInternal(false,"nul");
 	}
 	
 	/**
+     * Tests for Request payload data (String) on parsing error
+     * 
+     * @throws Exception
+     */
+    public void testRequestPayloadAsStringOnParseException() throws Exception {
+        testRequestPayloadAsStringOnParseExceptionInternal(true,"nul");
+        testRequestPayloadAsStringOnParseExceptionInternal(false,"nul");
+    }
+
+    /**
+     * Tests for Raw Request payload data on parsing error
+     * 
+     * @throws Exception
+     */
+    public void testRawRequestPayloadOnParseException() throws Exception {
+        testRawRequestPayloadOnParseExceptionInternal(true,"nul");
+        testRawRequestPayloadOnParseExceptionInternal(false,"nul");
+    }
+    
+	/**
 	 * Tests for no Request payload data on parsing error
+	 * 
 	 * @throws Exception
 	 */
-	public void testNoRequestPayloadOnParseException() throws Exception{
+	public void testNoRequestPayloadOnParseException() throws Exception {
 		testNoRequestPayloadOnParseExceptionInternal(true,"nul");
 		testNoRequestPayloadOnParseExceptionInternal(false,"nul");
 	}
 	
 	/**
 	 * Tests for Request payload data which is null
+	 * 
 	 * @throws Exception
 	 */
-	public void testNullRequestPayloadOnParseException() throws Exception{
+	public void testNullRequestPayloadOnParseException() throws Exception {
 		testNullRequestPayloadOnParseExceptionInternal(true,"nul");
 		testNullRequestPayloadOnParseExceptionInternal(false,"nul");
 	}
 	
 	/**
 	 * Tests for null Charset in Request payload data
+	 * 
 	 * @throws Exception
 	 */
-	public void testNullCharsetOnParseException() throws Exception{
+	public void testNullCharsetOnParseException() throws Exception {
 		testNullCharsetOnParseExceptionInternal(true,"nul");
 		testNullCharsetOnParseExceptionInternal(false,"nul");
 	}
@@ -48,7 +72,8 @@ public class TestRequestPayloadOnParseException extends BaseTest {
 	/*
 	 * *******************Private Methods*************************
 	 */
-	private void testRequestPayloadOnParseExceptionInternal(boolean isStream, String value) throws Exception{
+	private void testRequestPayloadAsBytesOnParseExceptionInternal(boolean isStream, String value) 
+	        throws Exception {
 		final String doc = "{ \"key1\" : "+value+" }";
 	     JsonParser jp = isStream ? createParserUsingStream(doc, "UTF-8")
 	                : createParserUsingReader(doc);
@@ -63,6 +88,40 @@ public class TestRequestPayloadOnParseException extends BaseTest {
 	    	 assertTrue("Message contains request body", ex.getMessage().contains("Request Payload : "+doc));
 	     }
 	}
+	
+	private void testRequestPayloadAsStringOnParseExceptionInternal(boolean isStream, String value) 
+	        throws Exception {
+        final String doc = "{ \"key1\" : "+value+" }";
+         JsonParser jp = isStream ? createParserUsingStream(doc, "UTF-8")
+                    : createParserUsingReader(doc);
+         jp.setRequestPayloadOnError(doc);
+         assertToken(JsonToken.START_OBJECT, jp.nextToken());
+         try{
+             jp.nextToken();
+             fail("Expecting parsing exception");
+         }
+         catch(JsonParseException ex){
+             assertEquals("Request payload data should match", doc, ex.getRequestPayload());
+             assertTrue("Message contains request body", ex.getMessage().contains("Request Payload : "+doc));
+         }
+    }
+	
+	private void testRawRequestPayloadOnParseExceptionInternal(boolean isStream, String value) 
+	        throws Exception {
+        final String doc = "{ \"key1\" : "+value+" }";
+         JsonParser jp = isStream ? createParserUsingStream(doc, "UTF-8")
+                    : createParserUsingReader(doc);
+         jp.setRequestPayloadOnError(doc.getBytes(), "UTF-8");
+         assertToken(JsonToken.START_OBJECT, jp.nextToken());
+         try{
+             jp.nextToken();
+             fail("Expecting parsing exception");
+         }
+         catch(JsonParseException ex){
+             assertTrue(((byte[])ex.getRawRequestPayload()).length > 0);
+             assertTrue("Message contains request body", ex.getMessage().contains("Request Payload : "+doc));
+         }
+    }
 
 	private void testNoRequestPayloadOnParseExceptionInternal(boolean isStream, String value) throws Exception{
 		final String doc = "{ \"key1\" : "+value+" }";
@@ -78,7 +137,8 @@ public class TestRequestPayloadOnParseException extends BaseTest {
 	     }
 	}
 	
-	private void testNullRequestPayloadOnParseExceptionInternal(boolean isStream, String value) throws Exception{
+	private void testNullRequestPayloadOnParseExceptionInternal(boolean isStream, String value) 
+	        throws Exception {
 		final String doc = "{ \"key1\" : "+value+" }";
 	     JsonParser jp = isStream ? createParserUsingStream(doc, "UTF-8")
 	                : createParserUsingReader(doc);
@@ -93,7 +153,8 @@ public class TestRequestPayloadOnParseException extends BaseTest {
 	     }
 	}
 	
-	private void testNullCharsetOnParseExceptionInternal(boolean isStream, String value) throws Exception{
+	private void testNullCharsetOnParseExceptionInternal(boolean isStream, String value) 
+	        throws Exception {
 		final String doc = "{ \"key1\" : "+value+" }";
 	     JsonParser jp = isStream ? createParserUsingStream(doc, "UTF-8")
 	                : createParserUsingReader(doc);

--- a/src/test/java/com/fasterxml/jackson/core/json/TestRequestPayloadOnParseException.java
+++ b/src/test/java/com/fasterxml/jackson/core/json/TestRequestPayloadOnParseException.java
@@ -8,25 +8,25 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 
 public class TestRequestPayloadOnParseException extends BaseTest {
-	
-	/**
-	 * Tests for Request payload data (bytes) on parsing error
-	 * 
-	 * @throws Exception
-	 */
-	public void testRequestPayloadAsBytesOnParseException() throws Exception {
-	    testRequestPayloadAsBytesOnParseExceptionInternal(true,"nul");
-	    testRequestPayloadAsBytesOnParseExceptionInternal(false,"nul");
-	}
-	
-	/**
+
+    /**
+     * Tests for Request payload data (bytes) on parsing error
+     * 
+     * @throws Exception
+     */
+    public void testRequestPayloadAsBytesOnParseException() throws Exception {
+        testRequestPayloadAsBytesOnParseExceptionInternal(true, "nul");
+        testRequestPayloadAsBytesOnParseExceptionInternal(false, "nul");
+    }
+
+    /**
      * Tests for Request payload data (String) on parsing error
      * 
      * @throws Exception
      */
     public void testRequestPayloadAsStringOnParseException() throws Exception {
-        testRequestPayloadAsStringOnParseExceptionInternal(true,"nul");
-        testRequestPayloadAsStringOnParseExceptionInternal(false,"nul");
+        testRequestPayloadAsStringOnParseExceptionInternal(true, "nul");
+        testRequestPayloadAsStringOnParseExceptionInternal(false, "nul");
     }
 
     /**
@@ -35,138 +35,121 @@ public class TestRequestPayloadOnParseException extends BaseTest {
      * @throws Exception
      */
     public void testRawRequestPayloadOnParseException() throws Exception {
-        testRawRequestPayloadOnParseExceptionInternal(true,"nul");
-        testRawRequestPayloadOnParseExceptionInternal(false,"nul");
-    }
-    
-	/**
-	 * Tests for no Request payload data on parsing error
-	 * 
-	 * @throws Exception
-	 */
-	public void testNoRequestPayloadOnParseException() throws Exception {
-		testNoRequestPayloadOnParseExceptionInternal(true,"nul");
-		testNoRequestPayloadOnParseExceptionInternal(false,"nul");
-	}
-	
-	/**
-	 * Tests for Request payload data which is null
-	 * 
-	 * @throws Exception
-	 */
-	public void testNullRequestPayloadOnParseException() throws Exception {
-		testNullRequestPayloadOnParseExceptionInternal(true,"nul");
-		testNullRequestPayloadOnParseExceptionInternal(false,"nul");
-	}
-	
-	/**
-	 * Tests for null Charset in Request payload data
-	 * 
-	 * @throws Exception
-	 */
-	public void testNullCharsetOnParseException() throws Exception {
-		testNullCharsetOnParseExceptionInternal(true,"nul");
-		testNullCharsetOnParseExceptionInternal(false,"nul");
-	}
-	
-	/*
-	 * *******************Private Methods*************************
-	 */
-	private void testRequestPayloadAsBytesOnParseExceptionInternal(boolean isStream, String value) 
-	        throws Exception {
-		final String doc = "{ \"key1\" : "+value+" }";
-	     JsonParser jp = isStream ? createParserUsingStream(doc, "UTF-8")
-	                : createParserUsingReader(doc);
-	     jp.setRequestPayloadOnError(doc.getBytes(), "UTF-8");
-	     assertToken(JsonToken.START_OBJECT, jp.nextToken());
-	     try{
-	    	 jp.nextToken();
-	    	 fail("Expecting parsing exception");
-	     }
-	     catch(JsonParseException ex){
-	    	 assertEquals("Request payload data should match", doc, ex.getRequestPayload());
-	    	 assertTrue("Message contains request body", ex.getMessage().contains("Request Payload : "+doc));
-	     }
-	}
-	
-	private void testRequestPayloadAsStringOnParseExceptionInternal(boolean isStream, String value) 
-	        throws Exception {
-        final String doc = "{ \"key1\" : "+value+" }";
-         JsonParser jp = isStream ? createParserUsingStream(doc, "UTF-8")
-                    : createParserUsingReader(doc);
-         jp.setRequestPayloadOnError(doc);
-         assertToken(JsonToken.START_OBJECT, jp.nextToken());
-         try{
-             jp.nextToken();
-             fail("Expecting parsing exception");
-         }
-         catch(JsonParseException ex){
-             assertEquals("Request payload data should match", doc, ex.getRequestPayload());
-             assertTrue("Message contains request body", ex.getMessage().contains("Request Payload : "+doc));
-         }
-    }
-	
-	private void testRawRequestPayloadOnParseExceptionInternal(boolean isStream, String value) 
-	        throws Exception {
-        final String doc = "{ \"key1\" : "+value+" }";
-         JsonParser jp = isStream ? createParserUsingStream(doc, "UTF-8")
-                    : createParserUsingReader(doc);
-         jp.setRequestPayloadOnError(doc.getBytes(), "UTF-8");
-         assertToken(JsonToken.START_OBJECT, jp.nextToken());
-         try{
-             jp.nextToken();
-             fail("Expecting parsing exception");
-         }
-         catch(JsonParseException ex){
-             assertTrue(((byte[])ex.getRawRequestPayload()).length > 0);
-             assertTrue("Message contains request body", ex.getMessage().contains("Request Payload : "+doc));
-         }
+        testRawRequestPayloadOnParseExceptionInternal(true, "nul");
+        testRawRequestPayloadOnParseExceptionInternal(false, "nul");
     }
 
-	private void testNoRequestPayloadOnParseExceptionInternal(boolean isStream, String value) throws Exception{
-		final String doc = "{ \"key1\" : "+value+" }";
-	     JsonParser jp = isStream ? createParserUsingStream(doc, "UTF-8")
-	                : createParserUsingReader(doc);
-	     assertToken(JsonToken.START_OBJECT, jp.nextToken());
-	     try{
-	    	 jp.nextToken();
-	    	 fail("Expecting parsing exception");
-	     }
-	     catch(JsonParseException ex){
-	    	 assertEquals("Request payload data should be null", null, ex.getRequestPayload());
-	     }
-	}
-	
-	private void testNullRequestPayloadOnParseExceptionInternal(boolean isStream, String value) 
-	        throws Exception {
-		final String doc = "{ \"key1\" : "+value+" }";
-	     JsonParser jp = isStream ? createParserUsingStream(doc, "UTF-8")
-	                : createParserUsingReader(doc);
-	     jp.setRequestPayloadOnError(null, "UTF-8");
-	     assertToken(JsonToken.START_OBJECT, jp.nextToken());
-	     try{
-	    	 jp.nextToken();
-	    	 fail("Expecting parsing exception");
-	     }
-	     catch(JsonParseException ex){
-	    	 assertEquals("Request payload data should be null", null, ex.getRequestPayload());
-	     }
-	}
-	
-	private void testNullCharsetOnParseExceptionInternal(boolean isStream, String value) 
-	        throws Exception {
-		final String doc = "{ \"key1\" : "+value+" }";
-	     JsonParser jp = isStream ? createParserUsingStream(doc, "UTF-8")
-	                : createParserUsingReader(doc);
-	     jp.setRequestPayloadOnError(doc.getBytes(), "");
-	     assertToken(JsonToken.START_OBJECT, jp.nextToken());
-	     try{
-	    	 jp.nextToken();
-	    	 fail("Expecting parsing exception");
-	     }
-	     catch(JsonParseException ex){
-	    	 assertEquals("Request payload data should match", doc, ex.getRequestPayload());
-	    	 assertTrue("Message contains request body", ex.getMessage().contains("Request Payload : "+doc));
-	     }
-	}
+    /**
+     * Tests for no Request payload data on parsing error
+     * 
+     * @throws Exception
+     */
+    public void testNoRequestPayloadOnParseException() throws Exception {
+        testNoRequestPayloadOnParseExceptionInternal(true, "nul");
+        testNoRequestPayloadOnParseExceptionInternal(false, "nul");
+    }
+
+    /**
+     * Tests for Request payload data which is null
+     * 
+     * @throws Exception
+     */
+    public void testNullRequestPayloadOnParseException() throws Exception {
+        testNullRequestPayloadOnParseExceptionInternal(true, "nul");
+        testNullRequestPayloadOnParseExceptionInternal(false, "nul");
+    }
+
+    /**
+     * Tests for null Charset in Request payload data
+     * 
+     * @throws Exception
+     */
+    public void testNullCharsetOnParseException() throws Exception {
+        testNullCharsetOnParseExceptionInternal(true, "nul");
+        testNullCharsetOnParseExceptionInternal(false, "nul");
+    }
+
+    /*
+     * *******************Private Methods*************************
+     */
+    private void testRequestPayloadAsBytesOnParseExceptionInternal(boolean isStream, String value) throws Exception {
+        final String doc = "{ \"key1\" : " + value + " }";
+        JsonParser jp = isStream ? createParserUsingStream(doc, "UTF-8") : createParserUsingReader(doc);
+        jp.setRequestPayloadOnError(doc.getBytes(), "UTF-8");
+        assertToken(JsonToken.START_OBJECT, jp.nextToken());
+        try {
+            jp.nextToken();
+            fail("Expecting parsing exception");
+        } catch (JsonParseException ex) {
+            assertEquals("Request payload data should match", doc, ex.getRequestPayload());
+            assertTrue("Message contains request body", ex.getMessage().contains("Request Payload : " + doc));
+        }
+    }
+
+    private void testRequestPayloadAsStringOnParseExceptionInternal(boolean isStream, String value) throws Exception {
+        final String doc = "{ \"key1\" : " + value + " }";
+        JsonParser jp = isStream ? createParserUsingStream(doc, "UTF-8") : createParserUsingReader(doc);
+        jp.setRequestPayloadOnError(doc);
+        assertToken(JsonToken.START_OBJECT, jp.nextToken());
+        try {
+            jp.nextToken();
+            fail("Expecting parsing exception");
+        } catch (JsonParseException ex) {
+            assertEquals("Request payload data should match", doc, ex.getRequestPayload());
+            assertTrue("Message contains request body", ex.getMessage().contains("Request Payload : " + doc));
+        }
+    }
+
+    private void testRawRequestPayloadOnParseExceptionInternal(boolean isStream, String value) throws Exception {
+        final String doc = "{ \"key1\" : " + value + " }";
+        JsonParser jp = isStream ? createParserUsingStream(doc, "UTF-8") : createParserUsingReader(doc);
+        jp.setRequestPayloadOnError(doc.getBytes(), "UTF-8");
+        assertToken(JsonToken.START_OBJECT, jp.nextToken());
+        try {
+            jp.nextToken();
+            fail("Expecting parsing exception");
+        } catch (JsonParseException ex) {
+            assertTrue(((byte[]) ex.getRawRequestPayload()).length > 0);
+            assertTrue("Message contains request body", ex.getMessage().contains("Request Payload : " + doc));
+        }
+    }
+
+    private void testNoRequestPayloadOnParseExceptionInternal(boolean isStream, String value) throws Exception {
+        final String doc = "{ \"key1\" : " + value + " }";
+        JsonParser jp = isStream ? createParserUsingStream(doc, "UTF-8") : createParserUsingReader(doc);
+        assertToken(JsonToken.START_OBJECT, jp.nextToken());
+        try {
+            jp.nextToken();
+            fail("Expecting parsing exception");
+        } catch (JsonParseException ex) {
+            assertEquals("Request payload data should be null", null, ex.getRequestPayload());
+        }
+    }
+
+    private void testNullRequestPayloadOnParseExceptionInternal(boolean isStream, String value) throws Exception {
+        final String doc = "{ \"key1\" : " + value + " }";
+        JsonParser jp = isStream ? createParserUsingStream(doc, "UTF-8") : createParserUsingReader(doc);
+        jp.setRequestPayloadOnError(null, "UTF-8");
+        assertToken(JsonToken.START_OBJECT, jp.nextToken());
+        try {
+            jp.nextToken();
+            fail("Expecting parsing exception");
+        } catch (JsonParseException ex) {
+            assertEquals("Request payload data should be null", null, ex.getRequestPayload());
+        }
+    }
+
+    private void testNullCharsetOnParseExceptionInternal(boolean isStream, String value) throws Exception {
+        final String doc = "{ \"key1\" : " + value + " }";
+        JsonParser jp = isStream ? createParserUsingStream(doc, "UTF-8") : createParserUsingReader(doc);
+        jp.setRequestPayloadOnError(doc.getBytes(), "");
+        assertToken(JsonToken.START_OBJECT, jp.nextToken());
+        try {
+            jp.nextToken();
+            fail("Expecting parsing exception");
+        } catch (JsonParseException ex) {
+            assertEquals("Request payload data should match", doc, ex.getRequestPayload());
+            assertTrue("Message contains request body", ex.getMessage().contains("Request Payload : " + doc));
+        }
+    }
 }

--- a/src/test/java/com/fasterxml/jackson/core/json/TestRequestPayloadOnParseException.java
+++ b/src/test/java/com/fasterxml/jackson/core/json/TestRequestPayloadOnParseException.java
@@ -10,27 +10,45 @@ import com.fasterxml.jackson.core.JsonToken;
 public class TestRequestPayloadOnParseException extends BaseTest {
 	
 	/**
-	 * Tests for Request body data on parsing error
+	 * Tests for Request payload data on parsing error
 	 * @throws Exception
 	 */
-	public void testRequestBodyOnParseException() throws Exception{
-		testRequestBodyOnParseExceptionInternal(true,"nul");
-		testRequestBodyOnParseExceptionInternal(false,"nul");
+	public void testRequestPayloadOnParseException() throws Exception{
+		testRequestPayloadOnParseExceptionInternal(true,"nul");
+		testRequestPayloadOnParseExceptionInternal(false,"nul");
 	}
 	
 	/**
-	 * Tests for no Request body data on parsing error
+	 * Tests for no Request payload data on parsing error
 	 * @throws Exception
 	 */
-	public void testNoRequestBodyOnParseException() throws Exception{
-		testNoRequestBodyOnParseExceptionInternal(true,"nul");
-		testNoRequestBodyOnParseExceptionInternal(false,"nul");
+	public void testNoRequestPayloadOnParseException() throws Exception{
+		testNoRequestPayloadOnParseExceptionInternal(true,"nul");
+		testNoRequestPayloadOnParseExceptionInternal(false,"nul");
+	}
+	
+	/**
+	 * Tests for Request payload data which is null
+	 * @throws Exception
+	 */
+	public void testNullRequestPayloadOnParseException() throws Exception{
+		testNullRequestPayloadOnParseExceptionInternal(true,"nul");
+		testNullRequestPayloadOnParseExceptionInternal(false,"nul");
+	}
+	
+	/**
+	 * Tests for null Charset in Request payload data
+	 * @throws Exception
+	 */
+	public void testNullCharsetOnParseException() throws Exception{
+		testNullCharsetOnParseExceptionInternal(true,"nul");
+		testNullCharsetOnParseExceptionInternal(false,"nul");
 	}
 	
 	/*
 	 * *******************Private Methods*************************
 	 */
-	private void testRequestBodyOnParseExceptionInternal(boolean isStream, String value) throws Exception{
+	private void testRequestPayloadOnParseExceptionInternal(boolean isStream, String value) throws Exception{
 		final String doc = "{ \"key1\" : "+value+" }";
 	     JsonParser jp = isStream ? createParserUsingStream(doc, "UTF-8")
 	                : createParserUsingReader(doc);
@@ -46,7 +64,7 @@ public class TestRequestPayloadOnParseException extends BaseTest {
 	     }
 	}
 
-	private void testNoRequestBodyOnParseExceptionInternal(boolean isStream, String value) throws Exception{
+	private void testNoRequestPayloadOnParseExceptionInternal(boolean isStream, String value) throws Exception{
 		final String doc = "{ \"key1\" : "+value+" }";
 	     JsonParser jp = isStream ? createParserUsingStream(doc, "UTF-8")
 	                : createParserUsingReader(doc);
@@ -57,6 +75,37 @@ public class TestRequestPayloadOnParseException extends BaseTest {
 	     }
 	     catch(JsonParseException ex){
 	    	 assertEquals("Request payload data should be null", null, ex.getRequestPayload());
+	     }
+	}
+	
+	private void testNullRequestPayloadOnParseExceptionInternal(boolean isStream, String value) throws Exception{
+		final String doc = "{ \"key1\" : "+value+" }";
+	     JsonParser jp = isStream ? createParserUsingStream(doc, "UTF-8")
+	                : createParserUsingReader(doc);
+	     jp.setRequestPayloadOnError(null, "UTF-8");
+	     assertToken(JsonToken.START_OBJECT, jp.nextToken());
+	     try{
+	    	 jp.nextToken();
+	    	 fail("Expecting parsing exception");
+	     }
+	     catch(JsonParseException ex){
+	    	 assertEquals("Request payload data should be null", null, ex.getRequestPayload());
+	     }
+	}
+	
+	private void testNullCharsetOnParseExceptionInternal(boolean isStream, String value) throws Exception{
+		final String doc = "{ \"key1\" : "+value+" }";
+	     JsonParser jp = isStream ? createParserUsingStream(doc, "UTF-8")
+	                : createParserUsingReader(doc);
+	     jp.setRequestPayloadOnError(doc.getBytes(), "");
+	     assertToken(JsonToken.START_OBJECT, jp.nextToken());
+	     try{
+	    	 jp.nextToken();
+	    	 fail("Expecting parsing exception");
+	     }
+	     catch(JsonParseException ex){
+	    	 assertEquals("Request payload data should match", doc, ex.getRequestPayload());
+	    	 assertTrue("Message contains request body", ex.getMessage().contains("Request Payload : "+doc));
 	     }
 	}
 }

--- a/src/test/java/com/fasterxml/jackson/core/json/TestRequestPayloadOnParseException.java
+++ b/src/test/java/com/fasterxml/jackson/core/json/TestRequestPayloadOnParseException.java
@@ -7,7 +7,7 @@ import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 
-public class TestRequestBodyOnParseException extends BaseTest {
+public class TestRequestPayloadOnParseException extends BaseTest {
 	
 	/**
 	 * Tests for Request body data on parsing error
@@ -34,15 +34,15 @@ public class TestRequestBodyOnParseException extends BaseTest {
 		final String doc = "{ \"key1\" : "+value+" }";
 	     JsonParser jp = isStream ? createParserUsingStream(doc, "UTF-8")
 	                : createParserUsingReader(doc);
-	     jp.setRequestBodyOnError(doc.getBytes(), "UTF-8");
+	     jp.setRequestPayloadOnError(doc.getBytes(), "UTF-8");
 	     assertToken(JsonToken.START_OBJECT, jp.nextToken());
 	     try{
 	    	 jp.nextToken();
 	    	 fail("Expecting parsing exception");
 	     }
 	     catch(JsonParseException ex){
-	    	 assertEquals("Request body data should match", doc, ex.getRequestBody());
-	    	 assertTrue("Message contains request body", ex.getMessage().contains("Request Body : "+doc));
+	    	 assertEquals("Request payload data should match", doc, ex.getRequestPayload());
+	    	 assertTrue("Message contains request body", ex.getMessage().contains("Request Payload : "+doc));
 	     }
 	}
 
@@ -56,7 +56,7 @@ public class TestRequestBodyOnParseException extends BaseTest {
 	    	 fail("Expecting parsing exception");
 	     }
 	     catch(JsonParseException ex){
-	    	 assertEquals("Request body data should be empty", "", ex.getRequestBody());
+	    	 assertEquals("Request payload data should be null", null, ex.getRequestPayload());
 	     }
 	}
 }


### PR DESCRIPTION
This commit fixes the issue #86, where request body as byte[] is taken as input (taking byte[] as input to avoid any rewind errors) to the JsonParser along with the charset and will be displayed in the JsonParseException.
 Along with that there is an additional method - getRequestBody() to get only the request body from the JsonParseException.
By default, the request body will not be shown in the exception as it will be null. Once the request body is set it will be shown as part of the exception.