### PR TITLE
Fix javadocs for getValueAsLong/Double

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/JsonParser.java
+++ b/src/main/java/com/fasterxml/jackson/core/JsonParser.java
@@ -1490,9 +1490,9 @@ public abstract class JsonParser
      * and 1 (true), and Strings are parsed using default Java language integer
      * parsing rules.
      *<p>
-     * If representation can not be converted to an int (including structured type
+     * If representation can not be converted to a long (including structured type
      * markers like start/end Object/Array)
-     * default value of <b>0</b> will be returned; no exceptions are thrown.
+     * default value of <b>0L</b> will be returned; no exceptions are thrown.
      */
     public long getValueAsLong() throws IOException {
         return getValueAsLong(0);
@@ -1505,7 +1505,7 @@ public abstract class JsonParser
      * and 1 (true), and Strings are parsed using default Java language integer
      * parsing rules.
      *<p>
-     * If representation can not be converted to an int (including structured type
+     * If representation can not be converted to a long (including structured type
      * markers like start/end Object/Array)
      * specified <b>def</b> will be returned; no exceptions are thrown.
      */
@@ -1517,10 +1517,10 @@ public abstract class JsonParser
      * Method that will try to convert value of current token to a Java
      * <b>double</b>.
      * Numbers are coerced using default Java rules; booleans convert to 0.0 (false)
-     * and 1.0 (true), and Strings are parsed using default Java language integer
-     * parsing rules.
+     * and 1.0 (true), and Strings are parsed using default Java language floating
+     * point parsing rules.
      *<p>
-     * If representation can not be converted to an int (including structured types
+     * If representation can not be converted to a double (including structured types
      * like Objects and Arrays),
      * default value of <b>0.0</b> will be returned; no exceptions are thrown.
      */
@@ -1532,10 +1532,10 @@ public abstract class JsonParser
      * Method that will try to convert value of current token to a
      * Java <b>double</b>.
      * Numbers are coerced using default Java rules; booleans convert to 0.0 (false)
-     * and 1.0 (true), and Strings are parsed using default Java language integer
-     * parsing rules.
+     * and 1.0 (true), and Strings are parsed using default Java language floating
+     * point parsing rules.
      *<p>
-     * If representation can not be converted to an int (including structured types
+     * If representation can not be converted to a double (including structured types
      * like Objects and Arrays),
      * specified <b>def</b> will be returned; no exceptions are thrown.
      */


### PR DESCRIPTION
Apparently simple copy/paste issue, identical to getValueAsInt but shouldn't be.