### PR TITLE
UTF8StreamJsonParser: fix byte to int conversion for malformed escapes

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/json/UTF8StreamJsonParser.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/UTF8StreamJsonParser.java
@@ -3602,7 +3602,7 @@ public class UTF8StreamJsonParser
                     _reportInvalidEOF(" in character escape sequence", JsonToken.VALUE_STRING);
                 }
             }
-            int ch = (int) _inputBuffer[_inputPtr++];
+            int ch = _inputBuffer[_inputPtr++] & 0xFF;
             int digit = CharTypes.charToHex(ch);
             if (digit < 0) {
                 _reportUnexpectedChar(ch, "expected a hex-digit for character escape sequence");


### PR DESCRIPTION
This change ensures that the byte-to-int conversion results in a positive integer. Prior to this, the conversion could result to a negative integer when the byte was >= 0x80, which would lead to an ArrayIndexOutOfBoundsException when calling CharTypes.charToHex(ch).

The issue can be reproduced with the following snippet: `factory.createParser(ObjectReadContext.empty(), "\"\\u\u0080\"".getBytes("UTF-8").nextToken()`.

Traceback:
```
java.lang.ArrayIndexOutOfBoundsException: -62
	at com.fasterxml.jackson.core.io.CharTypes.charToHex(CharTypes.java:213)
	at com.fasterxml.jackson.core.json.UTF8StreamJsonParser._decodeEscaped(UTF8StreamJsonParser.java:3606)
	at com.fasterxml.jackson.core.json.UTF8StreamJsonParser._skipString(UTF8StreamJsonParser.java:2888)
	at com.fasterxml.jackson.core.json.UTF8StreamJsonParser.nextToken(UTF8StreamJsonParser.java:685)
```

I'd be happy to add this testcase to the tests if you point me to the right test file.