### PR TITLE
JsonWriteContext#writeFieldName not updating _currentName correctly

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/json/JsonWriteContext.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/JsonWriteContext.java
@@ -162,11 +162,13 @@ public class JsonWriteContext extends JsonStreamContext
      * @return Index of the field entry (0-based)
      */
     public int writeFieldName(String name) throws JsonProcessingException {
+        if (_type == TYPE_OBJECT) {
+            _currentName = name;
+        }
         if ((_type != TYPE_OBJECT) || _gotName) {
             return STATUS_EXPECT_VALUE;
         }
         _gotName = true;
-        _currentName = name;
         if (_dups != null) { _checkDup(_dups, name); }
         return (_index < 0) ? STATUS_OK_AS_IS : STATUS_OK_AFTER_COMMA;
     }


### PR DESCRIPTION
Currently, for a JSON like this -

`{
"a": {
},
"b": {
"c": "cval"
}
}`

When writeFieldName is called for node 'b', the _currentName is not updated
as the _gotName value is already set to true (because of the earlier processing
done for 'a'). This means that later down the line, when I try to do a
context.getParent().getCurrentName(), I get 'a' back, instead of 'b'.

This PR tentatively fixes that by pulling the setting of the _currentName earlier
before the function exits.