### PR TITLE
Trim tokens in error messages to 256 byte to prevent attacks

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/json/ReaderBasedJsonParser.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/ReaderBasedJsonParser.java
@@ -2819,7 +2819,8 @@ public class ReaderBasedJsonParser // final in 2.3, earlier
          * regular Java identifier character rules. It's just a heuristic,
          * nothing fancy here.
          */
-        while (true) {
+        final int maxTokenLength = 256;
+        while (sb.length() < maxTokenLength) {
             if (_inputPtr >= _inputEnd) {
                 if (!_loadMore()) {
                     break;
@@ -2831,6 +2832,9 @@ public class ReaderBasedJsonParser // final in 2.3, earlier
             }
             ++_inputPtr;
             sb.append(c);
+        }
+        if (sb.length() == maxTokenLength) {
+            sb.append("...");
         }
         _reportError("Unrecognized token '"+sb.toString()+"': was expecting "+msg);
     }

--- a/src/main/java/com/fasterxml/jackson/core/json/UTF8StreamJsonParser.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/UTF8StreamJsonParser.java
@@ -3510,7 +3510,8 @@ public class UTF8StreamJsonParser
           * regular Java identifier character rules. It's just a heuristic,
           * nothing fancy here (nor fast).
           */
-         while (true) {
+         final int maxTokenLength = 256;
+         while (sb.length() < maxTokenLength) {
              if (_inputPtr >= _inputEnd && !_loadMore()) {
                  break;
              }
@@ -3520,6 +3521,9 @@ public class UTF8StreamJsonParser
                  break;
              }
              sb.append(c);
+         }
+         if (sb.length() == maxTokenLength) {
+                sb.append("...");
          }
          _reportError("Unrecognized token '"+sb.toString()+"': was expecting "+msg);
      }

--- a/src/test/java/com/fasterxml/jackson/core/json/TestMaxErrorSize.java
+++ b/src/test/java/com/fasterxml/jackson/core/json/TestMaxErrorSize.java
@@ -1,0 +1,88 @@
+package com.fasterxml.jackson.core.json;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonParser;
+
+/**
+ * Test size of parser error messages
+ */
+public class TestMaxErrorSize
+    extends com.fasterxml.jackson.core.BaseTest
+{
+    public void testLongErrorMessage()
+        throws Exception
+    {
+        final String DOC = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        		+ "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        		+ "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        		+ "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+    	assertTrue(DOC.length() > 256);
+        JsonParser jp = createParserUsingReader(DOC);
+        try {
+            jp.nextToken();
+            fail("Expected an exception for unrecognized token");
+        } catch (JsonParseException jpe) {
+        	String msg = jpe.getMessage();
+        	final String expectedPrefix = "Unrecognized token '";
+        	final String expectedSuffix = "...': was expecting ('true', 'false' or 'null')";
+        	assertTrue(msg.startsWith(expectedPrefix));
+        	assertTrue(msg.contains(expectedSuffix));
+        	msg = msg.substring(expectedPrefix.length(), msg.indexOf(expectedSuffix));
+        	assertEquals(256, msg.length());
+        }
+        jp.close();
+        
+        jp = createParser(MODE_INPUT_STREAM, DOC);
+        try {
+            jp.nextToken();
+            fail("Expected an exception for unrecognized token");
+        } catch (JsonParseException jpe) {
+        	String msg = jpe.getMessage();
+        	final String expectedPrefix = "Unrecognized token '";
+        	final String expectedSuffix = "...': was expecting ('true', 'false' or 'null')";
+        	assertTrue(msg.startsWith(expectedPrefix));
+        	assertTrue(msg.contains(expectedSuffix));
+        	msg = msg.substring(expectedPrefix.length(), msg.indexOf(expectedSuffix));
+        	assertEquals(256, msg.length());
+        }
+        jp.close();
+    }
+    
+    public void testShortErrorMessage()
+            throws Exception
+        {
+            final String DOC = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+            		+ "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+        	assertTrue(DOC.length() < 256);
+            JsonParser jp = createParserUsingReader(DOC);
+            try {
+                jp.nextToken();
+                fail("Expected an exception for unrecognized token");
+            } catch (JsonParseException jpe) {
+            	String msg = jpe.getMessage();
+            	final String expectedPrefix = "Unrecognized token '";
+            	final String expectedSuffix = "': was expecting ('true', 'false' or 'null')";
+            	assertTrue(msg.startsWith(expectedPrefix));
+            	assertTrue(msg.contains(expectedSuffix));
+            	msg = msg.substring(expectedPrefix.length(), msg.indexOf(expectedSuffix));
+            	assertEquals(DOC.length(), msg.length());
+            }
+            jp.close();
+            
+            jp = createParser(MODE_INPUT_STREAM, DOC);
+            try {
+                jp.nextToken();
+                fail("Expected an exception for unrecognized token");
+            } catch (JsonParseException jpe) {
+            	String msg = jpe.getMessage();
+            	final String expectedPrefix = "Unrecognized token '";
+            	final String expectedSuffix = "': was expecting ('true', 'false' or 'null')";
+            	assertTrue(msg.startsWith(expectedPrefix));
+            	assertTrue(msg.contains(expectedSuffix));
+            	msg = msg.substring(expectedPrefix.length(), msg.indexOf(expectedSuffix));
+            	assertEquals(DOC.length(), msg.length());
+            }
+            jp.close();
+        }
+}
+


### PR DESCRIPTION
See https://issues.jboss.org/browse/JBEAP-6316 (description and reproducer)
The fix here is really minimal, it might make sense to have something configurable, etc.
