### PR TITLE
Prefer ArrayList over LinkedList

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/util/ByteArrayBuilder.java
+++ b/src/main/java/com/fasterxml/jackson/core/util/ByteArrayBuilder.java
@@ -41,7 +41,7 @@ public final class ByteArrayBuilder extends OutputStream
 
     // Optional buffer recycler instance that we can use for allocating the first block.
     private final BufferRecycler _bufferRecycler;
-    private final LinkedList<byte[]> _pastBlocks = new LinkedList<byte[]>();
+    private final List<byte[]> _pastBlocks = new ArrayList<byte[]>();
     
     // Number of bytes within byte arrays in {@link _pastBlocks}.
     private int _pastLen;
@@ -61,9 +61,7 @@ public final class ByteArrayBuilder extends OutputStream
         _pastLen = 0;
         _currBlockPtr = 0;
 
-        if (!_pastBlocks.isEmpty()) {
-            _pastBlocks.clear();
-        }
+        _pastBlocks.clear();
     }
 
     /**


### PR DESCRIPTION
> ArrayList with ArrayDeque are preferable in much more use-cases than LinkedList. If you're not sure — just start with ArrayList.

https://stackoverflow.com/questions/322715/when-to-use-linkedlist-over-arraylist-in-java

Also, there is currently a check for 'isEmpty()' before a call to 'clear'.  This is superfluous because the 'clear' method will perform a no-op if there are no entries to clear... no need to double-check.