### PR TITLE
Added support for parsing 'INF' as positive infinity

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/json/ReaderBasedJsonParser.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/ReaderBasedJsonParser.java
@@ -1870,11 +1870,24 @@ public class ReaderBasedJsonParser // final in 2.3, earlier
             _reportError("Non-standard token 'NaN': enable JsonParser.Feature.ALLOW_NON_NUMERIC_NUMBERS to allow");
             break;
         case 'I':
-            _matchToken("Infinity", 1);
-            if (isEnabled(Feature.ALLOW_NON_NUMERIC_NUMBERS)) {
-                return resetAsNaN("Infinity", Double.POSITIVE_INFINITY);
+            if (_inputPtr >= _inputEnd) {
+                if (!_loadMore()) {
+                    _reportInvalidEOFInValue();
+                }
             }
-            _reportError("Non-standard token 'Infinity': enable JsonParser.Feature.ALLOW_NON_NUMERIC_NUMBERS to allow");
+
+            String match = null;
+            if (_inputBuffer[_inputPtr] == 'n') {
+                _matchToken("Infinity", 1);
+                match = "Infinity";
+            } else {
+                _matchToken("INF", 1);
+                match = "INF";
+            }
+            if (isEnabled(Feature.ALLOW_NON_NUMERIC_NUMBERS)) {
+                return resetAsNaN(match, Double.POSITIVE_INFINITY);
+            }
+            _reportError("Non-standard token '"+match+"': enable JsonParser.Feature.ALLOW_NON_NUMERIC_NUMBERS to allow");
             break;
         case '+': // note: '-' is taken as number
             if (_inputPtr >= _inputEnd) {

--- a/src/main/java/com/fasterxml/jackson/core/json/UTF8DataInputJsonParser.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/UTF8DataInputJsonParser.java
@@ -2025,11 +2025,19 @@ public class UTF8DataInputJsonParser
             _reportError("Non-standard token 'NaN': enable JsonParser.Feature.ALLOW_NON_NUMERIC_NUMBERS to allow");
             break;
         case 'I':
-            _matchToken("Infinity", 1);
-            if (isEnabled(Feature.ALLOW_NON_NUMERIC_NUMBERS)) {
-                return resetAsNaN("Infinity", Double.POSITIVE_INFINITY);
+            String match = null;
+            int nextChar = _inputData.readUnsignedByte();
+            if (nextChar == 'n') {
+                _matchToken("Infinity", 2);
+                match = "Infinity";
+            } else {
+                _matchToken("INF", 2);
+                match = "INF";
             }
-            _reportError("Non-standard token 'Infinity': enable JsonParser.Feature.ALLOW_NON_NUMERIC_NUMBERS to allow");
+            if (isEnabled(Feature.ALLOW_NON_NUMERIC_NUMBERS)) {
+                return resetAsNaN(match, Double.POSITIVE_INFINITY);
+            }
+            _reportError("Non-standard token '"+match+"': enable JsonParser.Feature.ALLOW_NON_NUMERIC_NUMBERS to allow");
             break;
         case '+': // note: '-' is taken as number
             return _handleInvalidNumberStart(_inputData.readUnsignedByte(), false);

--- a/src/main/java/com/fasterxml/jackson/core/json/UTF8StreamJsonParser.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/UTF8StreamJsonParser.java
@@ -2664,11 +2664,24 @@ public class UTF8StreamJsonParser
             _reportError("Non-standard token 'NaN': enable JsonParser.Feature.ALLOW_NON_NUMERIC_NUMBERS to allow");
             break;
         case 'I':
-            _matchToken("Infinity", 1);
-            if (isEnabled(Feature.ALLOW_NON_NUMERIC_NUMBERS)) {
-                return resetAsNaN("Infinity", Double.POSITIVE_INFINITY);
+            if (_inputPtr >= _inputEnd) {
+                if (!_loadMore()) {
+                    _reportInvalidEOFInValue();
+                }
             }
-            _reportError("Non-standard token 'Infinity': enable JsonParser.Feature.ALLOW_NON_NUMERIC_NUMBERS to allow");
+
+            String match = null;
+            if (_inputBuffer[_inputPtr] == 'n') {
+                _matchToken("Infinity", 1);
+                match = "Infinity";
+            } else {
+                _matchToken("INF", 1);
+                match = "INF";
+            }
+            if (isEnabled(Feature.ALLOW_NON_NUMERIC_NUMBERS)) {
+                return resetAsNaN(match, Double.POSITIVE_INFINITY);
+            }
+            _reportError("Non-standard token '"+match+"': enable JsonParser.Feature.ALLOW_NON_NUMERIC_NUMBERS to allow");
             break;
         case '+': // note: '-' is taken as number
             if (_inputPtr >= _inputEnd) {

--- a/src/test/java/com/fasterxml/jackson/core/read/NonStandardParserFeaturesTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/read/NonStandardParserFeaturesTest.java
@@ -468,7 +468,7 @@ public class NonStandardParserFeaturesTest
 
     private void _testAllowInf(int mode) throws Exception
     {
-        final String JSON = "[ -INF, +INF, +Infinity, Infinity, -Infinity ]";
+        final String JSON = "[ -INF, +INF, INF, +Infinity, Infinity, -Infinity ]";
         JsonFactory f = new JsonFactory();
         assertFalse(f.isEnabled(JsonParser.Feature.ALLOW_NON_NUMERIC_NUMBERS));
 
@@ -501,6 +501,12 @@ public class NonStandardParserFeaturesTest
 
         assertToken(JsonToken.VALUE_NUMBER_FLOAT, p.nextToken());
         d = p.getDoubleValue();
+        assertEquals("INF", p.getText());
+        assertTrue(Double.isInfinite(d));
+        assertTrue(d == Double.POSITIVE_INFINITY);
+
+        assertToken(JsonToken.VALUE_NUMBER_FLOAT, p.nextToken());
+        d = p.getDoubleValue();
         assertEquals("+Infinity", p.getText());
         assertTrue(Double.isInfinite(d));
         assertTrue(d == Double.POSITIVE_INFINITY);
@@ -525,6 +531,7 @@ public class NonStandardParserFeaturesTest
         p = createParser(f, mode, JSON);
 
         assertToken(JsonToken.START_ARRAY, p.nextToken());
+        assertToken(JsonToken.VALUE_NUMBER_FLOAT, p.nextToken());
         assertToken(JsonToken.VALUE_NUMBER_FLOAT, p.nextToken());
         assertToken(JsonToken.VALUE_NUMBER_FLOAT, p.nextToken());
         assertToken(JsonToken.VALUE_NUMBER_FLOAT, p.nextToken());


### PR DESCRIPTION
Currently jackson supoorts 'Infinity' and '+Infinity' for positive infinity. However, it only supports '+INF'. If there is no special reason to skip this support, it should be better to be consistent.