### PR TITLE
issue #15 - readtext in jsonparser

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/JsonParser.java
+++ b/src/main/java/com/fasterxml/jackson/core/JsonParser.java
@@ -1018,10 +1018,11 @@ public abstract class JsonParser
      * Method to read the textual representation of the current token in chunks and 
      * pass it to the given Writer
      * 
-     *  @return true, if the text chunks has been processed completely and passed to the given writer
-     *          false, if the text chunks are still being processed
+     *  @return The number of characters written to the Writer 
+     *  
+     *  @since 2.5
      */
-    public abstract boolean readText(Writer writer) throws IOException;
+    public abstract int readText(Writer writer) throws IOException, UnsupportedOperationException;
 
     /**
      * Method similar to {@link #getText}, but that will return

--- a/src/main/java/com/fasterxml/jackson/core/JsonParser.java
+++ b/src/main/java/com/fasterxml/jackson/core/JsonParser.java
@@ -1013,6 +1013,15 @@ public abstract class JsonParser
      * Method can be called for any token type.
      */
     public abstract String getText() throws IOException;
+    
+    /**
+     * Method to read the textual representation of the current token in chunks and 
+     * pass it to the given Writer
+     * 
+     *  @return true, if the text chunks has been processed completely and passed to the given writer
+     *          false, if the text chunks are still being processed
+     */
+    public abstract boolean readText(Writer writer) throws IOException;
 
     /**
      * Method similar to {@link #getText}, but that will return

--- a/src/main/java/com/fasterxml/jackson/core/json/ReaderBasedJsonParser.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/ReaderBasedJsonParser.java
@@ -97,12 +97,6 @@ public class ReaderBasedJsonParser // final in 2.3, earlier
      */
     protected int _nameStartCol;
     
-    /**
-     * Indicates the currently read text buffer index which refers to the 
-     * TextBuffer character segment
-     */
-    protected int _readTextBufferIndex;
-
     /*
     /**********************************************************
     /* Life-cycle
@@ -129,7 +123,6 @@ public class ReaderBasedJsonParser // final in 2.3, earlier
         _symbols = st;
         _hashSeed = st.hashSeed();
         _bufferRecyclable = bufferRecyclable;
-        _readTextBufferIndex = 0;
     }
 
     /**
@@ -148,7 +141,6 @@ public class ReaderBasedJsonParser // final in 2.3, earlier
         _symbols = st;
         _hashSeed = st.hashSeed();
         _bufferRecyclable = true;
-        _readTextBufferIndex = 0;
     }
 
     /*
@@ -283,8 +275,10 @@ public class ReaderBasedJsonParser // final in 2.3, earlier
     }
     
     @Override
-    public final boolean readText(Writer writer) throws IOException {
+    public final int readText(Writer writer) throws IOException, UnsupportedOperationException {
         JsonToken t = _currToken;
+        //Stores the length of the bytes read
+        int len = 0;
         if (t == JsonToken.VALUE_STRING) {
             if (_tokenIncomplete) {
                 _tokenIncomplete = false;
@@ -292,17 +286,19 @@ public class ReaderBasedJsonParser // final in 2.3, earlier
             }
             List<char[]> segments = _textBuffer.getCharacterSegments();
             
-            
+            //Indicates the currently read text buffer index which refers to the 
+            //TextBuffer character segment
+            int readTextBufferIndex = 0;
             //if there are character segments, then use them and write them to the writer
-            if(segments != null && _readTextBufferIndex < segments.size()) {
-                writer.write(segments.get(_readTextBufferIndex++));
-                return false;
+            while(segments != null && readTextBufferIndex < segments.size()) {
+                writer.write(segments.get(readTextBufferIndex));
+                len += segments.get(readTextBufferIndex).length;
+                readTextBufferIndex++;
             }
-            //if there are no character segments, then read the string from the current segment, and 
+            //if there are no character segments left, then read the string from the current segment, and 
             //write them directly to the buffer
-            else {
-                writer.write(_textBuffer.getCurrentSegment(), 0, _textBuffer.getCurrentSegmentSize());
-            }
+            writer.write(_textBuffer.getCurrentSegment(), 0, _textBuffer.getCurrentSegmentSize());
+            len += _textBuffer.getCurrentSegmentSize();
            
         }
         else if(t != null) {
@@ -319,10 +315,8 @@ public class ReaderBasedJsonParser // final in 2.3, earlier
                 writer.write(t.asString());
             }
         }
-        //resetting the text buffer index back to zero, once all the chunks are passed to the
-        //given writer object
-        _readTextBufferIndex = 0;
-        return true;
+        
+        return len;
     }
 
     // // // Let's override default impls for improved performance

--- a/src/main/java/com/fasterxml/jackson/core/json/UTF8DataInputJsonParser.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/UTF8DataInputJsonParser.java
@@ -2,6 +2,7 @@ package com.fasterxml.jackson.core.json;
 
 import java.io.*;
 import java.util.Arrays;
+import java.util.List;
 
 import com.fasterxml.jackson.core.*;
 import com.fasterxml.jackson.core.base.ParserBase;
@@ -98,6 +99,12 @@ public class UTF8DataInputJsonParser
      * have to "push back"
      */
     protected int _nextCharByte = -1;
+    
+    /**
+     * Indicates the currently read text buffer index which refers to the 
+     * TextBuffer character segment
+     */
+    protected int _readTextBufferIndex;
 
     /*
     /**********************************************************
@@ -112,6 +119,7 @@ public class UTF8DataInputJsonParser
         _objectCodec = codec;
         _symbols = sym;
         _inputData = inputData;
+        _readTextBufferIndex = 0;
     }
 
     @Override
@@ -180,6 +188,49 @@ public class UTF8DataInputJsonParser
             return _textBuffer.contentsAsString();
         }
         return _getText2(_currToken);
+    }
+    
+    @Override
+    public final boolean readText(Writer writer) throws IOException {
+        JsonToken t = _currToken;
+        if (t == JsonToken.VALUE_STRING) {
+            if (_tokenIncomplete) {
+                _tokenIncomplete = false;
+                _finishString(); // only strings can be incomplete
+            }
+            List<char[]> segments = _textBuffer.getCharacterSegments();
+            
+            
+            //if there are character segments, then use them and write them to the writer
+            if(segments != null && _readTextBufferIndex < segments.size()) {
+                writer.write(segments.get(_readTextBufferIndex++));
+                return false;
+            }
+            //if there are no character segments, then read the string from the current segment, and 
+            //write them directly to the buffer
+            else {
+                writer.write(_textBuffer.getCurrentSegment(), 0, _textBuffer.getCurrentSegmentSize());
+            }
+           
+        }
+        else if(t != null) {
+            switch (t.id()) {
+            case ID_FIELD_NAME:
+                writer.write(_parsingContext.getCurrentName());
+                break;    
+            case ID_STRING:
+            case ID_NUMBER_INT:
+            case ID_NUMBER_FLOAT:
+                writer.write(_textBuffer.contentsAsString());
+                break;
+            default:
+                writer.write(t.asString());
+            }
+        }
+        //resetting the text buffer index back to zero, once all the chunks are passed to the
+        //given writer object
+        _readTextBufferIndex = 0;
+        return true;
     }
 
     // // // Let's override default impls for improved performance

--- a/src/main/java/com/fasterxml/jackson/core/json/UTF8StreamJsonParser.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/UTF8StreamJsonParser.java
@@ -328,8 +328,10 @@ public class UTF8StreamJsonParser
     }
     
     @Override
-    public final boolean readText(Writer writer) throws IOException {
+    public final int readText(Writer writer) throws IOException, UnsupportedOperationException {
         JsonToken t = _currToken;
+        //Stores the length of the bytes read
+        int len = 0;
         if (t == JsonToken.VALUE_STRING) {
             if (_tokenIncomplete) {
                 _tokenIncomplete = false;
@@ -337,17 +339,19 @@ public class UTF8StreamJsonParser
             }
             List<char[]> segments = _textBuffer.getCharacterSegments();
             
-            
+            //Indicates the currently read text buffer index which refers to the 
+            //TextBuffer character segment
+            int readTextBufferIndex = 0;
             //if there are character segments, then use them and write them to the writer
-            if(segments != null && _readTextBufferIndex < segments.size()) {
-                writer.write(segments.get(_readTextBufferIndex++));
-                return false;
+            while(segments != null && readTextBufferIndex < segments.size()) {
+                writer.write(segments.get(readTextBufferIndex));
+                len += segments.get(readTextBufferIndex).length;
+                readTextBufferIndex++;
             }
-            //if there are no character segments, then read the string from the current segment, and 
+            //if there are no character segments left, then read the string from the current segment, and 
             //write them directly to the buffer
-            else {
-                writer.write(_textBuffer.getCurrentSegment(), 0, _textBuffer.getCurrentSegmentSize());
-            }
+            writer.write(_textBuffer.getCurrentSegment(), 0, _textBuffer.getCurrentSegmentSize());
+            len += _textBuffer.getCurrentSegmentSize();
            
         }
         else if(t != null) {
@@ -364,10 +368,8 @@ public class UTF8StreamJsonParser
                 writer.write(t.asString());
             }
         }
-        //resetting the text buffer index back to zero, once all the chunks are passed to the
-        //given writer object
-        _readTextBufferIndex = 0;
-        return true;
+        
+        return len;
     }
 
     // // // Let's override default impls for improved performance

--- a/src/main/java/com/fasterxml/jackson/core/json/UTF8StreamJsonParser.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/UTF8StreamJsonParser.java
@@ -2,6 +2,7 @@ package com.fasterxml.jackson.core.json;
 
 import java.io.*;
 import java.util.Arrays;
+import java.util.List;
 
 import com.fasterxml.jackson.core.*;
 import com.fasterxml.jackson.core.base.ParserBase;
@@ -119,6 +120,12 @@ public class UTF8StreamJsonParser
      */
     protected boolean _bufferRecyclable;
     
+    /**
+     * Indicates the currently read text buffer index which refers to the 
+     * TextBuffer character segment
+     */
+    protected int _readTextBufferIndex;
+    
     /*
     /**********************************************************
     /* Life-cycle
@@ -141,6 +148,7 @@ public class UTF8StreamJsonParser
         // If we have offset, need to omit that from byte offset, so:
         _currInputProcessed = -start;
         _bufferRecyclable = bufferRecyclable;
+        _readTextBufferIndex = 0;
     }
 
     @Override
@@ -317,6 +325,49 @@ public class UTF8StreamJsonParser
             return _textBuffer.contentsAsString();
         }
         return _getText2(_currToken);
+    }
+    
+    @Override
+    public final boolean readText(Writer writer) throws IOException {
+        JsonToken t = _currToken;
+        if (t == JsonToken.VALUE_STRING) {
+            if (_tokenIncomplete) {
+                _tokenIncomplete = false;
+                _finishString(); // only strings can be incomplete
+            }
+            List<char[]> segments = _textBuffer.getCharacterSegments();
+            
+            
+            //if there are character segments, then use them and write them to the writer
+            if(segments != null && _readTextBufferIndex < segments.size()) {
+                writer.write(segments.get(_readTextBufferIndex++));
+                return false;
+            }
+            //if there are no character segments, then read the string from the current segment, and 
+            //write them directly to the buffer
+            else {
+                writer.write(_textBuffer.getCurrentSegment(), 0, _textBuffer.getCurrentSegmentSize());
+            }
+           
+        }
+        else if(t != null) {
+            switch (t.id()) {
+            case ID_FIELD_NAME:
+                writer.write(_parsingContext.getCurrentName());
+                break;    
+            case ID_STRING:
+            case ID_NUMBER_INT:
+            case ID_NUMBER_FLOAT:
+                writer.write(_textBuffer.contentsAsString());
+                break;
+            default:
+                writer.write(t.asString());
+            }
+        }
+        //resetting the text buffer index back to zero, once all the chunks are passed to the
+        //given writer object
+        _readTextBufferIndex = 0;
+        return true;
     }
 
     // // // Let's override default impls for improved performance

--- a/src/main/java/com/fasterxml/jackson/core/util/JsonParserDelegate.java
+++ b/src/main/java/com/fasterxml/jackson/core/util/JsonParserDelegate.java
@@ -2,6 +2,7 @@ package com.fasterxml.jackson.core.util;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.io.Writer;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 
@@ -140,6 +141,7 @@ public class JsonParserDelegate extends JsonParser
     @Override public char[] getTextCharacters() throws IOException { return delegate.getTextCharacters(); }
     @Override public int getTextLength() throws IOException { return delegate.getTextLength(); }
     @Override public int getTextOffset() throws IOException { return delegate.getTextOffset(); }
+    @Override public boolean readText(Writer writer) throws IOException { return delegate.readText(writer);  }
 
     /*
     /**********************************************************

--- a/src/main/java/com/fasterxml/jackson/core/util/JsonParserDelegate.java
+++ b/src/main/java/com/fasterxml/jackson/core/util/JsonParserDelegate.java
@@ -141,7 +141,7 @@ public class JsonParserDelegate extends JsonParser
     @Override public char[] getTextCharacters() throws IOException { return delegate.getTextCharacters(); }
     @Override public int getTextLength() throws IOException { return delegate.getTextLength(); }
     @Override public int getTextOffset() throws IOException { return delegate.getTextOffset(); }
-    @Override public boolean readText(Writer writer) throws IOException { return delegate.readText(writer);  }
+    @Override public int readText(Writer writer) throws IOException { return delegate.readText(writer);  }
 
     /*
     /**********************************************************

--- a/src/main/java/com/fasterxml/jackson/core/util/TextBuffer.java
+++ b/src/main/java/com/fasterxml/jackson/core/util/TextBuffer.java
@@ -3,6 +3,7 @@ package com.fasterxml.jackson.core.util;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 import com.fasterxml.jackson.core.io.NumberInput;
 
@@ -554,6 +555,15 @@ public final class TextBuffer
         return curr;
     }
 
+    /**
+     * Returns the raw list of character segments
+     * 
+     * @return The character segments
+     */
+    public List<char[]> getCharacterSegments() {
+        return _segments;
+    }
+    
     public int getCurrentSegmentSize() { return _currentSize; }
     public void setCurrentLength(int len) { _currentSize = len; }
 

--- a/src/test/java/com/fasterxml/jackson/core/read/JsonParserTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/read/JsonParserTest.java
@@ -608,12 +608,10 @@ if (type == MODE_INPUT_DATA) {
         parser.nextToken();
         
         Writer writer = new StringWriter();
-        while(!parser.readText(writer)) {
-            writer.flush();
-            assertTrue("String not empty", writer.toString().length() > 0);
-        }
+        int len = parser.readText(writer);
         
         assertTrue("String length should be same", writer.toString().length() == "this is a sample text for json parsing using readText() method".length());
+        assertEquals("Returned length should be same", len, writer.toString().length());
         
         //create parser in stream mode..
         parser = _createParser(MODE_INPUT_STREAM, JSON);
@@ -623,12 +621,10 @@ if (type == MODE_INPUT_DATA) {
         parser.nextToken();
         
         writer = new StringWriter();
-        while(!parser.readText(writer)) {
-            writer.flush();
-            assertTrue("String not empty", writer.toString().length() > 0);
-        }
+        len = parser.readText(writer);
         
         assertTrue("String length should be same", writer.toString().length() == "this is a sample text for json parsing using readText() method".length());
+        assertEquals("Returned length should be same", len, writer.toString().length());
         
         //create parser in data input mode..
         parser = createParserForDataInput(JSON_FACTORY, new MockDataInput(JSON));
@@ -638,12 +634,10 @@ if (type == MODE_INPUT_DATA) {
         parser.nextToken();
         
         writer = new StringWriter();
-        while(!parser.readText(writer)) {
-            writer.flush();
-            assertTrue("String not empty", writer.toString().length() > 0);
-        }
+        len = parser.readText(writer);
         
         assertTrue("String length should be same", writer.toString().length() == "this is a sample text for json parsing using readText() method".length());
+        assertEquals("Returned length should be same", len, writer.toString().length());
     }
     
     public void testLongerReadText() throws Exception {
@@ -661,12 +655,8 @@ if (type == MODE_INPUT_DATA) {
         parser.nextToken();
         
         Writer writer = new StringWriter();
-        while(!parser.readText(writer)) {
-            writer.flush();
-            assertTrue("String not empty", writer.toString().length() > 0);
-        }
-        
-        assertTrue("String length should be same", writer.toString().length() == longText.length());
+        int len = parser.readText(writer);
+        assertEquals("Returned length should be same", len, writer.toString().length());
         
         //create parser in stream mode..
         parser = _createParser(MODE_INPUT_STREAM, JSON);
@@ -676,27 +666,19 @@ if (type == MODE_INPUT_DATA) {
         parser.nextToken();
         
         writer = new StringWriter();
-        while(!parser.readText(writer)) {
-            writer.flush();
-            assertTrue("String not empty", writer.toString().length() > 0);
-        }
-        
-        assertTrue("String length should be same", writer.toString().length() == longText.length());
+        len = parser.readText(writer);
+        assertEquals("Returned length should be same", len, writer.toString().length());
         
         //create parser in data input mode..
-        parser = _createParser(MODE_INPUT_DATA, SAMPLE_DOC_JSON_SPEC);
+        parser = _createParser(MODE_INPUT_DATA, JSON);
         //move the token until the string field
         parser.nextToken();
         parser.nextToken();
         parser.nextToken();
         
         writer = new StringWriter();
-        while(!parser.readText(writer)) {
-            writer.flush();
-            assertTrue("String not empty", writer.toString().length() > 0);
-        }
-        //Need to check this...
-        //assertTrue("String length should be same", writer.toString().length() == SAMPLE_DOC_JSON_SPEC.length());
+        len = parser.readText(writer);
+        assertEquals("Returned length should be same", len, writer.toString().length());
         
     }
 

--- a/src/test/java/com/fasterxml/jackson/core/read/JsonParserTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/read/JsonParserTest.java
@@ -597,6 +597,108 @@ if (type == MODE_INPUT_DATA) {
         assertNull(p.nextToken());
         p.close();
     }
+    
+    public void testReadText() throws Exception {
+        final String JSON = "{\"a\":\"this is a sample text for json parsing using readText() method\",\"b\":true,\"c\":null,\"d\":\"foo\"}";
+        //create parser in reader mode..
+        JsonParser parser = _createParser(MODE_READER, JSON);
+        //move the token until the string field
+        parser.nextToken();
+        parser.nextToken();
+        parser.nextToken();
+        
+        Writer writer = new StringWriter();
+        while(!parser.readText(writer)) {
+            writer.flush();
+            assertTrue("String not empty", writer.toString().length() > 0);
+        }
+        
+        assertTrue("String length should be same", writer.toString().length() == "this is a sample text for json parsing using readText() method".length());
+        
+        //create parser in stream mode..
+        parser = _createParser(MODE_INPUT_STREAM, JSON);
+        //move the token until the string field
+        parser.nextToken();
+        parser.nextToken();
+        parser.nextToken();
+        
+        writer = new StringWriter();
+        while(!parser.readText(writer)) {
+            writer.flush();
+            assertTrue("String not empty", writer.toString().length() > 0);
+        }
+        
+        assertTrue("String length should be same", writer.toString().length() == "this is a sample text for json parsing using readText() method".length());
+        
+        //create parser in data input mode..
+        parser = createParserForDataInput(JSON_FACTORY, new MockDataInput(JSON));
+        //move the token until the string field
+        parser.nextToken();
+        parser.nextToken();
+        parser.nextToken();
+        
+        writer = new StringWriter();
+        while(!parser.readText(writer)) {
+            writer.flush();
+            assertTrue("String not empty", writer.toString().length() > 0);
+        }
+        
+        assertTrue("String length should be same", writer.toString().length() == "this is a sample text for json parsing using readText() method".length());
+    }
+    
+    public void testLongerReadText() throws Exception {
+        StringBuilder builder = new StringBuilder();
+        for(int i= 0; i < 1000; i++) {
+            builder.append("Sample Text"+i);
+        }
+        String longText = builder.toString();
+        final String JSON = "{\"a\":\""+ longText +"\",\"b\":true,\"c\":null,\"d\":\"foo\"}";
+        //create parser in reader mode..
+        JsonParser parser = _createParser(MODE_READER, JSON);
+        //move the token until the string field
+        parser.nextToken();
+        parser.nextToken();
+        parser.nextToken();
+        
+        Writer writer = new StringWriter();
+        while(!parser.readText(writer)) {
+            writer.flush();
+            assertTrue("String not empty", writer.toString().length() > 0);
+        }
+        
+        assertTrue("String length should be same", writer.toString().length() == longText.length());
+        
+        //create parser in stream mode..
+        parser = _createParser(MODE_INPUT_STREAM, JSON);
+        //move the token until the string field
+        parser.nextToken();
+        parser.nextToken();
+        parser.nextToken();
+        
+        writer = new StringWriter();
+        while(!parser.readText(writer)) {
+            writer.flush();
+            assertTrue("String not empty", writer.toString().length() > 0);
+        }
+        
+        assertTrue("String length should be same", writer.toString().length() == longText.length());
+        
+        //create parser in data input mode..
+        parser = _createParser(MODE_INPUT_DATA, SAMPLE_DOC_JSON_SPEC);
+        //move the token until the string field
+        parser.nextToken();
+        parser.nextToken();
+        parser.nextToken();
+        
+        writer = new StringWriter();
+        while(!parser.readText(writer)) {
+            writer.flush();
+            assertTrue("String not empty", writer.toString().length() > 0);
+        }
+        //Need to check this...
+        //assertTrue("String length should be same", writer.toString().length() == SAMPLE_DOC_JSON_SPEC.length());
+        
+    }
 
     /*
     /**********************************************************


### PR DESCRIPTION
I have implemented the readText(writer) which reads the character segments and writes to the given writer object. Let me know if this implementation is fine or we need to further divide the character segments into smaller chunks and pass it to the writer

Note: In the testcase for the longer texts, in datainput parser somehow the writer object length does not match (I have commented that testcase for now). Let me know if some additional implementation is required for datainput.  