### PR TITLE
Fix for issue #117 - Supports the missing values in an array

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/JsonParser.java
+++ b/src/main/java/com/fasterxml/jackson/core/JsonParser.java
@@ -208,7 +208,20 @@ public abstract class JsonParser
           *
           * @since 2.6
           */
-         IGNORE_UNDEFINED(false)
+         IGNORE_UNDEFINED(false),
+         
+         
+         /**
+          * Feature allows the support for missing values in a JSON array. Enabling this feature 
+          * will replace any missing value by null in the JSON array.
+          * <p>
+          * For example, enabling this feature will represent a JSON array <code>["value1",,"value3",]</code>
+          * as <code>["value1", null, "value3", null]</code> 
+          * <p>
+          * Since the JSON specification does not allow missing values, this is a non-compliant JSON
+          * feature, and is disabled by default
+          */
+         ALLOW_MISSING_VALUES(false)
          ;
 
         /**

--- a/src/main/java/com/fasterxml/jackson/core/json/ReaderBasedJsonParser.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/ReaderBasedJsonParser.java
@@ -3,6 +3,7 @@ package com.fasterxml.jackson.core.json;
 import java.io.*;
 
 import com.fasterxml.jackson.core.*;
+import com.fasterxml.jackson.core.JsonParser.Feature;
 import com.fasterxml.jackson.core.base.ParserBase;
 import com.fasterxml.jackson.core.io.CharTypes;
 import com.fasterxml.jackson.core.io.IOContext;
@@ -667,9 +668,22 @@ public class ReaderBasedJsonParser // final in 2.3, earlier
             }
             t = JsonToken.START_OBJECT;
             break;
+        /*
+         * This check proceeds only if the Feature.ALLOW_MISSING_VALUES is enabled
+         * The Check is for missing values. Incase of missing values in an array, the next token will be either ',' or ']'.
+         * This case, decrements the already incremented _inputPtr in the buffer in case of comma(,) 
+         * so that the existing flow goes back to checking the next token which will be comma again and
+         * it continues the parsing.
+         * Also the case returns NULL as current token in case of ',' or ']'.    
+         */
+        case ',':
         case ']':
+        	if(isEnabled(Feature.ALLOW_MISSING_VALUES)) {
+        		_inputPtr--;
+        		return (_currToken = JsonToken.VALUE_NULL);  
+        	}    
         case '}':
-            // Error: neither is valid at this point; valid closers have
+            // Error: } is not valid at this point; valid closers have
             // been handled earlier
             _reportUnexpectedChar(i, "expected a value");
         case 't':
@@ -1070,6 +1084,20 @@ public class ReaderBasedJsonParser // final in 2.3, earlier
         case '8':
         case '9':
             return (_currToken = _parsePosNumber(i));
+        /*
+         * This check proceeds only if the Feature.ALLOW_MISSING_VALUES is enabled
+         * The Check is for missing values. Incase of missing values in an array, the next token will be either ',' or ']'.
+         * This case, decrements the already incremented _inputPtr in the buffer in case of comma(,) 
+         * so that the existing flow goes back to checking the next token which will be comma again and
+         * it continues the parsing.
+         * Also the case returns NULL as current token in case of ',' or ']'.    
+         */
+        case ',':
+        case ']':
+        	if(isEnabled(Feature.ALLOW_MISSING_VALUES)) {
+        		_inputPtr--;
+        		return (_currToken = JsonToken.VALUE_NULL);  
+        	}    
         }
         return (_currToken = _handleOddValue(i));
     }

--- a/src/main/java/com/fasterxml/jackson/core/json/UTF8StreamJsonParser.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/UTF8StreamJsonParser.java
@@ -850,6 +850,20 @@ public class UTF8StreamJsonParser
         case '8':
         case '9':
             return (_currToken = _parsePosNumber(i));
+        /*
+         * This check proceeds only if the Feature.ALLOW_MISSING_VALUES is enabled
+         * The Check is for missing values. Incase of missing values in an array, the next token will be either ',' or ']'.
+         * This case, decrements the already incremented _inputPtr in the buffer in case of comma(,) 
+         * so that the existing flow goes back to checking the next token which will be comma again and
+         * it continues the parsing.
+         * Also the case returns NULL as current token in case of ',' or ']'.    
+         */
+        case ',':
+        case ']':
+        	if(isEnabled(Feature.ALLOW_MISSING_VALUES)) {
+        		_inputPtr--;
+        		return (_currToken = JsonToken.VALUE_NULL);  
+        	}
         }
         return (_currToken = _handleUnexpectedValue(i));
     }

--- a/src/test/java/com/fasterxml/jackson/core/main/TestArrayParsing.java
+++ b/src/test/java/com/fasterxml/jackson/core/main/TestArrayParsing.java
@@ -69,4 +69,102 @@ public class TestArrayParsing
         }
         jp.close();
     }
+    
+    /**
+     * Tests the missing value as 'null' in an array 
+     * This needs enabling of the Feature.ALLOW_MISSING_VALUES in JsonParser
+     * This tests both Stream based parsing and the Reader based parsing
+     * @throws Exception
+     */
+    public void testMissingValueAsNullByEnablingFeature() throws Exception
+    {
+    	_testMissingValueByEnablingFeature(true);
+    	_testMissingValueByEnablingFeature(false);
+    }
+
+    /**
+     * Tests the missing value in an array by not enabling 
+     * the Feature.ALLOW_MISSING_VALUES
+     * @throws Exception
+     */
+    public void testMissingValueAsNullByNotEnablingFeature() throws Exception
+    {
+    	_testMissingValueNotEnablingFeature(true);
+    	_testMissingValueNotEnablingFeature(false);
+    }
+    
+    /**
+     * Tests the not missing any value in an array by enabling the 
+     * Feature.ALLOW_MISSING_VALUES in JsonParser
+     * This tests both Stream based parsing and the Reader based parsing for not missing any value
+     * @throws Exception
+     */
+    public void testNotMissingValueByEnablingFeature() throws Exception
+    {
+    	_testNotMissingValueByEnablingFeature(true);
+    	_testNotMissingValueByEnablingFeature(false);
+    }
+    
+    private void _testMissingValueByEnablingFeature(boolean useStream) throws Exception {
+    	final String DOC = "[ \"a\",,,,\"abc\", ] ";
+
+    	JsonFactory f = new JsonFactory();
+    	f.configure(JsonParser.Feature.ALLOW_MISSING_VALUES, true);
+    	
+        JsonParser jp = useStream ? createParserUsingStream(f, DOC, "UTF-8")
+   			          : createParserUsingReader(f, DOC);
+        
+        assertToken(JsonToken.START_ARRAY, jp.nextToken());
+        assertToken(JsonToken.VALUE_STRING, jp.nextToken());
+        assertEquals("a", jp.getValueAsString());
+        
+        assertToken(JsonToken.VALUE_NULL, jp.nextToken());
+        assertToken(JsonToken.VALUE_NULL, jp.nextToken());
+        assertToken(JsonToken.VALUE_NULL, jp.nextToken());
+        assertToken(JsonToken.VALUE_STRING, jp.nextToken());
+        assertToken(JsonToken.VALUE_NULL, jp.nextToken());
+        assertToken(JsonToken.END_ARRAY, jp.nextToken());
+             
+        jp.close();
+    }
+    
+    private void _testMissingValueNotEnablingFeature(boolean useStream) throws Exception {
+    	final String DOC = "[ \"a\",,\"abc\"] ";
+
+    	JsonFactory f = new JsonFactory();
+    	
+        JsonParser jp = useStream ? createParserUsingStream(f, DOC, "UTF-8")
+   			          : createParserUsingReader(f, DOC);
+        
+        assertToken(JsonToken.START_ARRAY, jp.nextToken());
+        assertToken(JsonToken.VALUE_STRING, jp.nextToken());
+        assertEquals("a", jp.getValueAsString());
+        try {
+	        assertToken(JsonToken.VALUE_STRING, jp.nextToken());
+	        fail("Expecting exception here");
+        }
+        catch(JsonParseException ex){
+        	verifyException(ex, "expected a valid value", "expected a value");
+        }
+        jp.close();
+    }
+    
+    private void _testNotMissingValueByEnablingFeature(boolean useStream) throws Exception {
+    	final String DOC = "[ \"a\",\"abc\"] ";
+
+    	JsonFactory f = new JsonFactory();
+    	f.configure(JsonParser.Feature.ALLOW_MISSING_VALUES, true);
+    	
+        JsonParser jp = useStream ? createParserUsingStream(f, DOC, "UTF-8")
+   			          : createParserUsingReader(f, DOC);
+        
+        assertToken(JsonToken.START_ARRAY, jp.nextToken());
+        assertToken(JsonToken.VALUE_STRING, jp.nextToken());
+        assertEquals("a", jp.getValueAsString());
+        
+        assertToken(JsonToken.VALUE_STRING, jp.nextToken());
+        assertToken(JsonToken.END_ARRAY, jp.nextToken());
+             
+        jp.close();
+    }
 }


### PR DESCRIPTION
The fix (#117) supports the missing values in an array by replacing the missing value with null
This feature can be enabled by setting Feature.ALLOW_MISSING_VALUES in JsonParser.