### PR TITLE
Remove double-check of v value

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/io/NumberOutput.java
+++ b/src/main/java/com/fasterxml/jackson/core/io/NumberOutput.java
@@ -66,11 +66,11 @@ public final class NumberOutput
         }
 
         if (v < MILLION) { // at most 2 triplets...
+            if (v < 10) {
+                b[off] = (char) ('0' + v);
+                return off+1;
+            }
             if (v < 1000) {
-                if (v < 10) {
-                    b[off] = (char) ('0' + v);
-                    return off+1;
-                }
                 return _leading3(v, b, off);
             }
             int thousands = v / 1000;


### PR DESCRIPTION
Found a place where it checks 'is this value less than 1000'... 'is this value less than 10'.  Bring out the second check so that anything less than 10 does not have to pass through two checks.