### PR TITLE
 minor startup / perf fixes

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/Base64Variants.java
+++ b/src/main/java/com/fasterxml/jackson/core/Base64Variants.java
@@ -29,10 +29,7 @@ public final class Base64Variants
      * it is <b>not</b> the default for Jackson: no-linefeeds alternative
      * is because of JSON requirement of escaping all linefeeds.
      */
-    public final static Base64Variant MIME;
-    static {
-        MIME = new Base64Variant("MIME", STD_BASE64_ALPHABET, true, '=', 76);
-    }
+    public final static Base64Variant MIME = new Base64Variant("MIME", STD_BASE64_ALPHABET, true, '=', 76);
 
     /**
      * Slightly non-standard modification of {@link #MIME} which does not
@@ -40,10 +37,7 @@ public final class Base64Variants
      * wouldn't work well (possibly in attributes), or for minor space savings
      * (save 1 linefeed per 76 data chars, ie. ~1.4% savings).
      */
-    public final static Base64Variant MIME_NO_LINEFEEDS;
-    static {
-        MIME_NO_LINEFEEDS = new Base64Variant(MIME, "MIME-NO-LINEFEEDS", Integer.MAX_VALUE);
-    }
+    public final static Base64Variant MIME_NO_LINEFEEDS = new Base64Variant(MIME, "MIME-NO-LINEFEEDS", Integer.MAX_VALUE);
 
     /**
      * This variant is the one that predates {@link #MIME}: it is otherwise

--- a/src/main/java/com/fasterxml/jackson/core/io/CharTypes.java
+++ b/src/main/java/com/fasterxml/jackson/core/io/CharTypes.java
@@ -74,7 +74,7 @@ public final class CharTypes
     static {
         final int[] table = new int[256];
         // Default is "not a name char", mark ones that are
-        Arrays.fill(table, 0, 33, -1);
+        Arrays.fill(table, -1);
         // Assume rules with JS same as Java (change if/as needed)
         for (int i = 33; i < 256; ++i) {
             if (Character.isJavaIdentifierPart((char) i)) {

--- a/src/main/java/com/fasterxml/jackson/core/io/CharTypes.java
+++ b/src/main/java/com/fasterxml/jackson/core/io/CharTypes.java
@@ -43,7 +43,7 @@ public final class CharTypes
     private final static int[] sInputCodesUTF8;
     static {
         final int[] table = new int[sInputCodes.length];
-        System.arraycopy(sInputCodes, 0, table, 0, table.length);
+        System.arraycopy(sInputCodes, 0, table, 0, 128);
         for (int c = 128; c < 256; ++c) {
             int code;
 
@@ -74,7 +74,7 @@ public final class CharTypes
     static {
         final int[] table = new int[256];
         // Default is "not a name char", mark ones that are
-        Arrays.fill(table, -1);
+        Arrays.fill(table, 0, 33, -1);
         // Assume rules with JS same as Java (change if/as needed)
         for (int i = 33; i < 256; ++i) {
             if (Character.isJavaIdentifierPart((char) i)) {
@@ -101,7 +101,7 @@ public final class CharTypes
     static {
         final int[] table = new int[256];
         // start with 8-bit JS names
-        System.arraycopy(sInputCodesJsNames, 0, table, 0, table.length);
+        System.arraycopy(sInputCodesJsNames, 0, table, 0, 128);
         Arrays.fill(table, 128, 128, 0);
         sInputCodesUtf8JsNames = table;
     }

--- a/src/main/java/com/fasterxml/jackson/core/io/NumberInput.java
+++ b/src/main/java/com/fasterxml/jackson/core/io/NumberInput.java
@@ -174,13 +174,9 @@ public final class NumberInput
         if (alen < cmpLen) return true;
         if (alen > cmpLen) return false;
 
-        // could perhaps just use String.compareTo()?
-        for (int i = 0; i < cmpLen; ++i) {
-            int diff = s.charAt(i) - cmp.charAt(i);
-            if (diff != 0) {
-                return (diff < 0);
-            }
-        }
+        // use String.compareTo() as it is a JVM intrinsic
+        int diff = s.compareTo(cmp);
+        if (diff != 0) return (diff < 0);
         return true;
     }
 
@@ -200,7 +196,7 @@ public final class NumberInput
             char c = s.charAt(0);
             if (c == '+') { // for plus, actually physically remove
                 s = s.substring(1);
-                len = s.length();
+                --len;
             } else if (c == '-') { // minus, just skip for checks, must retain
                 ++i;
             }
@@ -238,7 +234,7 @@ public final class NumberInput
             char c = s.charAt(0);
             if (c == '+') { // for plus, actually physically remove
                 s = s.substring(1);
-                len = s.length();
+                --len;
             } else if (c == '-') { // minus, just skip for checks, must retain
                 ++i;
             }

--- a/src/main/java/com/fasterxml/jackson/core/util/JsonParserSequence.java
+++ b/src/main/java/com/fasterxml/jackson/core/util/JsonParserSequence.java
@@ -77,7 +77,7 @@ public class JsonParserSequence extends JsonParserDelegate
             return new JsonParserSequence(checkForExistingToken,
                     new JsonParser[] { first, second });
         }
-        ArrayList<JsonParser> p = new ArrayList<JsonParser>();
+        ArrayList<JsonParser> p = new ArrayList<JsonParser>(10);
         if (first instanceof JsonParserSequence) {
             ((JsonParserSequence) first).addFlattenedActiveParsers(p);
         } else {

--- a/src/main/java/com/fasterxml/jackson/core/util/TextBuffer.java
+++ b/src/main/java/com/fasterxml/jackson/core/util/TextBuffer.java
@@ -700,7 +700,7 @@ public final class TextBuffer
     
     public char[] finishCurrentSegment() {
         if (_segments == null) {
-            _segments = new ArrayList<char[]>();
+            _segments = new ArrayList<char[]>(10);
         }
         _hasSegments = true;
         _segments.add(_currentSegment);
@@ -806,7 +806,7 @@ public final class TextBuffer
     {
         // First, let's move current segment to segment list:
         if (_segments == null) {
-            _segments = new ArrayList<char[]>();
+            _segments = new ArrayList<char[]>(10);
         }
         char[] curr = _currentSegment;
         _hasSegments = true;

--- a/src/test/java/com/fasterxml/jackson/core/sym/SymbolsViaParserTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/sym/SymbolsViaParserTest.java
@@ -46,7 +46,7 @@ public class SymbolsViaParserTest
         JsonParser p = useBytes
                 ? f.createParser(ObjectReadContext.empty(), doc.getBytes("UTF-8"))
                 : f.createParser(ObjectReadContext.empty(), doc);
-        HashSet<String> syms = new HashSet<String>();
+        HashSet<String> syms = new HashSet<String>(64);
         assertToken(JsonToken.START_OBJECT, p.nextToken());
         for (int i = 0; i < 50; ++i) {
             assertToken(JsonToken.FIELD_NAME, p.nextToken());


### PR DESCRIPTION
- Don't copy an array section that will be filled later and other minor changes.
- Better sizing for collections. Java 8 defaults to empty collections on creation, which may not be desired to start with.