### PR TITLE
Add simple module-info for JDK9+, using Moditect

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: java
 # 08-Dec-2018, tatu: While it should be possible to run core streaming on Java 6,
 #   build won't work with anything below Java 8 now
   - openjdk8
+  - oraclejdk11
 
 # Below this line is configuration for deploying to the Sonatype OSS repo
 # http://blog.xeiam.com/2013/05/configure-travis-ci-to-deploy-snapshots.html

--- a/pom.xml
+++ b/pom.xml
@@ -23,15 +23,16 @@
   </scm>
 
   <properties>
-    <!-- 16-Sep-2016, tatu: Retain Java6/JDK1.6 compatibility for streaming for Jackson 2.x -->
+    <!-- 04-Mar-2019, tatu: Retain Java6/JDK1.6 compatibility for annotations for Jackson 2.x,
+             but use Moditect to get JDK9+ module info support; need newer bundle plugin as well
+      -->
     <javac.src.version>1.6</javac.src.version>
     <javac.target.version>1.6</javac.target.version>
 
-    <!-- 04-May-2016, tatu: Bundle-plugin 3.x seems to require Java 7, so to
-           build for Java 6 need to downgrade here to last working 2.x version
-          (2.5.4 had some issues wrt shading)
-      -->
-    <version.plugin.bundle>2.5.3</version.plugin.bundle>
+    <maven.compiler.source>1.6</maven.compiler.source>
+    <maven.compiler.target>1.6</maven.compiler.target>
+
+    <version.plugin.bundle>3.2.0</version.plugin.bundle>
 
     <osgi.export>com.fasterxml.jackson.core;version=${project.version},
 com.fasterxml.jackson.core.*;version=${project.version}
@@ -94,6 +95,30 @@ com.fasterxml.jackson.core.*;version=${project.version}
       <plugin>
         <groupId>com.google.code.maven-replacer-plugin</groupId>
         <artifactId>replacer</artifactId>
+      </plugin>
+
+      <!--  04-Mar-2019, tatu: Add rudimentary JDK9+ module info. To build with JDK 8
+             will have to use `moduleInfoFile` which is crappy but anything else requires
+             JDK 9+. With Jackson 3.0 will upgrade.
+        -->
+      <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>add-module-infos</id>
+            <phase>package</phase>
+            <goals>
+              <goal>add-module-info</goal>
+            </goals>
+            <configuration>
+              <overwriteExistingFiles>true</overwriteExistingFiles>
+              <module>
+                <moduleInfoFile>src/moditect/module-info.java</moduleInfoFile>
+              </module>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/src/moditect/module-info.java
+++ b/src/moditect/module-info.java
@@ -3,6 +3,7 @@ module com.fasterxml.jackson.core {
     //    So, for 2.x core need to make sure we manually include everything.
     //    Worse, there is only syntactic validation, not contents, so we can both miss
     //    AND add bogus packages.
+    //    However: at least syntax is verified; and this works with JKD8
     exports com.fasterxml.jackson.core;
     exports com.fasterxml.jackson.core.async;
     exports com.fasterxml.jackson.core.base;

--- a/src/moditect/module-info.java
+++ b/src/moditect/module-info.java
@@ -1,0 +1,18 @@
+module com.fasterxml.jackson.core {
+    // 04-Mar-2019, tatu: Ugh. Can not use wildcards, stupid ass JDK 9+ module system...
+    //    So, for 2.x core need to make sure we manually include everything.
+    //    Worse, there is only syntactic validation, not contents, so we can both miss
+    //    AND add bogus packages.
+    exports com.fasterxml.jackson.core;
+    exports com.fasterxml.jackson.core.async;
+    exports com.fasterxml.jackson.core.base;
+    exports com.fasterxml.jackson.core.exc;
+    exports com.fasterxml.jackson.core.filter;
+    exports com.fasterxml.jackson.core.format;
+    exports com.fasterxml.jackson.core.io;
+    exports com.fasterxml.jackson.core.json;
+    exports com.fasterxml.jackson.core.json.async;
+    exports com.fasterxml.jackson.core.sym;
+    exports com.fasterxml.jackson.core.type;
+    exports com.fasterxml.jackson.core.util;
+}


### PR DESCRIPTION
As per title. For 2.x will use `moduleInfoFile` which allows build using JDK 8, but is quite inconvenient as it can not do wildcard exports; will upgrade in 3.0, and probably for components other than `jackson-core` / `jackson-annotations`.
