### PR TITLE
Fix for issue 209 - make use of _allowMultipleMatches FilterParsingDelegate

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/filter/FilteringParserDelegate.java
+++ b/src/main/java/com/fasterxml/jackson/core/filter/FilteringParserDelegate.java
@@ -221,6 +221,13 @@ public class FilteringParserDelegate extends JsonParserDelegate
     @Override
     public JsonToken nextToken() throws IOException
     {
+    	//Check for _allowMultipleMatches - false and atleast there is one token - which is _currToken
+    	// and check for _itemFilter matching INCLUDE_ALL. 
+    	//If all the conditions matches then return null
+    	if(!_allowMultipleMatches && _currToken != null 
+    			&& _itemFilter == TokenFilter.INCLUDE_ALL){
+    		return null;
+    	}
         // Anything buffered?
         TokenFilterContext ctxt = _exposedContext;
 

--- a/src/test/java/com/fasterxml/jackson/core/filter/BasicParserFilteringTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/filter/BasicParserFilteringTest.java
@@ -103,6 +103,35 @@ public class BasicParserFilteringTest extends BaseTest
         assertEquals(aposToQuotes("{'ob':{'value':3}}"), result);
     }
 
+    
+    @SuppressWarnings("resource")
+    public void testNotAllowMultipleMatches() throws Exception
+    {
+    	String jsonString = aposToQuotes("{'a':123,'array':[1,2],'ob':{'value0':2,'value':3,'value2':4},'value':4,'b':true}");
+        JsonParser p0 = JSON_F.createParser(jsonString);
+        JsonParser p = new FilteringParserDelegate(p0,
+               new NameMatchFilter("value"),
+                   false, // includePath
+                   false // multipleMatches -false
+                );
+        String result = readAndWrite(JSON_F, p);
+        assertEquals(aposToQuotes("3"), result);
+    }
+    
+    @SuppressWarnings("resource")
+    public void testAllowMultipleMatches() throws Exception
+    {
+    	String jsonString = aposToQuotes("{'a':123,'array':[1,2],'ob':{'value0':2,'value':3,'value2':4},'value':4,'b':true}");
+        JsonParser p0 = JSON_F.createParser(jsonString);
+        JsonParser p = new FilteringParserDelegate(p0,
+               new NameMatchFilter("value"),
+                   false, // includePath
+                   true // multipleMatches - true
+                );
+        String result = readAndWrite(JSON_F, p);
+        assertEquals(aposToQuotes("3 4"), result);
+    }
+
     @SuppressWarnings("resource")
     public void testMultipleMatchFilteringWithPath1() throws Exception
     {


### PR DESCRIPTION
The commit fixes the issue #209 , when _allowMultipleMatches is set to false, then there should be only one match and if it is set to true then it continues to match the token until the end of the document.
