### PR TITLE
Alternate approach for issue #17 

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/JsonGenerator.java
+++ b/src/main/java/com/fasterxml/jackson/core/JsonGenerator.java
@@ -4,7 +4,9 @@
  */
 package com.fasterxml.jackson.core;
 
-import static com.fasterxml.jackson.core.JsonTokenId.*;
+import com.fasterxml.jackson.core.JsonParser.NumberType;
+import com.fasterxml.jackson.core.io.CharacterEscapes;
+import com.fasterxml.jackson.core.util.VersionUtil;
 
 import java.io.*;
 import java.math.BigDecimal;
@@ -13,9 +15,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
-import com.fasterxml.jackson.core.JsonParser.NumberType;
-import com.fasterxml.jackson.core.io.CharacterEscapes;
-import com.fasterxml.jackson.core.util.VersionUtil;
+import static com.fasterxml.jackson.core.JsonTokenId.*;
 
 /**
  * Base class that defines public API for writing JSON content.
@@ -931,6 +931,18 @@ public abstract class JsonGenerator
      * escaped as required by JSON specification.
      */
     public abstract void writeString(String text) throws IOException;
+
+    /**
+     * Method for outputting a String value. Depending on context
+     * this means either array element, (object) field value or
+     * a stand alone String; but in all cases, String will be
+     * surrounded in double quotes, and contents will be properly
+     * escaped as required by JSON specification.
+     * If the reader is null, then write a null.
+     * If len is < 0, then write all contents of the reader.
+     * Otherwise, write only len characters.
+     */
+    public abstract void writeString(Reader reader, int len) throws IOException;
 
     /**
      * Method for outputting a String value. Depending on context

--- a/src/main/java/com/fasterxml/jackson/core/base/GeneratorBase.java
+++ b/src/main/java/com/fasterxml/jackson/core/base/GeneratorBase.java
@@ -1,13 +1,15 @@
 package com.fasterxml.jackson.core.base;
 
-import java.io.*;
-import java.math.BigDecimal;
-
 import com.fasterxml.jackson.core.*;
 import com.fasterxml.jackson.core.json.DupDetector;
 import com.fasterxml.jackson.core.json.JsonWriteContext;
 import com.fasterxml.jackson.core.json.PackageVersion;
 import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Reader;
+import java.math.BigDecimal;
 
 /**
  * This base class implements part of API that a JSON generator exposes
@@ -337,6 +339,12 @@ public abstract class GeneratorBase extends JsonGenerator
         // Let's implement this as "unsupported" to make it easier to add new parser impls
         _reportUnsupportedOperation();
         return 0;
+    }
+
+    @Override
+    public void writeString(Reader reader, int len) throws IOException {
+        // Let's implement this as "unsupported" to make it easier to add new parser impls
+        _reportUnsupportedOperation();
     }
 
     /*

--- a/src/main/java/com/fasterxml/jackson/core/json/WriterBasedJsonGenerator.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/WriterBasedJsonGenerator.java
@@ -105,7 +105,7 @@ public class WriterBasedJsonGenerator
         _writer = w;
         _outputBuffer = ctxt.allocConcatBuffer();
         _outputEnd = _outputBuffer.length;
-        _charBuffer = ctxt.allocConcatBuffer();
+        _charBuffer = new char[_outputBuffer.length];
         _charBufferLength = _charBuffer.length;
     }
     
@@ -954,11 +954,7 @@ public class WriterBasedJsonGenerator
             _outputBuffer = null;
             _ioContext.releaseConcatBuffer(buf);
         }
-        char[] cbuf = _charBuffer;
-        if (cbuf != null) {
-            _charBuffer = null;
-            _ioContext.releaseConcatBuffer(cbuf);
-        }
+        _charBuffer = null;
     }
 
     /*

--- a/src/main/java/com/fasterxml/jackson/core/util/JsonGeneratorDelegate.java
+++ b/src/main/java/com/fasterxml/jackson/core/util/JsonGeneratorDelegate.java
@@ -1,12 +1,13 @@
 package com.fasterxml.jackson.core.util;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.math.BigDecimal;
-import java.math.BigInteger;
-
 import com.fasterxml.jackson.core.*;
 import com.fasterxml.jackson.core.io.CharacterEscapes;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Reader;
+import java.math.BigDecimal;
+import java.math.BigInteger;
 
 public class JsonGeneratorDelegate extends JsonGenerator
 {
@@ -245,6 +246,11 @@ public class JsonGeneratorDelegate extends JsonGenerator
 
     @Override
     public void writeString(String text) throws IOException { delegate.writeString(text); }
+
+    @Override
+    public void writeString(Reader reader, int len) throws IOException {
+        delegate.writeString(reader, len);
+    }
 
     @Override
     public void writeString(char[] text, int offset, int len) throws IOException { delegate.writeString(text, offset, len); }

--- a/src/test/java/com/fasterxml/jackson/core/json/GeneratorFailFromReaderTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/json/GeneratorFailFromReaderTest.java
@@ -1,0 +1,114 @@
+package com.fasterxml.jackson.core.json;
+
+import com.fasterxml.jackson.core.JsonEncoding;
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStreamWriter;
+import java.io.StringReader;
+
+public class GeneratorFailFromReaderTest
+    extends com.fasterxml.jackson.core.BaseTest
+{
+    private final JsonFactory F = new JsonFactory();
+
+    // [core#177]
+    // Also: should not try writing JSON String if field name expected
+    // (in future maybe take one as alias... but not yet)
+    public void testFailOnWritingStringNotFieldNameBytes() throws Exception {
+        _testFailOnWritingStringNotFieldName(F, false);
+    }
+
+    // [core#177]
+    public void testFailOnWritingStringNotFieldNameChars() throws Exception {
+        _testFailOnWritingStringNotFieldName(F, true);        
+    }
+
+    public void testFailOnWritingStringFromReaderWithTooFewCharacters() throws Exception {
+        _testFailOnWritingStringFromReaderWithTooFewCharacters(F, true);
+        _testFailOnWritingStringFromReaderWithTooFewCharacters(F, false);
+    }
+
+    public void testFailOnWritingStringFromNullReader() throws Exception {
+        _testFailOnWritingStringFromNullReader(F, true);
+        _testFailOnWritingStringFromNullReader(F, false);
+    }
+    
+    /*
+    /**********************************************************
+    /* Internal methods
+    /**********************************************************
+     */
+
+
+    private void _testFailOnWritingStringNotFieldName(JsonFactory f, boolean useReader) throws Exception
+    {
+        JsonGenerator gen;
+        ByteArrayOutputStream bout = new ByteArrayOutputStream();
+        if (useReader) {
+            gen = f.createGenerator(new OutputStreamWriter(bout, "UTF-8"));
+        } else {
+            gen = f.createGenerator(bout, JsonEncoding.UTF8);
+        }
+        gen.writeStartObject();
+        
+        try {
+            StringReader reader = new StringReader("a");
+            gen.writeString(reader, -1);
+            gen.flush();
+            String json = bout.toString("UTF-8");
+            fail("Should not have let "+gen.getClass().getName()+".writeString() be used in place of 'writeFieldName()': output = "+json);
+        } catch (JsonProcessingException e) {
+            verifyException(e, "can not write a String");
+        }
+        gen.close();
+    }
+
+    private void _testFailOnWritingStringFromReaderWithTooFewCharacters(JsonFactory f, boolean useReader) throws Exception{
+        JsonGenerator gen;
+        ByteArrayOutputStream bout = new ByteArrayOutputStream();
+        if (useReader) {
+            gen = f.createGenerator(new OutputStreamWriter(bout, "UTF-8"));
+        } else {
+            gen = f.createGenerator(bout, JsonEncoding.UTF8);
+        }
+        gen.writeStartObject();
+
+        try {
+            String testStr = "aaaaaaaaa";
+            StringReader reader = new StringReader(testStr);
+            gen.writeFieldName("a");
+            gen.writeString(reader, testStr.length() + 1);
+            gen.flush();
+            String json = bout.toString("UTF-8");
+            fail("Should not have let "+gen.getClass().getName()+".writeString() ': output = "+json);
+        } catch (JsonProcessingException e) {
+            verifyException(e, "Didn't read enough from reader");
+        }
+        gen.close();
+    }
+
+    private void _testFailOnWritingStringFromNullReader(JsonFactory f, boolean useReader) throws Exception{
+        JsonGenerator gen;
+        ByteArrayOutputStream bout = new ByteArrayOutputStream();
+        if (useReader) {
+            gen = f.createGenerator(new OutputStreamWriter(bout, "UTF-8"));
+        } else {
+            gen = f.createGenerator(bout, JsonEncoding.UTF8);
+        }
+        gen.writeStartObject();
+
+        try {
+            gen.writeFieldName("a");
+            gen.writeString(null, -1);
+            gen.flush();
+            String json = bout.toString("UTF-8");
+            fail("Should not have let "+gen.getClass().getName()+".writeString() ': output = "+json);
+        } catch (JsonProcessingException e) {
+            verifyException(e, "null reader");
+        }
+        gen.close();
+    }
+}

--- a/src/test/java/com/fasterxml/jackson/core/json/StringGenerationFromReaderTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/json/StringGenerationFromReaderTest.java
@@ -11,7 +11,7 @@ import java.util.Random;
  * Set of basic unit tests for verifying that the string
  * generation, including character escaping, works as expected.
  */
-public class StringGenerationFromWriterTest
+public class StringGenerationFromReaderTest
     extends BaseTest
 {
     final static String[] SAMPLES = new String[] {

--- a/src/test/java/com/fasterxml/jackson/core/json/StringGenerationFromWriterTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/json/StringGenerationFromWriterTest.java
@@ -1,0 +1,277 @@
+package com.fasterxml.jackson.core.json;
+
+import com.fasterxml.jackson.core.*;
+
+import java.io.ByteArrayOutputStream;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.util.Random;
+
+/**
+ * Set of basic unit tests for verifying that the string
+ * generation, including character escaping, works as expected.
+ */
+public class StringGenerationFromWriterTest
+    extends BaseTest
+{
+    final static String[] SAMPLES = new String[] {
+        "\"test\"",
+        "\n", "\\n", "\r\n", "a\\b", "tab:\nok?",
+        "a\tb\tc\n\fdef\t \tg\"\"\"h\"\\ijklmn\b",
+        "\"\"\"", "\\r)'\"",
+        "Longer text & other stuff:\twith some\r\n\r\n random linefeeds etc added in to cause some \"special\" handling \\\\ to occur...\n"
+    };
+
+    private final JsonFactory FACTORY = new JsonFactory();
+    
+    public void testBasicEscaping() throws Exception
+    {
+        doTestBasicEscaping();
+    }
+
+    // for [core#194]
+    public void testMediumStringsBytes() throws Exception
+    {
+        for (int mode : ALL_BINARY_MODES) {
+            for (int size : new int[] { 1100, 2300, 3800, 7500, 19000 }) {
+                _testMediumStrings(mode, size);
+            }
+        }
+    }
+
+    // for [core#194]
+    public void testMediumStringsChars() throws Exception
+    {
+        for (int mode : ALL_TEXT_MODES) {
+            for (int size : new int[] { 1100, 2300, 3800, 7500, 19000 }) {
+                _testMediumStrings(mode, size);
+            }
+        }
+    }
+
+    public void testLongerRandomSingleChunk() throws Exception
+    {
+        /* Let's first generate 100k of pseudo-random characters, favoring
+         * 7-bit ascii range
+         */
+        for (int mode : ALL_TEXT_MODES) {
+            for (int round = 0; round < 80; ++round) {
+                String content = generateRandom(75000+round);
+                _testLongerRandom(mode, content);
+            }
+        }
+    }
+
+    public void testLongerRandomMultiChunk() throws Exception
+    {
+        /* Let's first generate 100k of pseudo-random characters, favoring
+         * 7-bit ascii range
+         */
+        for (int mode : ALL_TEXT_MODES) {
+            for (int round = 0; round < 70; ++round) {
+                String content = generateRandom(73000+round);
+                _testLongerRandomMulti(mode, content, round);
+            }
+        }
+    }
+
+    /*
+    /**********************************************************
+    /* Internal methods
+    /**********************************************************
+     */
+
+    private String _generareMediumText(int minLen)
+    {
+        StringBuilder sb = new StringBuilder(minLen + 1000);
+        Random rnd = new Random(minLen);
+        do {
+            switch (rnd.nextInt() % 4) {
+            case 0:
+                sb.append(" foo");
+                break;
+            case 1:
+                sb.append(" bar");
+                break;
+            case 2:
+                sb.append(String.valueOf(sb.length()));
+                break;
+            default:
+                sb.append(" \"stuff\"");
+                break;
+            }
+        } while (sb.length() < minLen);
+        return sb.toString();
+    }
+    
+    private String generateRandom(int len)
+    {
+        StringBuilder sb = new StringBuilder(len+1000); // pad for surrogates
+        Random r = new Random(len);
+        for (int i = 0; i < len; ++i) {
+            if (r.nextBoolean()) { // non-ascii
+                int value = r.nextInt() & 0xFFFF;
+                // Otherwise easy, except that need to ensure that
+                // surrogates are properly paired: and, also
+                // their values do not exceed 0x10FFFF
+                if (value >= 0xD800 && value <= 0xDFFF) {
+                    // Let's discard first value, then, and produce valid pair
+                    int fullValue = (r.nextInt() & 0xFFFFF);
+                    sb.append((char) (0xD800 + (fullValue >> 10)));
+                    value = 0xDC00 + (fullValue & 0x3FF);
+                }
+                sb.append((char) value);
+            } else { // ascii
+                sb.append((char) (r.nextInt() & 0x7F));
+            }
+        }
+        return sb.toString();
+    }
+
+    private void _testMediumStrings(int readMode, int length) throws Exception
+    {
+        String text = _generareMediumText(length);
+        StringWriter sw = new StringWriter();
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+
+        JsonGenerator gen = (readMode != MODE_READER) ? FACTORY.createGenerator(bytes)
+                : FACTORY.createGenerator(sw);
+        gen.writeStartArray();
+
+        StringReader reader = new StringReader(text);
+        gen.writeString(reader, -1);
+        gen.writeEndArray();
+        gen.close();
+
+        JsonParser p;
+        if (readMode == MODE_READER) {
+            p = FACTORY.createParser(sw.toString());
+        } else {
+            p = createParser(FACTORY, readMode, bytes.toByteArray());
+        }
+        assertToken(JsonToken.START_ARRAY, p.nextToken());
+        assertToken(JsonToken.VALUE_STRING, p.nextToken());
+        assertEquals(text, p.getText());
+        assertToken(JsonToken.END_ARRAY, p.nextToken());
+        p.close();
+    }
+    
+    private void doTestBasicEscaping() throws Exception
+    {
+        for (int i = 0; i < SAMPLES.length; ++i) {
+            String VALUE = SAMPLES[i];
+            StringWriter sw = new StringWriter();
+            JsonGenerator gen = FACTORY.createGenerator(sw);
+            gen.writeStartArray();
+            StringReader reader = new StringReader(VALUE);
+            gen.writeString(reader, -1);
+            gen.writeEndArray();
+            gen.close();
+            String docStr = sw.toString();
+            JsonParser p = createParserUsingReader(docStr);
+            assertEquals(JsonToken.START_ARRAY, p.nextToken());
+            JsonToken t = p.nextToken();
+            assertEquals(JsonToken.VALUE_STRING, t);
+            assertEquals(VALUE, p.getText());
+            assertEquals(JsonToken.END_ARRAY, p.nextToken());
+            assertEquals(null, p.nextToken());
+            p.close();
+        }
+    }
+
+    private void _testLongerRandom(int readMode, String text)
+        throws Exception
+    {
+        ByteArrayOutputStream bow = new ByteArrayOutputStream(text.length());
+        JsonGenerator gen = FACTORY.createGenerator(bow, JsonEncoding.UTF8);
+        gen.writeStartArray();
+        StringReader reader = new StringReader(text);
+        gen.writeString(reader, -1);
+        gen.writeEndArray();
+        gen.close();
+        byte[] docData = bow.toByteArray();
+        JsonParser p = createParser(FACTORY, readMode, docData);
+        assertEquals(JsonToken.START_ARRAY, p.nextToken());
+        JsonToken t = p.nextToken();
+        assertEquals(JsonToken.VALUE_STRING, t);
+        String act = p.getText();
+        if (!text.equals(act)) {
+            if (text.length() != act.length()) {
+                fail("Expected string length "+text.length()+", actual "+act.length());
+            }
+            int i = 0;
+            for (int len = text.length(); i < len; ++i) {
+                if (text.charAt(i) != act.charAt(i)) {
+                    break;
+                }
+            }
+            fail("Strings differ at position #"+i+" (len "+text.length()+"): expected char 0x"+Integer.toHexString(text.charAt(i))+", actual 0x"+Integer.toHexString(act.charAt(i)));
+        }
+        assertEquals(JsonToken.END_ARRAY, p.nextToken());
+        p.close();
+    }
+
+    private void _testLongerRandomMulti(int readMode, String text, int round)
+        throws Exception
+    {
+        ByteArrayOutputStream bow = new ByteArrayOutputStream(text.length());
+        JsonGenerator gen = FACTORY.createGenerator(bow, JsonEncoding.UTF8);
+        gen.writeStartArray();
+        StringReader reader = new StringReader(text);
+        gen.writeString(reader, -1);
+        gen.writeEndArray();
+        gen.close();
+        
+        gen = FACTORY.createGenerator(bow, JsonEncoding.UTF8);
+        gen.writeStartArray();
+        gen.writeStartArray();
+
+        Random rnd = new Random(text.length());
+        int offset = 0;
+
+        while (offset < text.length()) {
+            int shift = 1 + ((rnd.nextInt() & 0xFFFFF) % 12); // 1 - 12
+            int len = (1 << shift) + shift; // up to 4k
+            if ((offset + len) >= text.length()) {
+                len = text.length() - offset;
+            } else {
+            	// Need to avoid splitting surrogates though
+            	char c = text.charAt(offset+len-1);
+            	if (c >= 0xD800 && c < 0xDC00) {
+            		++len;
+            	}
+            }
+            reader = new StringReader(text.substring(offset, offset+len));
+            gen.writeString(reader, -1);
+            offset += len;
+        }
+
+        gen.writeEndArray();
+        gen.close();
+        byte[] docData = bow.toByteArray();
+        JsonParser p = createParser(FACTORY, readMode, docData);
+        assertEquals(JsonToken.START_ARRAY, p.nextToken());
+
+        offset = 0;
+        while (p.nextToken() == JsonToken.VALUE_STRING) {
+            // Let's verify, piece by piece
+            String act = p.getText();
+            String exp = text.substring(offset, offset+act.length());
+            if (act.length() != exp.length()) {
+                fail("String segment ["+offset+" - "+(offset+act.length())+"[ differs; exp length "+exp+", actual "+act);                
+            }
+            if (!act.equals(exp)) {
+                int i = 0;
+                while (act.charAt(i) == exp.charAt(i)) {
+                    ++i;
+                }
+                fail("String segment ["+offset+" - "+(offset+act.length())+"[ different at offset #"+i
+                        +"; exp char 0x"+Integer.toHexString(exp.charAt(i))
+                        +", actual 0x"+Integer.toHexString(act.charAt(i)));
+            }
+            offset += act.length();
+        }
+        assertEquals(JsonToken.END_ARRAY, p.currentToken());
+        p.close();
+    }
+}


### PR DESCRIPTION
I've created a possible approach for addressing Issue #17 . 

First, I added the abstract method declaration in JsonGenerator. Next, I added implementations of this method in two of the JsonGenerator implementations. Iin one implementation of the JsonGenerator (WriterBasedJsonGenerator), I created a separate buffer field in the class (using new char[] to avoid calling the same IOContext.allocX method twice which apparently results in an exception). In another implementation of the JsonGenerator (UTF8JsonGenerator), I tried to reuse the (apparently pre-existing) _charBuffer.  I am not sure if these are the best approaches for getting a char[] for use as a temporary buffer for reading from a Reader. Then, I added an implementation in the JsonGeneratorDelegate that  calls the appropriate function of the delegate instance. 

As for a unit test, I copied one of the pre-existing unit test files (StringGenerationTest) and created a new version (StringGenerationReaderTest to avoid deleting the original tests) In StringGenerationReaderTest, the boolean parameters to the methods are removed (as it only tests using a Reader). Also, each function calls 
```
StringReader reader = new StringReader(text); gen.writeString(reader, -1)
```
where it would previously call 
```
gen.writeString(text); 
```
where text is the name of the String variable with the text to write. 

Let me know if there is anything I can do to further test and/or improve this approach. 