### PR TITLE
Prevent ArrayIndexOutOfBoundsException when using closed JsonParser

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/json/UTF8DataInputJsonParser.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/UTF8DataInputJsonParser.java
@@ -556,6 +556,9 @@ public class UTF8DataInputJsonParser
     @Override
     public JsonToken nextToken() throws IOException
     {
+        if (_closed) {
+            return null;
+        }
         /* First: field names are special -- we will always tokenize
          * (part of) value along with field name to simplify
          * state handling. If so, can and need to use secondary token:

--- a/src/main/java/com/fasterxml/jackson/core/json/UTF8StreamJsonParser.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/UTF8StreamJsonParser.java
@@ -669,6 +669,9 @@ public class UTF8StreamJsonParser
     @Override
     public JsonToken nextToken() throws IOException
     {
+        if (_closed) {
+            return null;
+        }
         /* First: field names are special -- we will always tokenize
          * (part of) value along with field name to simplify
          * state handling. If so, can and need to use secondary token:
@@ -861,6 +864,9 @@ public class UTF8StreamJsonParser
     public boolean nextFieldName(SerializableString str) throws IOException
     {
         // // // Note: most of code below is copied from nextToken()
+        if (_closed) {
+            return false;
+        }
         _numTypesValid = NR_UNKNOWN;
         if (_currToken == JsonToken.FIELD_NAME) { // can't have name right after name
             _nextAfterName();
@@ -947,7 +953,9 @@ public class UTF8StreamJsonParser
     public String nextFieldName() throws IOException
     {
         // // // Note: this is almost a verbatim copy of nextToken()
-
+        if (_closed) {
+            return null;
+        }
         _numTypesValid = NR_UNKNOWN;
         if (_currToken == JsonToken.FIELD_NAME) {
             _nextAfterName();
@@ -2918,7 +2926,7 @@ public class UTF8StreamJsonParser
         }        
         throw _constructError("Unexpected end-of-input within/between "+_parsingContext.typeDesc()+" entries");
     }
-    
+
     private final int _skipWSOrEnd() throws IOException
     {
         // Let's handle first character separately since it is likely that

--- a/src/test/java/com/fasterxml/jackson/core/json/JsonParserClosedCaseTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/json/JsonParserClosedCaseTest.java
@@ -1,0 +1,70 @@
+package com.fasterxml.jackson.core.json;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.io.SerializedString;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * These tests asserts that using closed parser doesn't cause ArrayIndexOutOfBoundsException
+ */
+@RunWith(Parameterized.class)
+public class JsonParserClosedCaseTest {
+    private static final JsonFactory JSON_F = new JsonFactory();
+
+    private JsonParser parser;
+
+    @Parameters(name = "{0}")
+    public static Collection<Object[]> parsers() throws IOException {
+        ByteArrayInputStream inputStream = new ByteArrayInputStream("{}".getBytes());
+
+        return closeParsers(
+                (ReaderBasedJsonParser) JSON_F.createParser(new InputStreamReader(inputStream)),
+                (UTF8StreamJsonParser) JSON_F.createParser(inputStream)
+        );
+    }
+
+    public JsonParserClosedCaseTest(String parserName, JsonParser parser) {
+        this.parser = parser;
+    }
+
+    @Test
+    public void testNullReturnedOnClosedParserOnNextFieldName() throws Exception {
+        Assert.assertNull(parser.nextFieldName());
+    }
+
+    @Test
+    public void testFalseReturnedOnClosedParserOnNextFieldNameSerializedString() throws Exception {
+        Assert.assertFalse(parser.nextFieldName(new SerializedString("")));
+    }
+
+    @Test
+    public void testNullReturnedOnClosedParserOnNextToken() throws Exception {
+        Assert.assertNull(parser.nextToken());
+    }
+
+    @Test
+    public void testNullReturnedOnClosedParserOnNextValue() throws Exception {
+        Assert.assertNull(parser.nextValue());
+    }
+
+    private static Collection<Object[]> closeParsers(JsonParser... parsersToClose) throws IOException {
+        List<Object[]> list = new ArrayList<Object[]>();
+        for (JsonParser p : parsersToClose) {
+            p.close();
+            list.add(new Object[] { p.getClass().getSimpleName(), p });
+        }
+        return list;
+    }
+}

--- a/src/test/java/com/fasterxml/jackson/core/json/JsonParserClosedCaseTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/json/JsonParserClosedCaseTest.java
@@ -3,6 +3,7 @@ package com.fasterxml.jackson.core.json;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.io.SerializedString;
+import com.fasterxml.jackson.core.testsupport.MockDataInput;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -10,6 +11,7 @@ import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
 import java.io.ByteArrayInputStream;
+import java.io.DataInput;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
@@ -17,7 +19,7 @@ import java.util.Collection;
 import java.util.List;
 
 /**
- * These tests asserts that using closed parser doesn't cause ArrayIndexOutOfBoundsException
+ * These tests asserts that using closed JsonParser doesn't cause ArrayIndexOutOfBoundsException.
  */
 @RunWith(Parameterized.class)
 public class JsonParserClosedCaseTest {
@@ -25,13 +27,20 @@ public class JsonParserClosedCaseTest {
 
     private JsonParser parser;
 
+    /**
+     * Creates a list of parsers to tests.
+     *
+     * @return List of Object[2]. Object[0] is is the name of the class, Object[1] is instance itself.
+     * @throws IOException when closing stream fails.
+     */
     @Parameters(name = "{0}")
     public static Collection<Object[]> parsers() throws IOException {
         ByteArrayInputStream inputStream = new ByteArrayInputStream("{}".getBytes());
 
         return closeParsers(
                 (ReaderBasedJsonParser) JSON_F.createParser(new InputStreamReader(inputStream)),
-                (UTF8StreamJsonParser) JSON_F.createParser(inputStream)
+                (UTF8StreamJsonParser) JSON_F.createParser(inputStream),
+                (UTF8DataInputJsonParser) JSON_F.createParser(new MockDataInput("{}"))
         );
     }
 


### PR DESCRIPTION
Solution with returning `null`s for #437