### PR TITLE
Fix typo in javadoc of readBinaryValue

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/JsonParser.java
+++ b/src/main/java/com/fasterxml/jackson/core/JsonParser.java
@@ -1084,7 +1084,7 @@ public abstract class JsonParser
     }
 
     /**
-     * Method that can be used as an alternative to {@link #getBigIntegerValue()},
+     * Method that can be used as an alternative to {@link #getBinaryValue()},
      * especially when value can be large. The main difference (beyond method
      * of returning content using {@link OutputStream} instead of as byte array)
      * is that content will NOT remain accessible after method returns: any content


### PR DESCRIPTION
Before this commit the javadoc was describing readBinaryValue as an alternative to getBigInteger which looks like a typo. From what the method does and the rest of the javadoc text it should be referring to getBinaryValue.