### PR TITLE
Use correct length variable

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/json/UTF8JsonGenerator.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/UTF8JsonGenerator.java
@@ -632,7 +632,7 @@ public class UTF8JsonGenerator
             }
             // If this is NOT the last segment and if the last character looks like
             // split surrogate second half, drop it
-            if (len > 0) {
+            if (len2 > 0) {
                 char ch = buf[len2-1];
                 if ((ch >= SURR1_FIRST) && (ch <= SURR1_LAST)) {
                     --len2;


### PR DESCRIPTION
This is probably a typo because previously
the condition would always evaluate to true.

It's unlikely to have caused any issues as it
would only manifest in the unlikely case
when `_charBuffer` has zero length.

Issue found by [lgtm.com](https://lgtm.com/projects/g/FasterXML/jackson-core/snapshot/dist-1118940165-1489497197924/files/src/main/java/com/fasterxml/jackson/core/json/UTF8JsonGenerator.java#L635)