### PR TITLE
handle byte[] and char[] sourceRef's specially in JsonLocation.toString()

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/JsonLocation.java
+++ b/src/main/java/com/fasterxml/jackson/core/JsonLocation.java
@@ -96,6 +96,10 @@ public class JsonLocation
         sb.append("[Source: ");
         if (_sourceRef == null) {
             sb.append("UNKNOWN");
+        } else if (_sourceRef instanceof byte[]) {
+            sb.append(new String((byte[]) _sourceRef));
+        } else if (_sourceRef instanceof char[]) {
+            sb.append((char[]) _sourceRef);
         } else {
             sb.append(_sourceRef.toString());
         }


### PR DESCRIPTION
Currently, when attempting to parse a syntactically incorrect byte array as JSON using `ObjectMapper`.`readValue`, the `JsonParseException` that is thrown from `ParserBase`.`_reportMismatchedEndMarker` looks as follows:

> Invalid Json: Unexpected close marker &#x27;}&#x27;: expected &#x27;]&#x27; (for ROOT starting at [Source: [B@4928787c; line: 1, column: 0])
 at [Source: [B@4928787c; line: 1, column: 2]

Since the "Source" in question is a byte array, which in this context can safely be assumed to be a UTF-8 stream, I would much prefer to have the original source that caused this exception included in my Exception, instead of a non-descript default "`[B@deadbeef`" hash. This eases debugging, especially if the source data cannot be deduced otherwise.

I believe the intent of the original code is like that, considering the cover-all `.toString()` call in the final `} else {` block.