### PR TITLE
#208 FilteringParserDelegate match count support

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/filter/FilteringParserDelegate.java
+++ b/src/main/java/com/fasterxml/jackson/core/filter/FilteringParserDelegate.java
@@ -414,7 +414,7 @@ public class FilteringParserDelegate extends JsonParserDelegate
                 }
                 _itemFilter = f;
                 if (f == TokenFilter.INCLUDE_ALL) {
-                    if (_includePath) {
+                    if (_verifyAllowedMatches() && _includePath) {
                         return (_currToken = t);
                     }
                 }
@@ -437,7 +437,9 @@ public class FilteringParserDelegate extends JsonParserDelegate
                 f = _headContext.checkValue(f);
                 if ((f == TokenFilter.INCLUDE_ALL)
                         || ((f != null) && f.includeValue(delegate))) {
-                    return (_currToken = t);
+                    if (_verifyAllowedMatches()) {
+                        return (_currToken = t);
+                    }
                 }
             }
             // Otherwise not included (leaves must be explicitly included)
@@ -572,7 +574,7 @@ public class FilteringParserDelegate extends JsonParserDelegate
                     }
                     _itemFilter = f;
                     if (f == TokenFilter.INCLUDE_ALL) {
-                        if (_includePath) {
+                        if (_verifyAllowedMatches() && _includePath) {
                             return (_currToken = t);
                         }
 //                        if (_includeImmediateParent) { ...
@@ -597,7 +599,9 @@ public class FilteringParserDelegate extends JsonParserDelegate
                     f = _headContext.checkValue(f);
                     if ((f == TokenFilter.INCLUDE_ALL)
                             || ((f != null) && f.includeValue(delegate))) {
-                        return (_currToken = t);
+                        if (_verifyAllowedMatches()) {
+                            return (_currToken = t);
+                        }
                     }
                 }
                 // Otherwise not included (leaves must be explicitly included)
@@ -714,7 +718,7 @@ public class FilteringParserDelegate extends JsonParserDelegate
                         continue main_loop;
                     }
                     _itemFilter = f;
-                    if (f == TokenFilter.INCLUDE_ALL) {
+                    if (f == TokenFilter.INCLUDE_ALL && _verifyAllowedMatches()) {
                         return _nextBuffered(buffRoot);
                     }
                 }
@@ -729,7 +733,9 @@ public class FilteringParserDelegate extends JsonParserDelegate
                     f = _headContext.checkValue(f);
                     if ((f == TokenFilter.INCLUDE_ALL)
                             || ((f != null) && f.includeValue(delegate))) {
-                        return _nextBuffered(buffRoot);
+                        if (_verifyAllowedMatches()) {
+                            return _nextBuffered(buffRoot);
+                        }
                     }
                 }
                 // Otherwise not included (leaves must be explicitly included)
@@ -767,7 +773,15 @@ public class FilteringParserDelegate extends JsonParserDelegate
             }
         }
     }
-    
+
+    private final boolean _verifyAllowedMatches() throws IOException {
+        if (_matchCount == 0 || _allowMultipleMatches) {
+            ++_matchCount;
+            return true;
+        }
+        return false;
+    }
+
     @Override
     public JsonToken nextValue() throws IOException {
         // Re-implemented same as ParserMinimalBase:

--- a/src/test/java/com/fasterxml/jackson/core/filter/BasicGeneratorFilteringTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/filter/BasicGeneratorFilteringTest.java
@@ -190,6 +190,7 @@ public class BasicGeneratorFilteringTest extends BaseTest
         gen.close();
 
         assertEquals(aposToQuotes("{'ob':{'value':['x']}}"), w.toString());
+        assertEquals(1, gen.getMatchCount());
     }
 
     public void testSingleMatchFilteringWithPathRawBinary() throws Exception
@@ -240,47 +241,51 @@ public class BasicGeneratorFilteringTest extends BaseTest
         gen.close();
 
         assertEquals(aposToQuotes("{'array':['AQ==',1,2,3,4 ,5.0 /*x*/,6.25,7.5]}"), w.toString());
+        assertEquals(1, gen.getMatchCount());
     }
     
     public void testMultipleMatchFilteringWithPath1() throws Exception
     {
         StringWriter w = new StringWriter();
-        JsonGenerator gen = new FilteringGeneratorDelegate(JSON_F.createGenerator(w),
+        FilteringGeneratorDelegate gen = new FilteringGeneratorDelegate(JSON_F.createGenerator(w),
                 new NameMatchFilter("value0", "value2"),
                 true, /* includePath */ true /* multipleMatches */ );
         final String JSON = "{'a':123,'array':[1,2],'ob':{'value0':2,'value':3,'value2':4},'b':true}";
         writeJsonDoc(JSON_F, JSON, gen);
         assertEquals(aposToQuotes("{'ob':{'value0':2,'value2':4}}"), w.toString());
+        assertEquals(2, gen.getMatchCount());
     }
 
     public void testMultipleMatchFilteringWithPath2() throws Exception
     {
         StringWriter w = new StringWriter();
-        
-        JsonGenerator gen = new FilteringGeneratorDelegate(JSON_F.createGenerator(w),
+
+        FilteringGeneratorDelegate gen = new FilteringGeneratorDelegate(JSON_F.createGenerator(w),
                 new NameMatchFilter("array", "b", "value"),
                 true, true);
         final String JSON = "{'a':123,'array':[1,2],'ob':{'value0':2,'value':3,'value2':4},'b':true}";
         writeJsonDoc(JSON_F, JSON, gen);
         assertEquals(aposToQuotes("{'array':[1,2],'ob':{'value':3},'b':true}"), w.toString());
+        assertEquals(3, gen.getMatchCount());
     }
 
     public void testMultipleMatchFilteringWithPath3() throws Exception
     {
         StringWriter w = new StringWriter();
-        
-        JsonGenerator gen = new FilteringGeneratorDelegate(JSON_F.createGenerator(w),
+
+        FilteringGeneratorDelegate gen = new FilteringGeneratorDelegate(JSON_F.createGenerator(w),
                 new NameMatchFilter("value"),
                 true, true);
         final String JSON = "{'root':{'a0':true,'a':{'value':3},'b':{'value':4}},'b0':false}";
         writeJsonDoc(JSON_F, JSON, gen);
         assertEquals(aposToQuotes("{'root':{'a':{'value':3},'b':{'value':4}}}"), w.toString());
+        assertEquals(2, gen.getMatchCount());
     }
 
     public void testIndexMatchWithPath1() throws Exception
     {
         StringWriter w = new StringWriter();
-        JsonGenerator gen = new FilteringGeneratorDelegate(JSON_F.createGenerator(w),
+        FilteringGeneratorDelegate gen = new FilteringGeneratorDelegate(JSON_F.createGenerator(w),
                 new IndexMatchFilter(1),
                 true, true);
         final String JSON = "{'a':123,'array':[1,2],'ob':{'value0':2,'value':3,'value2':4},'b':true}";
@@ -293,24 +298,26 @@ public class BasicGeneratorFilteringTest extends BaseTest
                 true, true);
         writeJsonDoc(JSON_F, JSON, gen);
         assertEquals(aposToQuotes("{'array':[1]}"), w.toString());
+        assertEquals(1, gen.getMatchCount());
     }
 
     public void testIndexMatchWithPath2() throws Exception
     {
         StringWriter w = new StringWriter();
-        JsonGenerator gen = new FilteringGeneratorDelegate(JSON_F.createGenerator(w),
+        FilteringGeneratorDelegate gen = new FilteringGeneratorDelegate(JSON_F.createGenerator(w),
                 new IndexMatchFilter(0,1),
                 true, true);
         final String JSON = "{'a':123,'array':[1,2],'ob':{'value0':2,'value':3,'value2':4},'b':true}";
         writeJsonDoc(JSON_F, JSON, gen);
         assertEquals(aposToQuotes("{'array':[1,2]}"), w.toString());
+        assertEquals(2, gen.getMatchCount());
     }
 
     public void testWriteStartObjectWithObject() throws Exception
     {
         StringWriter w = new StringWriter();
 
-        JsonGenerator gen = new FilteringGeneratorDelegate(JSON_F.createGenerator(w),
+        FilteringGeneratorDelegate gen = new FilteringGeneratorDelegate(JSON_F.createGenerator(w),
                 TokenFilter.INCLUDE_ALL,
                 true, true);
 


### PR DESCRIPTION
First approach to handle _matchCount. Given that `FilteringParserDelegate` is a non-trivial one - it's worth do have a double-check on this one.