### PR TITLE
Extend JsonStringEncoder to support CharSequence

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/io/JsonStringEncoder.java
+++ b/src/main/java/com/fasterxml/jackson/core/io/JsonStringEncoder.java
@@ -81,7 +81,7 @@ public final class JsonStringEncoder
      * Method that will quote text contents using JSON standard quoting,
      * and return results as a character array
      */
-    public char[] quoteAsString(String input)
+    public char[] quoteAsString(CharSequence input)
     {
         TextBuffer textBuffer = _text;
         if (textBuffer == null) {
@@ -178,7 +178,7 @@ public final class JsonStringEncoder
      * results as UTF-8, and return result as a byte array.
      */
     @SuppressWarnings("resource")
-    public byte[] quoteAsUTF8(String text)
+    public byte[] quoteAsUTF8(CharSequence text)
     {
         ByteArrayBuilder bb = _bytes;
         if (bb == null) {
@@ -275,7 +275,7 @@ public final class JsonStringEncoder
      * resulting byte array.
      */
     @SuppressWarnings("resource")
-    public byte[] encodeAsUTF8(String text)
+    public byte[] encodeAsUTF8(CharSequence text)
     {
         ByteArrayBuilder byteBuilder = _bytes;
         if (byteBuilder == null) {

--- a/src/main/java/com/fasterxml/jackson/core/io/JsonStringEncoder.java
+++ b/src/main/java/com/fasterxml/jackson/core/io/JsonStringEncoder.java
@@ -76,10 +76,18 @@ public final class JsonStringEncoder
     /* Public API
     /**********************************************************
      */
+    /**
+     * Method that will quote text contents from a String using JSON
+     * standard quoting, and return results as a character array
+     */
+    public char[] quoteAsString(String input)
+    {
+        return quoteAsString((CharSequence) input);
+    }
 
     /**
-     * Method that will quote text contents using JSON standard quoting,
-     * and return results as a character array
+     * Method that will quote text contents from a CharSequence using
+     * JSON standard quoting, and return results as a character array
      */
     public char[] quoteAsString(CharSequence input)
     {
@@ -138,8 +146,18 @@ public final class JsonStringEncoder
     }
 
     /**
-     * Method that will quote text contents using JSON standard quoting,
-     * and append results to a supplied {@link StringBuilder}.
+     * Method that will quote text contents from a String using JSON
+     * standard quoting, and append results to a supplied {@link StringBuilder}.
+     * Use this variant if you have e.g. a {@link StringBuilder} and want to avoid superfluous copying of it.
+     */
+    public void quoteAsString(String input, StringBuilder output)
+    {
+        return quoteAsString((CharSequence) input, output);
+    }
+
+    /**
+     * Method that will quote text contents from a CharSequence using
+     * JSON standard quoting, and append results to a supplied {@link StringBuilder}.
      * Use this variant if you have e.g. a {@link StringBuilder} and want to avoid superfluous copying of it.
      */
     public void quoteAsString(CharSequence input, StringBuilder output)
@@ -175,6 +193,15 @@ public final class JsonStringEncoder
 
     /**
      * Will quote given JSON String value using standard quoting, encode
+     * results as UTF-8, and return result as a byte array.
+     */
+    public byte[] quoteAsUTF8(String text)
+    {
+        return quoteAsUTF8((CharSequence) text);
+    }
+
+    /**
+     * Will quote given JSON CharSequence value using standard quoting, encode
      * results as UTF-8, and return result as a byte array.
      */
     @SuppressWarnings("resource")


### PR DESCRIPTION
Currently JsonStringEncoder requires a String, but it actually works completely on the API of CharSequence internally.
Widening the parameter to CharSequence for example allows passing in a StringBuilder, which can avoid an intermediate toString() copy