### PR TITLE
Enable Jackson users to strip security-sensitive data from parser errors.

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/JsonProcessingException.java
+++ b/src/main/java/com/fasterxml/jackson/core/JsonProcessingException.java
@@ -54,6 +54,12 @@ public class JsonProcessingException extends java.io.IOException
     public JsonLocation getLocation() { return _location; }
     
     /**
+     * Method that allows to remove context information from this exception's message.
+     * Useful when you are parsing security-sensitive data and don't want original data excerpts to be present in Jackson parser error messages.
+     */
+    public void clearLocation() { _location = null; }
+
+    /**
      * Method that allows accessing the original "message" argument,
      * without additional decorations (like location information)
      * that overridden {@link #getMessage} adds.


### PR DESCRIPTION
By default Jackson parser exception messages will contain excerpts from original data to provide some context about the location of the error. That is understandable but there are use cases when such excerpts contain security-sensitive data. Still the rest of Jackson exception information is very useful if only we could disable/remove the data contained in the `_location` field.
