### PR TITLE
Fix ArrayIndexOutofBoundsException found by LGTM.com

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/json/ReaderBasedJsonParser.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/ReaderBasedJsonParser.java
@@ -1944,7 +1944,7 @@ public class ReaderBasedJsonParser
             }
             char c = _inputBuffer[_inputPtr];
             int i = (int) c;
-            if (i <= maxCode) {
+            if (i < maxCode) {
                 if (codes[i] != 0) {
                     break;
                 }


### PR DESCRIPTION
Seen on LGTM.com (here)[https://lgtm.com/projects/g/FasterXML/jackson-core/alerts/?mode=tree]

As `codes.length == maxCode` so if `i == maxCode` an `ArrayIndexOutOfBoundsException` is thrown. This happens when `ALLOW_UNQUOTED_FIELD_NAMES` is enabled and character `256` is found as part of a field name after needing to consume more data from the reader.

A gist containing code to trigger this path can be found [here](https://gist.github.com/aeyerstaylor/90128cca75e69303254a0d5a5dbe6762). I could find any tests for this class but if there is a place to add tests I can add the example as a test.

_(Full disclosure: I'm part of the company behind LGTM.com)_