### PR TITLE
Migrate away from a magic slash to a constant.

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/JsonPointer.java
+++ b/src/main/java/com/fasterxml/jackson/core/JsonPointer.java
@@ -20,6 +20,11 @@ import com.fasterxml.jackson.core.io.NumberInput;
 public class JsonPointer
 {
     /**
+     * Character used to separate segments.
+     */
+    public final static char SEPARATOR = '/';
+    
+    /**
      * Marker instance used to represent segment that matches current
      * node or position (that is, returns true for
      * {@link #matches()}).


### PR DESCRIPTION
My code currently resembles:

    return '/' + reference.replace( getConfigSeparator(), '/' );

I'd rather that it resemble:

    import static JsonPointer.SEPARATOR;
    return SEPARATOR + reference.replace( getConfigSeparator(), SEPARATOR );

That way if JsonPointer ever changed its segment separator character (or added a configuration option for changing it), then my code won't have to change. Also, making a single location for the slash character follows the DRY principle while avoiding a magic value littered throughout the code.