### PR TITLE
FilteringGeneratorDelegate.writeUTF8String() should delegate to writeUTF8String()

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/filter/FilteringGeneratorDelegate.java
+++ b/src/main/java/com/fasterxml/jackson/core/filter/FilteringGeneratorDelegate.java
@@ -375,7 +375,7 @@ public class FilteringGeneratorDelegate extends JsonGeneratorDelegate
     {
         // not exact match, but best we can do
         if (_checkRawValueWrite()) {
-            delegate.writeRawUTF8String(text, offset, length);
+            delegate.writeUTF8String(text, offset, length);
         }
     }
 


### PR DESCRIPTION
In its `writeUTF8String()` method, a `FilteringGeneratorDelegate` uses the delegating `writeRawUTF8String()` method that do not manage additional escaping:

```java
@Override
public void writeUTF8String(byte[] text, int offset, int length) throws IOException
{
    // not exact match, but best we can do
    if (_checkRawValueWrite()) {
        delegate.writeRawUTF8String(text, offset, length);
    }
}
```

I think it should use the `delegate.writeUTF8String()` instead so that it correctly escapes required chars:

```java
    // not exact match, but best we can do
    if (_checkRawValueWrite()) {
        delegate.writeUTF8String(text, offset, length);
    }

```

This pull request changes that and adds a small unit test.
