### PR TITLE
Issue #455 getCurrentLocation() incorrect at end of input

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/json/ReaderBasedJsonParser.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/ReaderBasedJsonParser.java
@@ -6,8 +6,7 @@ import com.fasterxml.jackson.core.*;
 import com.fasterxml.jackson.core.io.CharTypes;
 import com.fasterxml.jackson.core.io.IOContext;
 import com.fasterxml.jackson.core.sym.CharsToNameCanonicalizer;
-import com.fasterxml.jackson.core.util.ByteArrayBuilder;
-import com.fasterxml.jackson.core.util.TextBuffer;
+import com.fasterxml.jackson.core.util.*;
 
 import static com.fasterxml.jackson.core.JsonTokenId.*;
 
@@ -17,7 +16,8 @@ import static com.fasterxml.jackson.core.JsonTokenId.*;
  * conversion tasks.
  */
 public class ReaderBasedJsonParser
-        extends JsonParserBase {
+    extends JsonParserBase
+{
     private final static int FEAT_MASK_TRAILING_COMMA = JsonReadFeature.ALLOW_TRAILING_COMMA.getMask();
     private final static int FEAT_MASK_ALLOW_MISSING = JsonReadFeature.ALLOW_MISSING_VALUES.getMask();
 
@@ -47,7 +47,7 @@ public class ReaderBasedJsonParser
     /**
      * Flag that indicates whether the input buffer is recycable (and
      * needs to be returned to recycler once we are done) or not.
-     * <p>
+     *<p>
      * If it is not, it also means that parser can NOT modify underlying
      * buffer.
      */
@@ -105,10 +105,11 @@ public class ReaderBasedJsonParser
      * and it may or may not be recyclable use standard recycle context.
      */
     public ReaderBasedJsonParser(ObjectReadContext readCtxt, IOContext ctxt,
-                                 int stdFeatures, int formatFeatures, Reader r,
-                                 CharsToNameCanonicalizer st,
-                                 char[] inputBuffer, int start, int end,
-                                 boolean bufferRecyclable) {
+            int stdFeatures, int formatFeatures, Reader r,
+            CharsToNameCanonicalizer st,
+            char[] inputBuffer, int start, int end,
+            boolean bufferRecyclable)
+    {
         super(readCtxt, ctxt, stdFeatures, formatFeatures);
         _reader = r;
         _inputBuffer = inputBuffer;
@@ -124,8 +125,9 @@ public class ReaderBasedJsonParser
      * can be done using default mechanism.
      */
     public ReaderBasedJsonParser(ObjectReadContext readCtxt, IOContext ctxt,
-                                 int stdFeatures, int formatFeatures, Reader r,
-                                 CharsToNameCanonicalizer st) {
+            int stdFeatures, int formatFeatures, Reader r,
+            CharsToNameCanonicalizer st)
+    {
         super(readCtxt, ctxt, stdFeatures, formatFeatures);
         _reader = r;
         _inputBuffer = ctxt.allocTokenBuffer();
@@ -145,19 +147,14 @@ public class ReaderBasedJsonParser
     @Override
     public int releaseBuffered(Writer w) throws IOException {
         int count = _inputEnd - _inputPtr;
-        if (count < 1) {
-            return 0;
-        }
+        if (count < 1) { return 0; }
         // let's just advance ptr to end
         int origPtr = _inputPtr;
         w.write(_inputBuffer, origPtr, count);
         return count;
     }
 
-    @Override
-    public Object getInputSource() {
-        return _reader;
-    }
+    @Override public Object getInputSource() { return _reader; }
 
     protected char getNextChar(String eofMsg, JsonToken forToken) throws IOException {
         if (_inputPtr >= _inputEnd) {
@@ -213,12 +210,11 @@ public class ReaderBasedJsonParser
      */
 
     protected void _loadMoreGuaranteed() throws IOException {
-        if (!_loadMore()) {
-            _reportInvalidEOF();
-        }
+        if (!_loadMore()) { _reportInvalidEOF(); }
     }
-
-    protected boolean _loadMore() throws IOException {
+    
+    protected boolean _loadMore() throws IOException
+    {
         final int bufSize = _inputEnd;
 
         if (_reader != null) {
@@ -226,6 +222,7 @@ public class ReaderBasedJsonParser
             if (count > 0) {
                 _inputPtr = 0;
                 _inputEnd = count;
+
                 _currInputProcessed += bufSize;
                 _currInputRowStart -= bufSize;
 
@@ -240,7 +237,7 @@ public class ReaderBasedJsonParser
             _closeInput();
             // Should never return 0, so let's fail
             if (count == 0) {
-                throw new IOException("Reader returned 0 characters when trying to read " + _inputEnd);
+                throw new IOException("Reader returned 0 characters when trying to read "+_inputEnd);
             }
         }
         return false;
@@ -259,7 +256,8 @@ public class ReaderBasedJsonParser
      * Method can be called for any event.
      */
     @Override
-    public final String getText() throws IOException {
+    public final String getText() throws IOException
+    {
         JsonToken t = _currToken;
         if (t == JsonToken.VALUE_STRING) {
             if (_tokenIncomplete) {
@@ -272,7 +270,8 @@ public class ReaderBasedJsonParser
     }
 
     @Override // since 2.8
-    public int getText(Writer writer) throws IOException {
+    public int getText(Writer writer) throws IOException
+    {
         JsonToken t = _currToken;
         if (t == JsonToken.VALUE_STRING) {
             if (_tokenIncomplete) {
@@ -296,12 +295,13 @@ public class ReaderBasedJsonParser
         }
         return 0;
     }
-
+    
     // // // Let's override default impls for improved performance
 
     // @since 2.1
     @Override
-    public final String getValueAsString() throws IOException {
+    public final String getValueAsString() throws IOException
+    {
         if (_currToken == JsonToken.VALUE_STRING) {
             if (_tokenIncomplete) {
                 _tokenIncomplete = false;
@@ -336,110 +336,114 @@ public class ReaderBasedJsonParser
             return null;
         }
         switch (t.id()) {
-            case ID_FIELD_NAME:
-                return _parsingContext.currentName();
+        case ID_FIELD_NAME:
+            return _parsingContext.currentName();
 
-            case ID_STRING:
-                // fall through
-            case ID_NUMBER_INT:
-            case ID_NUMBER_FLOAT:
-                return _textBuffer.contentsAsString();
-            default:
-                return t.asString();
+        case ID_STRING:
+            // fall through
+        case ID_NUMBER_INT:
+        case ID_NUMBER_FLOAT:
+            return _textBuffer.contentsAsString();
+        default:
+            return t.asString();
         }
     }
 
     @Override
-    public final char[] getTextCharacters() throws IOException {
+    public final char[] getTextCharacters() throws IOException
+    {
         if (_currToken != null) { // null only before/after document
             switch (_currToken.id()) {
-                case ID_FIELD_NAME:
-                    if (!_nameCopied) {
-                        String name = _parsingContext.currentName();
-                        int nameLen = name.length();
-                        if (_nameCopyBuffer == null) {
-                            _nameCopyBuffer = _ioContext.allocNameCopyBuffer(nameLen);
-                        } else if (_nameCopyBuffer.length < nameLen) {
-                            _nameCopyBuffer = new char[nameLen];
-                        }
-                        name.getChars(0, nameLen, _nameCopyBuffer, 0);
-                        _nameCopied = true;
+            case ID_FIELD_NAME:
+                if (!_nameCopied) {
+                    String name = _parsingContext.currentName();
+                    int nameLen = name.length();
+                    if (_nameCopyBuffer == null) {
+                        _nameCopyBuffer = _ioContext.allocNameCopyBuffer(nameLen);
+                    } else if (_nameCopyBuffer.length < nameLen) {
+                        _nameCopyBuffer = new char[nameLen];
                     }
-                    return _nameCopyBuffer;
-                case ID_STRING:
-                    if (_tokenIncomplete) {
-                        _tokenIncomplete = false;
-                        _finishString(); // only strings can be incomplete
-                    }
-                    // fall through
-                case ID_NUMBER_INT:
-                case ID_NUMBER_FLOAT:
-                    return _textBuffer.getTextBuffer();
-                default:
-                    return _currToken.asCharArray();
+                    name.getChars(0, nameLen, _nameCopyBuffer, 0);
+                    _nameCopied = true;
+                }
+                return _nameCopyBuffer;
+            case ID_STRING:
+                if (_tokenIncomplete) {
+                    _tokenIncomplete = false;
+                    _finishString(); // only strings can be incomplete
+                }
+                // fall through
+            case ID_NUMBER_INT:
+            case ID_NUMBER_FLOAT:
+                return _textBuffer.getTextBuffer();
+            default:
+                return _currToken.asCharArray();
             }
         }
         return null;
     }
 
     @Override
-    public final int getTextLength() throws IOException {
+    public final int getTextLength() throws IOException
+    {
         if (_currToken != null) { // null only before/after document
             switch (_currToken.id()) {
-                case ID_FIELD_NAME:
-                    return _parsingContext.currentName().length();
-                case ID_STRING:
-                    if (_tokenIncomplete) {
-                        _tokenIncomplete = false;
-                        _finishString(); // only strings can be incomplete
-                    }
-                    // fall through
-                case ID_NUMBER_INT:
-                case ID_NUMBER_FLOAT:
-                    return _textBuffer.size();
-                default:
-                    return _currToken.asCharArray().length;
+            case ID_FIELD_NAME:
+                return _parsingContext.currentName().length();
+            case ID_STRING:
+                if (_tokenIncomplete) {
+                    _tokenIncomplete = false;
+                    _finishString(); // only strings can be incomplete
+                }
+                // fall through
+            case ID_NUMBER_INT:
+            case ID_NUMBER_FLOAT:
+                return _textBuffer.size();
+            default:
+                return _currToken.asCharArray().length;
             }
         }
         return 0;
     }
 
     @Override
-    public final int getTextOffset() throws IOException {
+    public final int getTextOffset() throws IOException
+    {
         // Most have offset of 0, only some may have other values:
         if (_currToken != null) {
             switch (_currToken.id()) {
-                case ID_FIELD_NAME:
-                    return 0;
-                case ID_STRING:
-                    if (_tokenIncomplete) {
-                        _tokenIncomplete = false;
-                        _finishString(); // only strings can be incomplete
-                    }
-                    // fall through
-                case ID_NUMBER_INT:
-                case ID_NUMBER_FLOAT:
-                    return _textBuffer.getTextOffset();
-                default:
+            case ID_FIELD_NAME:
+                return 0;
+            case ID_STRING:
+                if (_tokenIncomplete) {
+                    _tokenIncomplete = false;
+                    _finishString(); // only strings can be incomplete
+                }
+                // fall through
+            case ID_NUMBER_INT:
+            case ID_NUMBER_FLOAT:
+                return _textBuffer.getTextOffset();
+            default:
             }
         }
         return 0;
     }
 
     @Override
-    public byte[] getBinaryValue(Base64Variant b64variant) throws IOException {
+    public byte[] getBinaryValue(Base64Variant b64variant) throws IOException
+    {
         if ((_currToken == JsonToken.VALUE_EMBEDDED_OBJECT) && (_binaryValue != null)) {
             return _binaryValue;
         }
         if (_currToken != JsonToken.VALUE_STRING) {
-            _reportError("Current token (" + _currToken + ") not VALUE_STRING or VALUE_EMBEDDED_OBJECT, can not access as binary");
+            _reportError("Current token ("+_currToken+") not VALUE_STRING or VALUE_EMBEDDED_OBJECT, can not access as binary");
         }
         // To ensure that we won't see inconsistent data, better clear up state
         if (_tokenIncomplete) {
             try {
                 _binaryValue = _decodeBase64(b64variant);
             } catch (IllegalArgumentException iae) {
-                throw _constructError("Failed to decode VALUE_STRING as base64 (" + b64variant + "): " + iae.getMessage());
+                throw _constructError("Failed to decode VALUE_STRING as base64 ("+b64variant+"): "+iae.getMessage());
             }
             // let's clear incomplete only now; allows for accessing other
             // textual content in error cases
@@ -456,7 +460,8 @@ public class ReaderBasedJsonParser
     }
 
     @Override
-    public int readBinaryValue(Base64Variant b64variant, OutputStream out) throws IOException {
+    public int readBinaryValue(Base64Variant b64variant, OutputStream out) throws IOException
+    {
         // if we have already read the token, just use whatever we may have
         if (!_tokenIncomplete || _currToken != JsonToken.VALUE_STRING) {
             byte[] b = getBinaryValue(b64variant);
@@ -472,7 +477,8 @@ public class ReaderBasedJsonParser
         }
     }
 
-    protected int _readBinary(Base64Variant b64variant, OutputStream out, byte[] buffer) throws IOException {
+    protected int _readBinary(Base64Variant b64variant, OutputStream out, byte[] buffer) throws IOException
+    {
         int outputPtr = 0;
         final int outputEnd = buffer.length - 3;
         int outputCount = 0;
@@ -548,7 +554,7 @@ public class ReaderBasedJsonParser
                     ch = _inputBuffer[_inputPtr++];
                     if (!b64variant.usesPaddingChar(ch)) {
                         if (_decodeBase64Escape(b64variant, ch, 3) != Base64Variant.BASE64_VALUE_PADDING) {
-                            throw reportInvalidBase64Char(b64variant, ch, 3, "expected padding character '" + b64variant.getPaddingChar() + "'");
+                            throw reportInvalidBase64Char(b64variant, ch, 3, "expected padding character '"+b64variant.getPaddingChar()+"'");
                         }
                     }
                     // Got 12 bits, only need 8, need to shift
@@ -615,10 +621,11 @@ public class ReaderBasedJsonParser
 
     /**
      * @return Next token from the stream, if any found, or null
-     * to indicate end-of-input
+     *   to indicate end-of-input
      */
     @Override
-    public final JsonToken nextToken() throws IOException {
+    public final JsonToken nextToken() throws IOException
+    {
         /* First: field names are special -- we will always tokenize
          * (part of) value along with field name to simplify
          * state handling. If so, can and need to use secondary token:
@@ -680,61 +687,61 @@ public class ReaderBasedJsonParser
         JsonToken t;
 
         switch (i) {
-            case '"':
-                _tokenIncomplete = true;
-                t = JsonToken.VALUE_STRING;
-                break;
-            case '[':
-                if (!inObject) {
-                    _parsingContext = _parsingContext.createChildArrayContext(_tokenInputRow, _tokenInputCol);
-                }
-                t = JsonToken.START_ARRAY;
-                break;
-            case '{':
-                if (!inObject) {
-                    _parsingContext = _parsingContext.createChildObjectContext(_tokenInputRow, _tokenInputCol);
-                }
-                t = JsonToken.START_OBJECT;
-                break;
-            case '}':
-                // Error: } is not valid at this point; valid closers have
-                // been handled earlier
-                _reportUnexpectedChar(i, "expected a value");
-            case 't':
-                _matchTrue();
-                t = JsonToken.VALUE_TRUE;
-                break;
-            case 'f':
-                _matchFalse();
-                t = JsonToken.VALUE_FALSE;
-                break;
-            case 'n':
-                _matchNull();
-                t = JsonToken.VALUE_NULL;
-                break;
+        case '"':
+            _tokenIncomplete = true;
+            t = JsonToken.VALUE_STRING;
+            break;
+        case '[':
+            if (!inObject) {
+                _parsingContext = _parsingContext.createChildArrayContext(_tokenInputRow, _tokenInputCol);
+            }
+            t = JsonToken.START_ARRAY;
+            break;
+        case '{':
+            if (!inObject) {
+                _parsingContext = _parsingContext.createChildObjectContext(_tokenInputRow, _tokenInputCol);
+            }
+            t = JsonToken.START_OBJECT;
+            break;
+        case '}':
+            // Error: } is not valid at this point; valid closers have
+            // been handled earlier
+            _reportUnexpectedChar(i, "expected a value");
+        case 't':
+            _matchTrue();
+            t = JsonToken.VALUE_TRUE;
+            break;
+        case 'f':
+            _matchFalse();
+            t = JsonToken.VALUE_FALSE;
+            break;
+        case 'n':
+            _matchNull();
+            t = JsonToken.VALUE_NULL;
+            break;
 
-            case '-':
-                /* Should we have separate handling for plus? Although
-                 * it is not allowed per se, it may be erroneously used,
-                 * and could be indicate by a more specific error message.
-                 */
-                t = _parseNegNumber();
-                break;
-            case '0':
-            case '1':
-            case '2':
-            case '3':
-            case '4':
-            case '5':
-            case '6':
-            case '7':
-            case '8':
-            case '9':
-                t = _parsePosNumber(i);
-                break;
-            default:
-                t = _handleOddValue(i);
-                break;
+        case '-':
+            /* Should we have separate handling for plus? Although
+             * it is not allowed per se, it may be erroneously used,
+             * and could be indicate by a more specific error message.
+             */
+            t = _parseNegNumber();
+            break;
+        case '0':
+        case '1':
+        case '2':
+        case '3':
+        case '4':
+        case '5':
+        case '6':
+        case '7':
+        case '8':
+        case '9':
+            t = _parsePosNumber(i);
+            break;
+        default:
+            t = _handleOddValue(i);
+            break;
         }
 
         if (inObject) {
@@ -745,13 +752,14 @@ public class ReaderBasedJsonParser
         return t;
     }
 
-    private final JsonToken _nextAfterName() {
+    private final JsonToken _nextAfterName()
+    {
         _nameCopied = false; // need to invalidate if it was copied
         JsonToken t = _nextToken;
         _nextToken = null;
 
 // !!! 16-Nov-2015, tatu: TODO: fix [databind#37], copy next location to current here
-
+        
         // Also: may need to start new context?
         if (t == JsonToken.START_ARRAY) {
             _parsingContext = _parsingContext.createChildArrayContext(_tokenInputRow, _tokenInputCol);
@@ -777,7 +785,8 @@ public class ReaderBasedJsonParser
 
     // Implemented since 2.7
     @Override
-    public boolean nextFieldName(SerializableString sstr) throws IOException {
+    public boolean nextFieldName(SerializableString sstr) throws IOException
+    {
         // // // Note: most of code below is copied from nextToken()
 
         _numTypesValid = NR_UNKNOWN;
@@ -829,14 +838,14 @@ public class ReaderBasedJsonParser
             // Require 4 more bytes for faster skipping of colon that follows name
             if ((_inputPtr + len + 4) < _inputEnd) { // maybe...
                 // first check length match by
-                final int end = _inputPtr + len;
+                final int end = _inputPtr+len;
                 if (_inputBuffer[end] == '"') {
                     int offset = 0;
                     int ptr = _inputPtr;
                     while (true) {
                         if (ptr == end) { // yes, match!
                             _parsingContext.setCurrentName(sstr.getValue());
-                            _isNextTokenNameYes(_skipColonFast(ptr + 1));
+                            _isNextTokenNameYes(_skipColonFast(ptr+1));
                             return true;
                         }
                         if (nameChars[offset] != _inputBuffer[ptr]) {
@@ -852,7 +861,8 @@ public class ReaderBasedJsonParser
     }
 
     @Override
-    public String nextFieldName() throws IOException {
+    public String nextFieldName() throws IOException
+    {
         // // // Note: this is almost a verbatim copy of nextToken() (minus comments)
 
         _numTypesValid = NR_UNKNOWN;
@@ -901,100 +911,102 @@ public class ReaderBasedJsonParser
             _nextToken = JsonToken.VALUE_STRING;
             return name;
         }
-
+        
         // Ok: we must have a value... what is it?
 
         JsonToken t;
 
         switch (i) {
-            case '-':
-                t = _parseNegNumber();
-                break;
-            case '0':
-            case '1':
-            case '2':
-            case '3':
-            case '4':
-            case '5':
-            case '6':
-            case '7':
-            case '8':
-            case '9':
-                t = _parsePosNumber(i);
-                break;
-            case 'f':
-                _matchFalse();
-                t = JsonToken.VALUE_FALSE;
-                break;
-            case 'n':
-                _matchNull();
-                t = JsonToken.VALUE_NULL;
-                break;
-            case 't':
-                _matchTrue();
-                t = JsonToken.VALUE_TRUE;
-                break;
-            case '[':
-                t = JsonToken.START_ARRAY;
-                break;
-            case '{':
-                t = JsonToken.START_OBJECT;
-                break;
-            default:
-                t = _handleOddValue(i);
-                break;
+        case '-':
+            t = _parseNegNumber();
+            break;
+        case '0':
+        case '1':
+        case '2':
+        case '3':
+        case '4':
+        case '5':
+        case '6':
+        case '7':
+        case '8':
+        case '9':
+            t = _parsePosNumber(i);
+            break;
+        case 'f':
+            _matchFalse();
+            t = JsonToken.VALUE_FALSE;
+            break;
+        case 'n':
+            _matchNull();
+            t = JsonToken.VALUE_NULL;
+            break;
+        case 't':
+            _matchTrue();
+            t = JsonToken.VALUE_TRUE;
+            break;
+        case '[':
+            t = JsonToken.START_ARRAY;
+            break;
+        case '{':
+            t = JsonToken.START_OBJECT;
+            break;
+        default:
+            t = _handleOddValue(i);
+            break;
         }
         _nextToken = t;
         return name;
     }
 
-    private final void _isNextTokenNameYes(int i) throws IOException {
+    private final void _isNextTokenNameYes(int i) throws IOException
+    {
         _currToken = JsonToken.FIELD_NAME;
         _updateLocation();
 
         switch (i) {
-            case '"':
-                _tokenIncomplete = true;
-                _nextToken = JsonToken.VALUE_STRING;
-                return;
-            case '[':
-                _nextToken = JsonToken.START_ARRAY;
-                return;
-            case '{':
-                _nextToken = JsonToken.START_OBJECT;
-                return;
-            case 't':
-                _matchToken("true", 1);
-                _nextToken = JsonToken.VALUE_TRUE;
-                return;
-            case 'f':
-                _matchToken("false", 1);
-                _nextToken = JsonToken.VALUE_FALSE;
-                return;
-            case 'n':
-                _matchToken("null", 1);
-                _nextToken = JsonToken.VALUE_NULL;
-                return;
-            case '-':
-                _nextToken = _parseNegNumber();
-                return;
-            case '0':
-            case '1':
-            case '2':
-            case '3':
-            case '4':
-            case '5':
-            case '6':
-            case '7':
-            case '8':
-            case '9':
-                _nextToken = _parsePosNumber(i);
-                return;
+        case '"':
+            _tokenIncomplete = true;
+            _nextToken = JsonToken.VALUE_STRING;
+            return;
+        case '[':
+            _nextToken = JsonToken.START_ARRAY;
+            return;
+        case '{':
+            _nextToken = JsonToken.START_OBJECT;
+            return;
+        case 't':
+            _matchToken("true", 1);
+            _nextToken = JsonToken.VALUE_TRUE;
+            return;
+        case 'f':
+            _matchToken("false", 1);
+            _nextToken = JsonToken.VALUE_FALSE;
+            return;
+        case 'n':
+            _matchToken("null", 1);
+            _nextToken = JsonToken.VALUE_NULL;
+            return;
+        case '-':
+            _nextToken = _parseNegNumber();
+            return;
+        case '0':
+        case '1':
+        case '2':
+        case '3':
+        case '4':
+        case '5':
+        case '6':
+        case '7':
+        case '8':
+        case '9':
+            _nextToken = _parsePosNumber(i);
+            return;
         }
         _nextToken = _handleOddValue(i);
     }
 
-    protected boolean _isNextTokenNameMaybe(int i, String nameToMatch) throws IOException {
+    protected boolean _isNextTokenNameMaybe(int i, String nameToMatch) throws IOException
+    {
         // // // and this is back to standard nextToken()
         String name = (i == INT_QUOTE) ? _parseName() : _handleOddName(i);
         _parsingContext.setCurrentName(name);
@@ -1009,106 +1021,107 @@ public class ReaderBasedJsonParser
         // Ok: we must have a value... what is it?
         JsonToken t;
         switch (i) {
-            case '-':
-                t = _parseNegNumber();
-                break;
-            case '0':
-            case '1':
-            case '2':
-            case '3':
-            case '4':
-            case '5':
-            case '6':
-            case '7':
-            case '8':
-            case '9':
-                t = _parsePosNumber(i);
-                break;
-            case 'f':
-                _matchFalse();
-                t = JsonToken.VALUE_FALSE;
-                break;
-            case 'n':
-                _matchNull();
-                t = JsonToken.VALUE_NULL;
-                break;
-            case 't':
-                _matchTrue();
-                t = JsonToken.VALUE_TRUE;
-                break;
-            case '[':
-                t = JsonToken.START_ARRAY;
-                break;
-            case '{':
-                t = JsonToken.START_OBJECT;
-                break;
-            default:
-                t = _handleOddValue(i);
-                break;
+        case '-':
+            t = _parseNegNumber();
+            break;
+        case '0':
+        case '1':
+        case '2':
+        case '3':
+        case '4':
+        case '5':
+        case '6':
+        case '7':
+        case '8':
+        case '9':
+            t = _parsePosNumber(i);
+            break;
+        case 'f':
+            _matchFalse();
+            t = JsonToken.VALUE_FALSE;
+            break;
+        case 'n':
+            _matchNull();
+            t = JsonToken.VALUE_NULL;
+            break;
+        case 't':
+            _matchTrue();
+            t = JsonToken.VALUE_TRUE;
+            break;
+        case '[':
+            t = JsonToken.START_ARRAY;
+            break;
+        case '{':
+            t = JsonToken.START_OBJECT;
+            break;
+        default:
+            t = _handleOddValue(i);
+            break;
         }
         _nextToken = t;
         return nameToMatch.equals(name);
     }
 
-    private final JsonToken _nextTokenNotInObject(int i) throws IOException {
+    private final JsonToken _nextTokenNotInObject(int i) throws IOException
+    {
         if (i == INT_QUOTE) {
             _tokenIncomplete = true;
             return (_currToken = JsonToken.VALUE_STRING);
         }
         switch (i) {
-            case '[':
-                _parsingContext = _parsingContext.createChildArrayContext(_tokenInputRow, _tokenInputCol);
-                return (_currToken = JsonToken.START_ARRAY);
-            case '{':
-                _parsingContext = _parsingContext.createChildObjectContext(_tokenInputRow, _tokenInputCol);
-                return (_currToken = JsonToken.START_OBJECT);
-            case 't':
-                _matchToken("true", 1);
-                return (_currToken = JsonToken.VALUE_TRUE);
-            case 'f':
-                _matchToken("false", 1);
-                return (_currToken = JsonToken.VALUE_FALSE);
-            case 'n':
-                _matchToken("null", 1);
-                return (_currToken = JsonToken.VALUE_NULL);
-            case '-':
-                return (_currToken = _parseNegNumber());
+        case '[':
+            _parsingContext = _parsingContext.createChildArrayContext(_tokenInputRow, _tokenInputCol);
+            return (_currToken = JsonToken.START_ARRAY);
+        case '{':
+            _parsingContext = _parsingContext.createChildObjectContext(_tokenInputRow, _tokenInputCol);
+            return (_currToken = JsonToken.START_OBJECT);
+        case 't':
+            _matchToken("true", 1);
+            return (_currToken = JsonToken.VALUE_TRUE);
+        case 'f':
+            _matchToken("false", 1);
+            return (_currToken = JsonToken.VALUE_FALSE);
+        case 'n':
+            _matchToken("null", 1);
+            return (_currToken = JsonToken.VALUE_NULL);
+        case '-':
+            return (_currToken = _parseNegNumber());
             /* Should we have separate handling for plus? Although
              * it is not allowed per se, it may be erroneously used,
              * and could be indicated by a more specific error message.
              */
-            case '0':
-            case '1':
-            case '2':
-            case '3':
-            case '4':
-            case '5':
-            case '6':
-            case '7':
-            case '8':
-            case '9':
-                return (_currToken = _parsePosNumber(i));
-            /*
-             * This check proceeds only if the Feature.ALLOW_MISSING_VALUES is enabled
-             * The Check is for missing values. Incase of missing values in an array, the next token will be either ',' or ']'.
-             * This case, decrements the already incremented _inputPtr in the buffer in case of comma(,)
-             * so that the existing flow goes back to checking the next token which will be comma again and
-             * it continues the parsing.
-             * Also the case returns NULL as current token in case of ',' or ']'.
-             */
-            case ',':
-            case ']':
-                if ((_formatReadFeatures & FEAT_MASK_ALLOW_MISSING) != 0) {
-                    --_inputPtr;
-                    return (_currToken = JsonToken.VALUE_NULL);
-                }
+        case '0':
+        case '1':
+        case '2':
+        case '3':
+        case '4':
+        case '5':
+        case '6':
+        case '7':
+        case '8':
+        case '9':
+            return (_currToken = _parsePosNumber(i));
+        /*
+         * This check proceeds only if the Feature.ALLOW_MISSING_VALUES is enabled
+         * The Check is for missing values. Incase of missing values in an array, the next token will be either ',' or ']'.
+         * This case, decrements the already incremented _inputPtr in the buffer in case of comma(,) 
+         * so that the existing flow goes back to checking the next token which will be comma again and
+         * it continues the parsing.
+         * Also the case returns NULL as current token in case of ',' or ']'.    
+         */
+        case ',':
+        case ']':
+            if ((_formatReadFeatures & FEAT_MASK_ALLOW_MISSING) != 0) {
+                --_inputPtr;
+                return (_currToken = JsonToken.VALUE_NULL);  
+            }
         }
         return (_currToken = _handleOddValue(i));
     }
-
     // note: identical to one in UTF8StreamJsonParser
     @Override
-    public final String nextTextValue() throws IOException {
+    public final String nextTextValue() throws IOException
+    {
         if (_currToken == JsonToken.FIELD_NAME) { // mostly copied from '_nextAfterName'
             _nameCopied = false;
             JsonToken t = _nextToken;
@@ -1134,7 +1147,8 @@ public class ReaderBasedJsonParser
 
     // note: identical to one in Utf8StreamParser
     @Override
-    public final int nextIntValue(int defaultValue) throws IOException {
+    public final int nextIntValue(int defaultValue) throws IOException
+    {
         if (_currToken == JsonToken.FIELD_NAME) {
             _nameCopied = false;
             JsonToken t = _nextToken;
@@ -1156,7 +1170,8 @@ public class ReaderBasedJsonParser
 
     // note: identical to one in Utf8StreamParser
     @Override
-    public final long nextLongValue(long defaultValue) throws IOException {
+    public final long nextLongValue(long defaultValue) throws IOException
+    {
         if (_currToken == JsonToken.FIELD_NAME) { // mostly copied from '_nextAfterName'
             _nameCopied = false;
             JsonToken t = _nextToken;
@@ -1178,7 +1193,8 @@ public class ReaderBasedJsonParser
 
     // note: identical to one in UTF8StreamJsonParser
     @Override
-    public final Boolean nextBooleanValue() throws IOException {
+    public final Boolean nextBooleanValue() throws IOException
+    {
         if (_currToken == JsonToken.FIELD_NAME) { // mostly copied from '_nextAfterName'
             _nameCopied = false;
             JsonToken t = _nextToken;
@@ -1220,21 +1236,22 @@ public class ReaderBasedJsonParser
      * as a floating point number. The basic rule is that if the number
      * has no fractional or exponential part, it is an integer; otherwise
      * a floating point number.
-     * <p>
+     *<p>
      * Because much of input has to be processed in any case, no partial
      * parsing is done: all input text will be stored for further
      * processing. However, actual numeric value conversion will be
      * deferred, since it is usually the most complicated and costliest
      * part of processing.
      */
-    protected final JsonToken _parsePosNumber(int ch) throws IOException {
+    protected final JsonToken _parsePosNumber(int ch) throws IOException
+    {
         /* Although we will always be complete with respect to textual
          * representation (that is, all characters will be parsed),
          * actual conversion to a number is deferred. Thus, need to
          * note that no representations are valid yet
          */
         int ptr = _inputPtr;
-        int startPtr = ptr - 1; // to include digit already read
+        int startPtr = ptr-1; // to include digit already read
         final int inputLen = _inputEnd;
 
         // One special case, leading zero(es):
@@ -1274,13 +1291,14 @@ public class ReaderBasedJsonParser
         if (_parsingContext.inRoot()) {
             _verifyRootSpace(ch);
         }
-        int len = ptr - startPtr;
+        int len = ptr-startPtr;
         _textBuffer.resetWithShared(_inputBuffer, startPtr, len);
         return resetInt(false, intLen);
     }
 
     private final JsonToken _parseFloat(int ch, int startPtr, int ptr, boolean neg, int intLen)
-            throws IOException {
+        throws IOException
+    {
         final int inputLen = _inputEnd;
         int fractLen = 0;
 
@@ -1336,15 +1354,16 @@ public class ReaderBasedJsonParser
         if (_parsingContext.inRoot()) {
             _verifyRootSpace(ch);
         }
-        int len = ptr - startPtr;
+        int len = ptr-startPtr;
         _textBuffer.resetWithShared(_inputBuffer, startPtr, len);
         // And there we have it!
         return resetFloat(neg, intLen, fractLen, expLen);
     }
 
-    protected final JsonToken _parseNegNumber() throws IOException {
+    protected final JsonToken _parseNegNumber() throws IOException
+    {
         int ptr = _inputPtr;
-        int startPtr = ptr - 1; // to include sign/digit already read
+        int startPtr = ptr-1; // to include sign/digit already read
         final int inputLen = _inputEnd;
 
         if (ptr >= inputLen) {
@@ -1384,7 +1403,7 @@ public class ReaderBasedJsonParser
         if (_parsingContext.inRoot()) {
             _verifyRootSpace(ch);
         }
-        int len = ptr - startPtr;
+        int len = ptr-startPtr;
         _textBuffer.resetWithShared(_inputBuffer, startPtr, len);
         return resetInt(true, intLen);
     }
@@ -1396,8 +1415,9 @@ public class ReaderBasedJsonParser
      * that it has to explicitly copy contents to the text buffer
      * instead of just sharing the main input buffer.
      */
-    private final JsonToken _parseNumber2(boolean neg, int startPtr) throws IOException {
-        _inputPtr = neg ? (startPtr + 1) : startPtr;
+    private final JsonToken _parseNumber2(boolean neg, int startPtr) throws IOException
+    {
+        _inputPtr = neg ? (startPtr+1) : startPtr;
         char[] outBuf = _textBuffer.emptyAndGetCurrentSegment();
         int outPtr = 0;
 
@@ -1478,7 +1498,7 @@ public class ReaderBasedJsonParser
             outBuf[outPtr++] = c;
             // Not optional, can require that we get one more char
             c = (_inputPtr < _inputEnd) ? _inputBuffer[_inputPtr++]
-                    : getNextChar("expected a digit for number exponent", JsonToken.VALUE_NUMBER_FLOAT);
+                : getNextChar("expected a digit for number exponent", JsonToken.VALUE_NUMBER_FLOAT);
             // Sign indicator?
             if (c == '-' || c == '+') {
                 if (outPtr >= outBuf.length) {
@@ -1488,7 +1508,7 @@ public class ReaderBasedJsonParser
                 outBuf[outPtr++] = c;
                 // Likewise, non optional:
                 c = (_inputPtr < _inputEnd) ? _inputBuffer[_inputPtr++]
-                        : getNextChar("expected a digit for number exponent", JsonToken.VALUE_NUMBER_FLOAT);
+                    : getNextChar("expected a digit for number exponent", JsonToken.VALUE_NUMBER_FLOAT);
             }
 
             exp_loop:
@@ -1527,7 +1547,8 @@ public class ReaderBasedJsonParser
      * Method called when we have seen one zero, and want to ensure
      * it is not followed by another
      */
-    private final char _verifyNoLeadingZeroes() throws IOException {
+    private final char _verifyNoLeadingZeroes() throws IOException
+    {
         // Fast case first:
         if (_inputPtr < _inputEnd) {
             char ch = _inputBuffer[_inputPtr];
@@ -1540,7 +1561,8 @@ public class ReaderBasedJsonParser
         return _verifyNLZ2();
     }
 
-    private char _verifyNLZ2() throws IOException {
+    private char _verifyNLZ2() throws IOException
+    {
         if (_inputPtr >= _inputEnd && !_loadMore()) {
             return '0';
         }
@@ -1572,7 +1594,8 @@ public class ReaderBasedJsonParser
      * Method called if expected numeric value (due to leading sign) does not
      * look like a number
      */
-    protected JsonToken _handleInvalidNumberStart(int ch, boolean negative) throws IOException {
+    protected JsonToken _handleInvalidNumberStart(int ch, boolean negative) throws IOException
+    {
         if (ch == 'I') {
             if (_inputPtr >= _inputEnd) {
                 if (!_loadMore()) {
@@ -1581,19 +1604,19 @@ public class ReaderBasedJsonParser
             }
             ch = _inputBuffer[_inputPtr++];
             if (ch == 'N') {
-                String match = negative ? "-INF" : "+INF";
+                String match = negative ? "-INF" :"+INF";
                 _matchToken(match, 3);
                 if (isEnabled(JsonReadFeature.ALLOW_NON_NUMERIC_NUMBERS)) {
                     return resetAsNaN(match, negative ? Double.NEGATIVE_INFINITY : Double.POSITIVE_INFINITY);
                 }
-                _reportError("Non-standard token '" + match + "': enable JsonParser.Feature.ALLOW_NON_NUMERIC_NUMBERS to allow");
+                _reportError("Non-standard token '"+match+"': enable JsonParser.Feature.ALLOW_NON_NUMERIC_NUMBERS to allow");
             } else if (ch == 'n') {
-                String match = negative ? "-Infinity" : "+Infinity";
+                String match = negative ? "-Infinity" :"+Infinity";
                 _matchToken(match, 3);
                 if (isEnabled(JsonReadFeature.ALLOW_NON_NUMERIC_NUMBERS)) {
                     return resetAsNaN(match, negative ? Double.NEGATIVE_INFINITY : Double.POSITIVE_INFINITY);
                 }
-                _reportError("Non-standard token '" + match + "': enable JsonParser.Feature.ALLOW_NON_NUMERIC_NUMBERS to allow");
+                _reportError("Non-standard token '"+match+"': enable JsonParser.Feature.ALLOW_NON_NUMERIC_NUMBERS to allow");
             }
         }
         reportUnexpectedNumberChar(ch, "expected digit (0-9) to follow minus sign, for valid numeric value");
@@ -1603,24 +1626,25 @@ public class ReaderBasedJsonParser
     /**
      * Method called to ensure that a root-value is followed by a space
      * token.
-     * <p>
+     *<p>
      * NOTE: caller MUST ensure there is at least one character available;
      * and that input pointer is AT given char (not past)
      */
-    private final void _verifyRootSpace(int ch) throws IOException {
+    private final void _verifyRootSpace(int ch) throws IOException
+    {
         // caller had pushed it back, before calling; reset
         ++_inputPtr;
         switch (ch) {
-            case ' ':
-            case '\t':
-                return;
-            case '\r':
-                _skipCR();
-                return;
-            case '\n':
-                ++_currInputRow;
-                _currInputRowStart = _inputPtr;
-                return;
+        case ' ':
+        case '\t':
+            return;
+        case '\r':
+            _skipCR();
+            return;
+        case '\n':
+            ++_currInputRow;
+            _currInputRowStart = _inputPtr;
+            return;
         }
         _reportMissingRootWS(ch);
     }
@@ -1631,7 +1655,8 @@ public class ReaderBasedJsonParser
     /**********************************************************
      */
 
-    protected final String _parseName() throws IOException {
+    protected final String _parseName() throws IOException
+    {
         // First: let's try to see if we have a simple name: one that does
         // not cross input buffer boundary, and does not contain escape sequences.
         int ptr = _inputPtr;
@@ -1643,7 +1668,7 @@ public class ReaderBasedJsonParser
             if (ch < codes.length && codes[ch] != 0) {
                 if (ch == '"') {
                     int start = _inputPtr;
-                    _inputPtr = ptr + 1; // to skip the quote
+                    _inputPtr = ptr+1; // to skip the quote
                     return _symbols.findSymbol(_inputBuffer, start, ptr - start, hash);
                 }
                 break;
@@ -1656,7 +1681,8 @@ public class ReaderBasedJsonParser
         return _parseName2(start, hash, INT_QUOTE);
     }
 
-    private String _parseName2(int startPtr, int hash, int endChar) throws IOException {
+    private String _parseName2(int startPtr, int hash, int endChar) throws IOException
+    {
         _textBuffer.resetWithShared(_inputBuffer, startPtr, (_inputPtr - startPtr));
 
         /* Output pointers; calls will also ensure that the buffer is
@@ -1715,7 +1741,8 @@ public class ReaderBasedJsonParser
      * In standard mode will just throw an expection; but
      * in non-standard modes may be able to parse name.
      */
-    protected String _handleOddName(int i) throws IOException {
+    protected String _handleOddName(int i) throws IOException
+    {
         // Allow single quotes?
         if (i == '\'' && isEnabled(JsonReadFeature.ALLOW_SINGLE_QUOTES)) {
             return _parseAposName();
@@ -1747,12 +1774,12 @@ public class ReaderBasedJsonParser
                 int ch = _inputBuffer[ptr];
                 if (ch < maxCode) {
                     if (codes[ch] != 0) {
-                        int start = _inputPtr - 1; // -1 to bring back first char
+                        int start = _inputPtr-1; // -1 to bring back first char
                         _inputPtr = ptr;
                         return _symbols.findSymbol(_inputBuffer, start, ptr - start, hash);
                     }
                 } else if (!Character.isJavaIdentifierPart((char) ch)) {
-                    int start = _inputPtr - 1; // -1 to bring back first char
+                    int start = _inputPtr-1; // -1 to bring back first char
                     _inputPtr = ptr;
                     return _symbols.findSymbol(_inputBuffer, start, ptr - start, hash);
                 }
@@ -1760,12 +1787,13 @@ public class ReaderBasedJsonParser
                 ++ptr;
             } while (ptr < inputLen);
         }
-        int start = _inputPtr - 1;
+        int start = _inputPtr-1;
         _inputPtr = ptr;
         return _handleOddName2(start, hash, codes);
     }
 
-    protected String _parseAposName() throws IOException {
+    protected String _parseAposName() throws IOException
+    {
         // Note: mostly copy of_parseFieldName
         int ptr = _inputPtr;
         int hash = _hashSeed;
@@ -1779,7 +1807,7 @@ public class ReaderBasedJsonParser
                 int ch = _inputBuffer[ptr];
                 if (ch == '\'') {
                     int start = _inputPtr;
-                    _inputPtr = ptr + 1; // to skip the quote
+                    _inputPtr = ptr+1; // to skip the quote
                     return _symbols.findSymbol(_inputBuffer, start, ptr - start, hash);
                 }
                 if (ch < maxCode && codes[ch] != 0) {
@@ -1800,65 +1828,67 @@ public class ReaderBasedJsonParser
      * Method for handling cases where first non-space character
      * of an expected value token is not legal for standard JSON content.
      */
-    protected JsonToken _handleOddValue(int i) throws IOException {
+    protected JsonToken _handleOddValue(int i) throws IOException
+    {
         // Most likely an error, unless we are to allow single-quote-strings
         switch (i) {
-            case '\'':
-                /* Allow single quotes? Unlike with regular Strings, we'll eagerly parse
-                 * contents; this so that there'sno need to store information on quote char used.
-                 * Also, no separation to fast/slow parsing; we'll just do
-                 * one regular (~= slowish) parsing, to keep code simple
-                 */
-                if (isEnabled(JsonReadFeature.ALLOW_SINGLE_QUOTES)) {
-                    return _handleApos();
-                }
+        case '\'':
+            /* Allow single quotes? Unlike with regular Strings, we'll eagerly parse
+             * contents; this so that there'sno need to store information on quote char used.
+             * Also, no separation to fast/slow parsing; we'll just do
+             * one regular (~= slowish) parsing, to keep code simple
+             */
+            if (isEnabled(JsonReadFeature.ALLOW_SINGLE_QUOTES)) {
+                return _handleApos();
+            }
+            break;
+        case ']':
+            // 28-Mar-2016: [core#116]: If Feature.ALLOW_MISSING_VALUES is enabled
+            //   we may allow "missing values", that is, encountering a trailing
+            //   comma or closing marker where value would be expected
+            if (!_parsingContext.inArray()) {
                 break;
-            case ']':
-                // 28-Mar-2016: [core#116]: If Feature.ALLOW_MISSING_VALUES is enabled
-                //   we may allow "missing values", that is, encountering a trailing
-                //   comma or closing marker where value would be expected
-                if (!_parsingContext.inArray()) {
-                    break;
+            }
+            // fall through
+        case ',':
+            if ((_formatReadFeatures & FEAT_MASK_ALLOW_MISSING) != 0) {
+                --_inputPtr;
+                return JsonToken.VALUE_NULL;
+            }
+            break;
+        case 'N':
+            _matchToken("NaN", 1);
+            if (isEnabled(JsonReadFeature.ALLOW_NON_NUMERIC_NUMBERS)) {
+                return resetAsNaN("NaN", Double.NaN);
+            }
+            _reportError("Non-standard token 'NaN': enable JsonParser.Feature.ALLOW_NON_NUMERIC_NUMBERS to allow");
+            break;
+        case 'I':
+            _matchToken("Infinity", 1);
+            if (isEnabled(JsonReadFeature.ALLOW_NON_NUMERIC_NUMBERS)) {
+                return resetAsNaN("Infinity", Double.POSITIVE_INFINITY);
+            }
+            _reportError("Non-standard token 'Infinity': enable JsonParser.Feature.ALLOW_NON_NUMERIC_NUMBERS to allow");
+            break;
+        case '+': // note: '-' is taken as number
+            if (_inputPtr >= _inputEnd) {
+                if (!_loadMore()) {
+                    _reportInvalidEOFInValue(JsonToken.VALUE_NUMBER_INT);
                 }
-                // fall through
-            case ',':
-                if ((_formatReadFeatures & FEAT_MASK_ALLOW_MISSING) != 0) {
-                    --_inputPtr;
-                    return JsonToken.VALUE_NULL;
-                }
-                break;
-            case 'N':
-                _matchToken("NaN", 1);
-                if (isEnabled(JsonReadFeature.ALLOW_NON_NUMERIC_NUMBERS)) {
-                    return resetAsNaN("NaN", Double.NaN);
-                }
-                _reportError("Non-standard token 'NaN': enable JsonParser.Feature.ALLOW_NON_NUMERIC_NUMBERS to allow");
-                break;
-            case 'I':
-                _matchToken("Infinity", 1);
-                if (isEnabled(JsonReadFeature.ALLOW_NON_NUMERIC_NUMBERS)) {
-                    return resetAsNaN("Infinity", Double.POSITIVE_INFINITY);
-                }
-                _reportError("Non-standard token 'Infinity': enable JsonParser.Feature.ALLOW_NON_NUMERIC_NUMBERS to allow");
-                break;
-            case '+': // note: '-' is taken as number
-                if (_inputPtr >= _inputEnd) {
-                    if (!_loadMore()) {
-                        _reportInvalidEOFInValue(JsonToken.VALUE_NUMBER_INT);
-                    }
-                }
-                return _handleInvalidNumberStart(_inputBuffer[_inputPtr++], false);
+            }
+            return _handleInvalidNumberStart(_inputBuffer[_inputPtr++], false);
         }
         // [core#77] Try to decode most likely token
         if (Character.isJavaIdentifierStart(i)) {
-            _reportInvalidToken("" + ((char) i), "('true', 'false' or 'null')");
+            _reportInvalidToken(""+((char) i), "('true', 'false' or 'null')");
         }
         // but if it doesn't look like a token:
         _reportUnexpectedChar(i, "expected a valid value (number, String, array, object, 'true', 'false' or 'null')");
         return null;
     }
 
-    protected JsonToken _handleApos() throws IOException {
+    protected JsonToken _handleApos() throws IOException
+    {
         char[] outBuf = _textBuffer.emptyAndGetCurrentSegment();
         int outPtr = _textBuffer.getCurrentSegmentSize();
 
@@ -1899,7 +1929,8 @@ public class ReaderBasedJsonParser
         return JsonToken.VALUE_STRING;
     }
 
-    private String _handleOddName2(int startPtr, int hash, int[] codes) throws IOException {
+    private String _handleOddName2(int startPtr, int hash, int[] codes) throws IOException
+    {
         _textBuffer.resetWithShared(_inputBuffer, startPtr, (_inputPtr - startPtr));
         char[] outBuf = _textBuffer.getCurrentSegment();
         int outPtr = _textBuffer.getCurrentSegmentSize();
@@ -1942,7 +1973,8 @@ public class ReaderBasedJsonParser
         }
     }
 
-    protected final void _finishString() throws IOException {
+    protected final void _finishString() throws IOException
+    {
         /* First: let's try to see if we have simple String value: one
          * that does not cross input buffer boundary, and does not
          * contain escape sequences.
@@ -1958,8 +1990,8 @@ public class ReaderBasedJsonParser
                 int ch = _inputBuffer[ptr];
                 if (ch < maxCode && codes[ch] != 0) {
                     if (ch == '"') {
-                        _textBuffer.resetWithShared(_inputBuffer, _inputPtr, (ptr - _inputPtr));
-                        _inputPtr = ptr + 1;
+                        _textBuffer.resetWithShared(_inputBuffer, _inputPtr, (ptr-_inputPtr));
+                        _inputPtr = ptr+1;
                         // Yes, we got it all
                         return;
                     }
@@ -1970,12 +2002,13 @@ public class ReaderBasedJsonParser
         }
 
         // Either ran out of input, or bumped into an escape sequence...
-        _textBuffer.resetWithCopy(_inputBuffer, _inputPtr, (ptr - _inputPtr));
+        _textBuffer.resetWithCopy(_inputBuffer, _inputPtr, (ptr-_inputPtr));
         _inputPtr = ptr;
         _finishString2();
     }
 
-    protected void _finishString2() throws IOException {
+    protected void _finishString2() throws IOException
+    {
         char[] outBuf = _textBuffer.getCurrentSegment();
         int outPtr = _textBuffer.getCurrentSegmentSize();
         final int[] codes = _icLatin1;
@@ -2019,7 +2052,8 @@ public class ReaderBasedJsonParser
      * if it is not needed. This can be done bit faster if contents
      * need not be stored for future access.
      */
-    protected final void _skipString() throws IOException {
+    protected final void _skipString() throws IOException
+    {
         _tokenIncomplete = false;
 
         int inPtr = _inputPtr;
@@ -2043,8 +2077,7 @@ public class ReaderBasedJsonParser
                     // Although chars outside of BMP are to be escaped as an UTF-16 surrogate pair,
                     // does that affect decoding? For now let's assume it does not.
                     _inputPtr = inPtr;
-                    /*c = */
-                    _decodeEscaped();
+                    /*c = */ _decodeEscaped();
                     inPtr = _inputPtr;
                     inLen = _inputEnd;
                 } else if (i <= INT_QUOTE) {
@@ -2081,7 +2114,8 @@ public class ReaderBasedJsonParser
         _currInputRowStart = _inputPtr;
     }
 
-    private final int _skipColon() throws IOException {
+    private final int _skipColon() throws IOException
+    {
         if ((_inputPtr + 4) >= _inputEnd) {
             return _skipColon2(false);
         }
@@ -2134,7 +2168,8 @@ public class ReaderBasedJsonParser
         return _skipColon2(false);
     }
 
-    private final int _skipColon2(boolean gotColon) throws IOException {
+    private final int _skipColon2(boolean gotColon) throws IOException
+    {
         while (_inputPtr < _inputEnd || _loadMore()) {
             int i = (int) _inputBuffer[_inputPtr++];
             if (i > INT_SPACE) {
@@ -2167,13 +2202,14 @@ public class ReaderBasedJsonParser
                 }
             }
         }
-        _reportInvalidEOF(" within/between " + _parsingContext.typeDesc() + " entries",
+        _reportInvalidEOF(" within/between "+_parsingContext.typeDesc()+" entries",
                 null);
         return -1;
     }
 
     // Variant called when we know there's at least 4 more bytes available
-    private final int _skipColonFast(int ptr) throws IOException {
+    private final int _skipColonFast(int ptr) throws IOException
+    {
         int i = (int) _inputBuffer[ptr++];
         if (i == INT_COLON) { // common case, no leading space
             i = _inputBuffer[ptr++];
@@ -2191,7 +2227,7 @@ public class ReaderBasedJsonParser
                     }
                 }
             }
-            _inputPtr = ptr - 1;
+            _inputPtr = ptr-1;
             return _skipColon2(true); // true -> skipped colon
         }
         if (i == INT_SPACE || i == INT_TAB) {
@@ -2215,14 +2251,15 @@ public class ReaderBasedJsonParser
                 }
             }
         }
-        _inputPtr = ptr - 1;
+        _inputPtr = ptr-1;
         return _skipColon2(gotColon);
     }
 
     // Primary loop: no reloading, comment handling
-    private final int _skipComma(int i) throws IOException {
+    private final int _skipComma(int i) throws IOException
+    {
         if (i != INT_COMMA) {
-            _reportUnexpectedChar(i, "was expecting comma to separate " + _parsingContext.typeDesc() + " entries");
+            _reportUnexpectedChar(i, "was expecting comma to separate "+_parsingContext.typeDesc()+" entries");
         }
         while (_inputPtr < _inputEnd) {
             i = (int) _inputBuffer[_inputPtr++];
@@ -2247,7 +2284,8 @@ public class ReaderBasedJsonParser
         return _skipAfterComma2();
     }
 
-    private final int _skipAfterComma2() throws IOException {
+    private final int _skipAfterComma2() throws IOException
+    {
         while (_inputPtr < _inputEnd || _loadMore()) {
             int i = (int) _inputBuffer[_inputPtr++];
             if (i > INT_SPACE) {
@@ -2273,10 +2311,11 @@ public class ReaderBasedJsonParser
                 }
             }
         }
-        throw _constructError("Unexpected end-of-input within/between " + _parsingContext.typeDesc() + " entries");
+        throw _constructError("Unexpected end-of-input within/between "+_parsingContext.typeDesc()+" entries");
     }
 
-    private final int _skipWSOrEnd() throws IOException {
+    private final int _skipWSOrEnd() throws IOException
+    {
         // Let's handle first character separately since it is likely that
         // it is either non-whitespace; or we have longer run of white space
         if (_inputPtr >= _inputEnd) {
@@ -2326,7 +2365,8 @@ public class ReaderBasedJsonParser
         return _skipWSOrEnd2();
     }
 
-    private int _skipWSOrEnd2() throws IOException {
+    private int _skipWSOrEnd2() throws IOException
+    {
         while (true) {
             if (_inputPtr >= _inputEnd) {
                 if (!_loadMore()) { // We ran out of input...
@@ -2358,7 +2398,8 @@ public class ReaderBasedJsonParser
         }
     }
 
-    private void _skipComment() throws IOException {
+    private void _skipComment() throws IOException
+    {
         if (!isEnabled(JsonReadFeature.ALLOW_JAVA_COMMENTS)) {
             _reportUnexpectedChar('/', "maybe a (non-standard) comment? (not recognized as one since Feature 'ALLOW_COMMENTS' not enabled for parser)");
         }
@@ -2376,7 +2417,8 @@ public class ReaderBasedJsonParser
         }
     }
 
-    private void _skipCComment() throws IOException {
+    private void _skipCComment() throws IOException
+    {
         // Ok: need the matching '*/'
         while ((_inputPtr < _inputEnd) || _loadMore()) {
             int i = (int) _inputBuffer[_inputPtr++];
@@ -2406,7 +2448,8 @@ public class ReaderBasedJsonParser
         _reportInvalidEOF(" in a comment", null);
     }
 
-    private boolean _skipYAMLComment() throws IOException {
+    private boolean _skipYAMLComment() throws IOException
+    {
         if (!isEnabled(JsonReadFeature.ALLOW_YAML_COMMENTS)) {
             return false;
         }
@@ -2414,7 +2457,8 @@ public class ReaderBasedJsonParser
         return true;
     }
 
-    private void _skipLine() throws IOException {
+    private void _skipLine() throws IOException
+    {
         // Ok: need to find EOF or linefeed
         while ((_inputPtr < _inputEnd) || _loadMore()) {
             int i = (int) _inputBuffer[_inputPtr++];
@@ -2434,7 +2478,8 @@ public class ReaderBasedJsonParser
     }
 
     @Override
-    protected char _decodeEscaped() throws IOException {
+    protected char _decodeEscaped() throws IOException
+    {
         if (_inputPtr >= _inputEnd) {
             if (!_loadMore()) {
                 _reportInvalidEOF(" in character escape sequence", JsonToken.VALUE_STRING);
@@ -2444,28 +2489,28 @@ public class ReaderBasedJsonParser
 
         switch ((int) c) {
             // First, ones that are mapped
-            case 'b':
-                return '\b';
-            case 't':
-                return '\t';
-            case 'n':
-                return '\n';
-            case 'f':
-                return '\f';
-            case 'r':
-                return '\r';
+        case 'b':
+            return '\b';
+        case 't':
+            return '\t';
+        case 'n':
+            return '\n';
+        case 'f':
+            return '\f';
+        case 'r':
+            return '\r';
 
             // And these are to be returned as they are
-            case '"':
-            case '/':
-            case '\\':
-                return c;
+        case '"':
+        case '/':
+        case '\\':
+            return c;
 
-            case 'u': // and finally hex-escaped
-                break;
+        case 'u': // and finally hex-escaped
+            break;
 
-            default:
-                return _handleUnrecognizedCharacterEscape(c);
+        default:
+            return _handleUnrecognizedCharacterEscape(c);
         }
 
         // Ok, a hex escape. Need 4 characters
@@ -2537,7 +2582,8 @@ public class ReaderBasedJsonParser
     /**
      * Helper method for checking whether input matches expected token
      */
-    protected final void _matchToken(String matchStr, int i) throws IOException {
+    protected final void _matchToken(String matchStr, int i) throws IOException
+    {
         final int len = matchStr.length();
         if ((_inputPtr + len) >= _inputEnd) {
             _matchToken2(matchStr, i);
@@ -2556,16 +2602,17 @@ public class ReaderBasedJsonParser
         }
     }
 
-    private final void _matchToken2(String matchStr, int i) throws IOException {
+    private final void _matchToken2(String matchStr, int i) throws IOException
+    {
         final int len = matchStr.length();
         do {
             if (((_inputPtr >= _inputEnd) && !_loadMore())
-                    || (_inputBuffer[_inputPtr] != matchStr.charAt(i))) {
+                ||  (_inputBuffer[_inputPtr] != matchStr.charAt(i))) {
                 _reportInvalidToken(matchStr.substring(0, i));
             }
             ++_inputPtr;
         } while (++i < len);
-
+    
         // but let's also ensure we either get EOF, or non-alphanum char...
         if (_inputPtr >= _inputEnd && !_loadMore()) {
             return;
@@ -2595,7 +2642,8 @@ public class ReaderBasedJsonParser
      * textual content.
      */
     @SuppressWarnings("resource")
-    protected byte[] _decodeBase64(Base64Variant b64variant) throws IOException {
+    protected byte[] _decodeBase64(Base64Variant b64variant) throws IOException
+    {
         ByteArrayBuilder builder = _getByteArrayBuilder();
 
         //main_loop:
@@ -2662,7 +2710,7 @@ public class ReaderBasedJsonParser
                     ch = _inputBuffer[_inputPtr++];
                     if (!b64variant.usesPaddingChar(ch)) {
                         if (_decodeBase64Escape(b64variant, ch, 3) != Base64Variant.BASE64_VALUE_PADDING) {
-                            throw reportInvalidBase64Char(b64variant, ch, 3, "expected padding character '" + b64variant.getPaddingChar() + "'");
+                            throw reportInvalidBase64Char(b64variant, ch, 3, "expected padding character '"+b64variant.getPaddingChar()+"'");
                         }
                     }
                     // Got 12 bits, only need 8, need to shift
@@ -2719,14 +2767,15 @@ public class ReaderBasedJsonParser
      */
 
     @Override
-    public JsonLocation getTokenLocation() {
+    public JsonLocation getTokenLocation()
+    {
         if (_currToken == JsonToken.FIELD_NAME) {
-            long total = _currInputProcessed + (_nameStartOffset - 1);
+            long total = _currInputProcessed + (_nameStartOffset-1);
             return new JsonLocation(_getSourceReference(),
                     -1L, total, _nameStartRow, _nameStartCol);
         }
         return new JsonLocation(_getSourceReference(),
-                -1L, _tokenInputTotal - 1, _tokenInputRow, _tokenInputCol);
+                -1L, _tokenInputTotal-1, _tokenInputRow, _tokenInputCol);
     }
 
     @Override
@@ -2738,7 +2787,8 @@ public class ReaderBasedJsonParser
     }
 
     // @since 2.7
-    private final void _updateLocation() {
+    private final void _updateLocation()
+    {
         int ptr = _inputPtr;
         _tokenInputTotal = _currInputProcessed + ptr;
         _tokenInputRow = _currInputRow;
@@ -2746,7 +2796,8 @@ public class ReaderBasedJsonParser
     }
 
     // @since 2.7
-    private final void _updateNameLocation() {
+    private final void _updateNameLocation()
+    {
         int ptr = _inputPtr;
         _nameStartOffset = ptr;
         _nameStartRow = _currInputRow;
@@ -2763,7 +2814,8 @@ public class ReaderBasedJsonParser
         _reportInvalidToken(matchedPart, "'null', 'true', 'false' or NaN");
     }
 
-    protected void _reportInvalidToken(String matchedPart, String msg) throws IOException {
+    protected void _reportInvalidToken(String matchedPart, String msg) throws IOException
+    {
         /* Let's just try to find what appears to be the token, using
          * regular Java identifier character rules. It's just a heuristic,
          * nothing fancy here.

--- a/src/main/java/com/fasterxml/jackson/core/json/ReaderBasedJsonParser.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/ReaderBasedJsonParser.java
@@ -1,13 +1,6 @@
 package com.fasterxml.jackson.core.json;
 
-import com.fasterxml.jackson.core.Base64Variant;
-import com.fasterxml.jackson.core.JsonLocation;
-import com.fasterxml.jackson.core.JsonParseException;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonToken;
-import com.fasterxml.jackson.core.ObjectReadContext;
-import com.fasterxml.jackson.core.SerializableString;
-import com.fasterxml.jackson.core.StreamReadFeature;
+import com.fasterxml.jackson.core.*;
 import com.fasterxml.jackson.core.io.CharTypes;
 import com.fasterxml.jackson.core.io.IOContext;
 import com.fasterxml.jackson.core.sym.CharsToNameCanonicalizer;
@@ -19,12 +12,7 @@ import java.io.OutputStream;
 import java.io.Reader;
 import java.io.Writer;
 
-import static com.fasterxml.jackson.core.JsonTokenId.ID_FALSE;
-import static com.fasterxml.jackson.core.JsonTokenId.ID_FIELD_NAME;
-import static com.fasterxml.jackson.core.JsonTokenId.ID_NUMBER_FLOAT;
-import static com.fasterxml.jackson.core.JsonTokenId.ID_NUMBER_INT;
-import static com.fasterxml.jackson.core.JsonTokenId.ID_STRING;
-import static com.fasterxml.jackson.core.JsonTokenId.ID_TRUE;
+import static com.fasterxml.jackson.core.JsonTokenId.*;
 
 /**
  * This is a concrete implementation of {@link JsonParser}, which is
@@ -32,8 +20,7 @@ import static com.fasterxml.jackson.core.JsonTokenId.ID_TRUE;
  * conversion tasks.
  */
 public class ReaderBasedJsonParser
-    extends JsonParserBase
-{
+        extends JsonParserBase {
     private final static int FEAT_MASK_TRAILING_COMMA = JsonReadFeature.ALLOW_TRAILING_COMMA.getMask();
     private final static int FEAT_MASK_ALLOW_MISSING = JsonReadFeature.ALLOW_MISSING_VALUES.getMask();
 
@@ -63,7 +50,7 @@ public class ReaderBasedJsonParser
     /**
      * Flag that indicates whether the input buffer is recycable (and
      * needs to be returned to recycler once we are done) or not.
-     *<p>
+     * <p>
      * If it is not, it also means that parser can NOT modify underlying
      * buffer.
      */
@@ -121,11 +108,10 @@ public class ReaderBasedJsonParser
      * and it may or may not be recyclable use standard recycle context.
      */
     public ReaderBasedJsonParser(ObjectReadContext readCtxt, IOContext ctxt,
-            int stdFeatures, int formatFeatures, Reader r,
-            CharsToNameCanonicalizer st,
-            char[] inputBuffer, int start, int end,
-            boolean bufferRecyclable)
-    {
+                                 int stdFeatures, int formatFeatures, Reader r,
+                                 CharsToNameCanonicalizer st,
+                                 char[] inputBuffer, int start, int end,
+                                 boolean bufferRecyclable) {
         super(readCtxt, ctxt, stdFeatures, formatFeatures);
         _reader = r;
         _inputBuffer = inputBuffer;
@@ -141,9 +127,8 @@ public class ReaderBasedJsonParser
      * can be done using default mechanism.
      */
     public ReaderBasedJsonParser(ObjectReadContext readCtxt, IOContext ctxt,
-            int stdFeatures, int formatFeatures, Reader r,
-            CharsToNameCanonicalizer st)
-    {
+                                 int stdFeatures, int formatFeatures, Reader r,
+                                 CharsToNameCanonicalizer st) {
         super(readCtxt, ctxt, stdFeatures, formatFeatures);
         _reader = r;
         _inputBuffer = ctxt.allocTokenBuffer();
@@ -163,14 +148,19 @@ public class ReaderBasedJsonParser
     @Override
     public int releaseBuffered(Writer w) throws IOException {
         int count = _inputEnd - _inputPtr;
-        if (count < 1) { return 0; }
+        if (count < 1) {
+            return 0;
+        }
         // let's just advance ptr to end
         int origPtr = _inputPtr;
         w.write(_inputBuffer, origPtr, count);
         return count;
     }
 
-    @Override public Object getInputSource() { return _reader; }
+    @Override
+    public Object getInputSource() {
+        return _reader;
+    }
 
     protected char getNextChar(String eofMsg, JsonToken forToken) throws IOException {
         if (_inputPtr >= _inputEnd) {
@@ -226,11 +216,12 @@ public class ReaderBasedJsonParser
      */
 
     protected void _loadMoreGuaranteed() throws IOException {
-        if (!_loadMore()) { _reportInvalidEOF(); }
+        if (!_loadMore()) {
+            _reportInvalidEOF();
+        }
     }
-    
-    protected boolean _loadMore() throws IOException
-    {
+
+    protected boolean _loadMore() throws IOException {
         final int bufSize = _inputEnd;
 
         if (_reader != null) {
@@ -252,7 +243,7 @@ public class ReaderBasedJsonParser
             _closeInput();
             // Should never return 0, so let's fail
             if (count == 0) {
-                throw new IOException("Reader returned 0 characters when trying to read "+_inputEnd);
+                throw new IOException("Reader returned 0 characters when trying to read " + _inputEnd);
             }
         }
         return false;
@@ -271,8 +262,7 @@ public class ReaderBasedJsonParser
      * Method can be called for any event.
      */
     @Override
-    public final String getText() throws IOException
-    {
+    public final String getText() throws IOException {
         JsonToken t = _currToken;
         if (t == JsonToken.VALUE_STRING) {
             if (_tokenIncomplete) {
@@ -285,8 +275,7 @@ public class ReaderBasedJsonParser
     }
 
     @Override // since 2.8
-    public int getText(Writer writer) throws IOException
-    {
+    public int getText(Writer writer) throws IOException {
         JsonToken t = _currToken;
         if (t == JsonToken.VALUE_STRING) {
             if (_tokenIncomplete) {
@@ -310,13 +299,12 @@ public class ReaderBasedJsonParser
         }
         return 0;
     }
-    
+
     // // // Let's override default impls for improved performance
 
     // @since 2.1
     @Override
-    public final String getValueAsString() throws IOException
-    {
+    public final String getValueAsString() throws IOException {
         if (_currToken == JsonToken.VALUE_STRING) {
             if (_tokenIncomplete) {
                 _tokenIncomplete = false;
@@ -351,114 +339,110 @@ public class ReaderBasedJsonParser
             return null;
         }
         switch (t.id()) {
-        case ID_FIELD_NAME:
-            return _parsingContext.currentName();
+            case ID_FIELD_NAME:
+                return _parsingContext.currentName();
 
-        case ID_STRING:
-            // fall through
-        case ID_NUMBER_INT:
-        case ID_NUMBER_FLOAT:
-            return _textBuffer.contentsAsString();
-        default:
-            return t.asString();
+            case ID_STRING:
+                // fall through
+            case ID_NUMBER_INT:
+            case ID_NUMBER_FLOAT:
+                return _textBuffer.contentsAsString();
+            default:
+                return t.asString();
         }
     }
 
     @Override
-    public final char[] getTextCharacters() throws IOException
-    {
+    public final char[] getTextCharacters() throws IOException {
         if (_currToken != null) { // null only before/after document
             switch (_currToken.id()) {
-            case ID_FIELD_NAME:
-                if (!_nameCopied) {
-                    String name = _parsingContext.currentName();
-                    int nameLen = name.length();
-                    if (_nameCopyBuffer == null) {
-                        _nameCopyBuffer = _ioContext.allocNameCopyBuffer(nameLen);
-                    } else if (_nameCopyBuffer.length < nameLen) {
-                        _nameCopyBuffer = new char[nameLen];
+                case ID_FIELD_NAME:
+                    if (!_nameCopied) {
+                        String name = _parsingContext.currentName();
+                        int nameLen = name.length();
+                        if (_nameCopyBuffer == null) {
+                            _nameCopyBuffer = _ioContext.allocNameCopyBuffer(nameLen);
+                        } else if (_nameCopyBuffer.length < nameLen) {
+                            _nameCopyBuffer = new char[nameLen];
+                        }
+                        name.getChars(0, nameLen, _nameCopyBuffer, 0);
+                        _nameCopied = true;
                     }
-                    name.getChars(0, nameLen, _nameCopyBuffer, 0);
-                    _nameCopied = true;
-                }
-                return _nameCopyBuffer;
-            case ID_STRING:
-                if (_tokenIncomplete) {
-                    _tokenIncomplete = false;
-                    _finishString(); // only strings can be incomplete
-                }
-                // fall through
-            case ID_NUMBER_INT:
-            case ID_NUMBER_FLOAT:
-                return _textBuffer.getTextBuffer();
-            default:
-                return _currToken.asCharArray();
+                    return _nameCopyBuffer;
+                case ID_STRING:
+                    if (_tokenIncomplete) {
+                        _tokenIncomplete = false;
+                        _finishString(); // only strings can be incomplete
+                    }
+                    // fall through
+                case ID_NUMBER_INT:
+                case ID_NUMBER_FLOAT:
+                    return _textBuffer.getTextBuffer();
+                default:
+                    return _currToken.asCharArray();
             }
         }
         return null;
     }
 
     @Override
-    public final int getTextLength() throws IOException
-    {
+    public final int getTextLength() throws IOException {
         if (_currToken != null) { // null only before/after document
             switch (_currToken.id()) {
-            case ID_FIELD_NAME:
-                return _parsingContext.currentName().length();
-            case ID_STRING:
-                if (_tokenIncomplete) {
-                    _tokenIncomplete = false;
-                    _finishString(); // only strings can be incomplete
-                }
-                // fall through
-            case ID_NUMBER_INT:
-            case ID_NUMBER_FLOAT:
-                return _textBuffer.size();
-            default:
-                return _currToken.asCharArray().length;
+                case ID_FIELD_NAME:
+                    return _parsingContext.currentName().length();
+                case ID_STRING:
+                    if (_tokenIncomplete) {
+                        _tokenIncomplete = false;
+                        _finishString(); // only strings can be incomplete
+                    }
+                    // fall through
+                case ID_NUMBER_INT:
+                case ID_NUMBER_FLOAT:
+                    return _textBuffer.size();
+                default:
+                    return _currToken.asCharArray().length;
             }
         }
         return 0;
     }
 
     @Override
-    public final int getTextOffset() throws IOException
-    {
+    public final int getTextOffset() throws IOException {
         // Most have offset of 0, only some may have other values:
         if (_currToken != null) {
             switch (_currToken.id()) {
-            case ID_FIELD_NAME:
-                return 0;
-            case ID_STRING:
-                if (_tokenIncomplete) {
-                    _tokenIncomplete = false;
-                    _finishString(); // only strings can be incomplete
-                }
-                // fall through
-            case ID_NUMBER_INT:
-            case ID_NUMBER_FLOAT:
-                return _textBuffer.getTextOffset();
-            default:
+                case ID_FIELD_NAME:
+                    return 0;
+                case ID_STRING:
+                    if (_tokenIncomplete) {
+                        _tokenIncomplete = false;
+                        _finishString(); // only strings can be incomplete
+                    }
+                    // fall through
+                case ID_NUMBER_INT:
+                case ID_NUMBER_FLOAT:
+                    return _textBuffer.getTextOffset();
+                default:
             }
         }
         return 0;
     }
 
     @Override
-    public byte[] getBinaryValue(Base64Variant b64variant) throws IOException
-    {
+    public byte[] getBinaryValue(Base64Variant b64variant) throws IOException {
         if ((_currToken == JsonToken.VALUE_EMBEDDED_OBJECT) && (_binaryValue != null)) {
             return _binaryValue;
         }
         if (_currToken != JsonToken.VALUE_STRING) {
-            _reportError("Current token ("+_currToken+") not VALUE_STRING or VALUE_EMBEDDED_OBJECT, can not access as binary");
+            _reportError("Current token (" + _currToken + ") not VALUE_STRING or VALUE_EMBEDDED_OBJECT, can not access as binary");
         }
         // To ensure that we won't see inconsistent data, better clear up state
         if (_tokenIncomplete) {
             try {
                 _binaryValue = _decodeBase64(b64variant);
             } catch (IllegalArgumentException iae) {
-                throw _constructError("Failed to decode VALUE_STRING as base64 ("+b64variant+"): "+iae.getMessage());
+                throw _constructError("Failed to decode VALUE_STRING as base64 (" + b64variant + "): " + iae.getMessage());
             }
             // let's clear incomplete only now; allows for accessing other
             // textual content in error cases
@@ -475,8 +459,7 @@ public class ReaderBasedJsonParser
     }
 
     @Override
-    public int readBinaryValue(Base64Variant b64variant, OutputStream out) throws IOException
-    {
+    public int readBinaryValue(Base64Variant b64variant, OutputStream out) throws IOException {
         // if we have already read the token, just use whatever we may have
         if (!_tokenIncomplete || _currToken != JsonToken.VALUE_STRING) {
             byte[] b = getBinaryValue(b64variant);
@@ -492,8 +475,7 @@ public class ReaderBasedJsonParser
         }
     }
 
-    protected int _readBinary(Base64Variant b64variant, OutputStream out, byte[] buffer) throws IOException
-    {
+    protected int _readBinary(Base64Variant b64variant, OutputStream out, byte[] buffer) throws IOException {
         int outputPtr = 0;
         final int outputEnd = buffer.length - 3;
         int outputCount = 0;
@@ -569,7 +551,7 @@ public class ReaderBasedJsonParser
                     ch = _inputBuffer[_inputPtr++];
                     if (!b64variant.usesPaddingChar(ch)) {
                         if (_decodeBase64Escape(b64variant, ch, 3) != Base64Variant.BASE64_VALUE_PADDING) {
-                            throw reportInvalidBase64Char(b64variant, ch, 3, "expected padding character '"+b64variant.getPaddingChar()+"'");
+                            throw reportInvalidBase64Char(b64variant, ch, 3, "expected padding character '" + b64variant.getPaddingChar() + "'");
                         }
                     }
                     // Got 12 bits, only need 8, need to shift
@@ -636,11 +618,10 @@ public class ReaderBasedJsonParser
 
     /**
      * @return Next token from the stream, if any found, or null
-     *   to indicate end-of-input
+     * to indicate end-of-input
      */
     @Override
-    public final JsonToken nextToken() throws IOException
-    {
+    public final JsonToken nextToken() throws IOException {
         /* First: field names are special -- we will always tokenize
          * (part of) value along with field name to simplify
          * state handling. If so, can and need to use secondary token:
@@ -702,61 +683,61 @@ public class ReaderBasedJsonParser
         JsonToken t;
 
         switch (i) {
-        case '"':
-            _tokenIncomplete = true;
-            t = JsonToken.VALUE_STRING;
-            break;
-        case '[':
-            if (!inObject) {
-                _parsingContext = _parsingContext.createChildArrayContext(_tokenInputRow, _tokenInputCol);
-            }
-            t = JsonToken.START_ARRAY;
-            break;
-        case '{':
-            if (!inObject) {
-                _parsingContext = _parsingContext.createChildObjectContext(_tokenInputRow, _tokenInputCol);
-            }
-            t = JsonToken.START_OBJECT;
-            break;
-        case '}':
-            // Error: } is not valid at this point; valid closers have
-            // been handled earlier
-            _reportUnexpectedChar(i, "expected a value");
-        case 't':
-            _matchTrue();
-            t = JsonToken.VALUE_TRUE;
-            break;
-        case 'f':
-            _matchFalse();
-            t = JsonToken.VALUE_FALSE;
-            break;
-        case 'n':
-            _matchNull();
-            t = JsonToken.VALUE_NULL;
-            break;
+            case '"':
+                _tokenIncomplete = true;
+                t = JsonToken.VALUE_STRING;
+                break;
+            case '[':
+                if (!inObject) {
+                    _parsingContext = _parsingContext.createChildArrayContext(_tokenInputRow, _tokenInputCol);
+                }
+                t = JsonToken.START_ARRAY;
+                break;
+            case '{':
+                if (!inObject) {
+                    _parsingContext = _parsingContext.createChildObjectContext(_tokenInputRow, _tokenInputCol);
+                }
+                t = JsonToken.START_OBJECT;
+                break;
+            case '}':
+                // Error: } is not valid at this point; valid closers have
+                // been handled earlier
+                _reportUnexpectedChar(i, "expected a value");
+            case 't':
+                _matchTrue();
+                t = JsonToken.VALUE_TRUE;
+                break;
+            case 'f':
+                _matchFalse();
+                t = JsonToken.VALUE_FALSE;
+                break;
+            case 'n':
+                _matchNull();
+                t = JsonToken.VALUE_NULL;
+                break;
 
-        case '-':
-            /* Should we have separate handling for plus? Although
-             * it is not allowed per se, it may be erroneously used,
-             * and could be indicate by a more specific error message.
-             */
-            t = _parseNegNumber();
-            break;
-        case '0':
-        case '1':
-        case '2':
-        case '3':
-        case '4':
-        case '5':
-        case '6':
-        case '7':
-        case '8':
-        case '9':
-            t = _parsePosNumber(i);
-            break;
-        default:
-            t = _handleOddValue(i);
-            break;
+            case '-':
+                /* Should we have separate handling for plus? Although
+                 * it is not allowed per se, it may be erroneously used,
+                 * and could be indicate by a more specific error message.
+                 */
+                t = _parseNegNumber();
+                break;
+            case '0':
+            case '1':
+            case '2':
+            case '3':
+            case '4':
+            case '5':
+            case '6':
+            case '7':
+            case '8':
+            case '9':
+                t = _parsePosNumber(i);
+                break;
+            default:
+                t = _handleOddValue(i);
+                break;
         }
 
         if (inObject) {
@@ -767,14 +748,13 @@ public class ReaderBasedJsonParser
         return t;
     }
 
-    private final JsonToken _nextAfterName()
-    {
+    private final JsonToken _nextAfterName() {
         _nameCopied = false; // need to invalidate if it was copied
         JsonToken t = _nextToken;
         _nextToken = null;
 
 // !!! 16-Nov-2015, tatu: TODO: fix [databind#37], copy next location to current here
-        
+
         // Also: may need to start new context?
         if (t == JsonToken.START_ARRAY) {
             _parsingContext = _parsingContext.createChildArrayContext(_tokenInputRow, _tokenInputCol);
@@ -800,8 +780,7 @@ public class ReaderBasedJsonParser
 
     // Implemented since 2.7
     @Override
-    public boolean nextFieldName(SerializableString sstr) throws IOException
-    {
+    public boolean nextFieldName(SerializableString sstr) throws IOException {
         // // // Note: most of code below is copied from nextToken()
 
         _numTypesValid = NR_UNKNOWN;
@@ -853,14 +832,14 @@ public class ReaderBasedJsonParser
             // Require 4 more bytes for faster skipping of colon that follows name
             if ((_inputPtr + len + 4) < _inputEnd) { // maybe...
                 // first check length match by
-                final int end = _inputPtr+len;
+                final int end = _inputPtr + len;
                 if (_inputBuffer[end] == '"') {
                     int offset = 0;
                     int ptr = _inputPtr;
                     while (true) {
                         if (ptr == end) { // yes, match!
                             _parsingContext.setCurrentName(sstr.getValue());
-                            _isNextTokenNameYes(_skipColonFast(ptr+1));
+                            _isNextTokenNameYes(_skipColonFast(ptr + 1));
                             return true;
                         }
                         if (nameChars[offset] != _inputBuffer[ptr]) {
@@ -876,8 +855,7 @@ public class ReaderBasedJsonParser
     }
 
     @Override
-    public String nextFieldName() throws IOException
-    {
+    public String nextFieldName() throws IOException {
         // // // Note: this is almost a verbatim copy of nextToken() (minus comments)
 
         _numTypesValid = NR_UNKNOWN;
@@ -926,102 +904,100 @@ public class ReaderBasedJsonParser
             _nextToken = JsonToken.VALUE_STRING;
             return name;
         }
-        
+
         // Ok: we must have a value... what is it?
 
         JsonToken t;
 
         switch (i) {
-        case '-':
-            t = _parseNegNumber();
-            break;
-        case '0':
-        case '1':
-        case '2':
-        case '3':
-        case '4':
-        case '5':
-        case '6':
-        case '7':
-        case '8':
-        case '9':
-            t = _parsePosNumber(i);
-            break;
-        case 'f':
-            _matchFalse();
-            t = JsonToken.VALUE_FALSE;
-            break;
-        case 'n':
-            _matchNull();
-            t = JsonToken.VALUE_NULL;
-            break;
-        case 't':
-            _matchTrue();
-            t = JsonToken.VALUE_TRUE;
-            break;
-        case '[':
-            t = JsonToken.START_ARRAY;
-            break;
-        case '{':
-            t = JsonToken.START_OBJECT;
-            break;
-        default:
-            t = _handleOddValue(i);
-            break;
+            case '-':
+                t = _parseNegNumber();
+                break;
+            case '0':
+            case '1':
+            case '2':
+            case '3':
+            case '4':
+            case '5':
+            case '6':
+            case '7':
+            case '8':
+            case '9':
+                t = _parsePosNumber(i);
+                break;
+            case 'f':
+                _matchFalse();
+                t = JsonToken.VALUE_FALSE;
+                break;
+            case 'n':
+                _matchNull();
+                t = JsonToken.VALUE_NULL;
+                break;
+            case 't':
+                _matchTrue();
+                t = JsonToken.VALUE_TRUE;
+                break;
+            case '[':
+                t = JsonToken.START_ARRAY;
+                break;
+            case '{':
+                t = JsonToken.START_OBJECT;
+                break;
+            default:
+                t = _handleOddValue(i);
+                break;
         }
         _nextToken = t;
         return name;
     }
 
-    private final void _isNextTokenNameYes(int i) throws IOException
-    {
+    private final void _isNextTokenNameYes(int i) throws IOException {
         _currToken = JsonToken.FIELD_NAME;
         _updateLocation();
 
         switch (i) {
-        case '"':
-            _tokenIncomplete = true;
-            _nextToken = JsonToken.VALUE_STRING;
-            return;
-        case '[':
-            _nextToken = JsonToken.START_ARRAY;
-            return;
-        case '{':
-            _nextToken = JsonToken.START_OBJECT;
-            return;
-        case 't':
-            _matchToken("true", 1);
-            _nextToken = JsonToken.VALUE_TRUE;
-            return;
-        case 'f':
-            _matchToken("false", 1);
-            _nextToken = JsonToken.VALUE_FALSE;
-            return;
-        case 'n':
-            _matchToken("null", 1);
-            _nextToken = JsonToken.VALUE_NULL;
-            return;
-        case '-':
-            _nextToken = _parseNegNumber();
-            return;
-        case '0':
-        case '1':
-        case '2':
-        case '3':
-        case '4':
-        case '5':
-        case '6':
-        case '7':
-        case '8':
-        case '9':
-            _nextToken = _parsePosNumber(i);
-            return;
+            case '"':
+                _tokenIncomplete = true;
+                _nextToken = JsonToken.VALUE_STRING;
+                return;
+            case '[':
+                _nextToken = JsonToken.START_ARRAY;
+                return;
+            case '{':
+                _nextToken = JsonToken.START_OBJECT;
+                return;
+            case 't':
+                _matchToken("true", 1);
+                _nextToken = JsonToken.VALUE_TRUE;
+                return;
+            case 'f':
+                _matchToken("false", 1);
+                _nextToken = JsonToken.VALUE_FALSE;
+                return;
+            case 'n':
+                _matchToken("null", 1);
+                _nextToken = JsonToken.VALUE_NULL;
+                return;
+            case '-':
+                _nextToken = _parseNegNumber();
+                return;
+            case '0':
+            case '1':
+            case '2':
+            case '3':
+            case '4':
+            case '5':
+            case '6':
+            case '7':
+            case '8':
+            case '9':
+                _nextToken = _parsePosNumber(i);
+                return;
         }
         _nextToken = _handleOddValue(i);
     }
 
-    protected boolean _isNextTokenNameMaybe(int i, String nameToMatch) throws IOException
-    {
+    protected boolean _isNextTokenNameMaybe(int i, String nameToMatch) throws IOException {
         // // // and this is back to standard nextToken()
         String name = (i == INT_QUOTE) ? _parseName() : _handleOddName(i);
         _parsingContext.setCurrentName(name);
@@ -1036,107 +1012,106 @@ public class ReaderBasedJsonParser
         // Ok: we must have a value... what is it?
         JsonToken t;
         switch (i) {
-        case '-':
-            t = _parseNegNumber();
-            break;
-        case '0':
-        case '1':
-        case '2':
-        case '3':
-        case '4':
-        case '5':
-        case '6':
-        case '7':
-        case '8':
-        case '9':
-            t = _parsePosNumber(i);
-            break;
-        case 'f':
-            _matchFalse();
-            t = JsonToken.VALUE_FALSE;
-            break;
-        case 'n':
-            _matchNull();
-            t = JsonToken.VALUE_NULL;
-            break;
-        case 't':
-            _matchTrue();
-            t = JsonToken.VALUE_TRUE;
-            break;
-        case '[':
-            t = JsonToken.START_ARRAY;
-            break;
-        case '{':
-            t = JsonToken.START_OBJECT;
-            break;
-        default:
-            t = _handleOddValue(i);
-            break;
+            case '-':
+                t = _parseNegNumber();
+                break;
+            case '0':
+            case '1':
+            case '2':
+            case '3':
+            case '4':
+            case '5':
+            case '6':
+            case '7':
+            case '8':
+            case '9':
+                t = _parsePosNumber(i);
+                break;
+            case 'f':
+                _matchFalse();
+                t = JsonToken.VALUE_FALSE;
+                break;
+            case 'n':
+                _matchNull();
+                t = JsonToken.VALUE_NULL;
+                break;
+            case 't':
+                _matchTrue();
+                t = JsonToken.VALUE_TRUE;
+                break;
+            case '[':
+                t = JsonToken.START_ARRAY;
+                break;
+            case '{':
+                t = JsonToken.START_OBJECT;
+                break;
+            default:
+                t = _handleOddValue(i);
+                break;
         }
         _nextToken = t;
         return nameToMatch.equals(name);
     }
 
-    private final JsonToken _nextTokenNotInObject(int i) throws IOException
-    {
+    private final JsonToken _nextTokenNotInObject(int i) throws IOException {
         if (i == INT_QUOTE) {
             _tokenIncomplete = true;
             return (_currToken = JsonToken.VALUE_STRING);
         }
         switch (i) {
-        case '[':
-            _parsingContext = _parsingContext.createChildArrayContext(_tokenInputRow, _tokenInputCol);
-            return (_currToken = JsonToken.START_ARRAY);
-        case '{':
-            _parsingContext = _parsingContext.createChildObjectContext(_tokenInputRow, _tokenInputCol);
-            return (_currToken = JsonToken.START_OBJECT);
-        case 't':
-            _matchToken("true", 1);
-            return (_currToken = JsonToken.VALUE_TRUE);
-        case 'f':
-            _matchToken("false", 1);
-            return (_currToken = JsonToken.VALUE_FALSE);
-        case 'n':
-            _matchToken("null", 1);
-            return (_currToken = JsonToken.VALUE_NULL);
-        case '-':
-            return (_currToken = _parseNegNumber());
+            case '[':
+                _parsingContext = _parsingContext.createChildArrayContext(_tokenInputRow, _tokenInputCol);
+                return (_currToken = JsonToken.START_ARRAY);
+            case '{':
+                _parsingContext = _parsingContext.createChildObjectContext(_tokenInputRow, _tokenInputCol);
+                return (_currToken = JsonToken.START_OBJECT);
+            case 't':
+                _matchToken("true", 1);
+                return (_currToken = JsonToken.VALUE_TRUE);
+            case 'f':
+                _matchToken("false", 1);
+                return (_currToken = JsonToken.VALUE_FALSE);
+            case 'n':
+                _matchToken("null", 1);
+                return (_currToken = JsonToken.VALUE_NULL);
+            case '-':
+                return (_currToken = _parseNegNumber());
             /* Should we have separate handling for plus? Although
              * it is not allowed per se, it may be erroneously used,
              * and could be indicated by a more specific error message.
              */
-        case '0':
-        case '1':
-        case '2':
-        case '3':
-        case '4':
-        case '5':
-        case '6':
-        case '7':
-        case '8':
-        case '9':
-            return (_currToken = _parsePosNumber(i));
-        /*
-         * This check proceeds only if the Feature.ALLOW_MISSING_VALUES is enabled
-         * The Check is for missing values. Incase of missing values in an array, the next token will be either ',' or ']'.
-         * This case, decrements the already incremented _inputPtr in the buffer in case of comma(,) 
-         * so that the existing flow goes back to checking the next token which will be comma again and
-         * it continues the parsing.
-         * Also the case returns NULL as current token in case of ',' or ']'.    
-         */
-        case ',':
-        case ']':
-            if ((_formatReadFeatures & FEAT_MASK_ALLOW_MISSING) != 0) {
-                --_inputPtr;
-                return (_currToken = JsonToken.VALUE_NULL);  
-            }
+            case '0':
+            case '1':
+            case '2':
+            case '3':
+            case '4':
+            case '5':
+            case '6':
+            case '7':
+            case '8':
+            case '9':
+                return (_currToken = _parsePosNumber(i));
+            /*
+             * This check proceeds only if the Feature.ALLOW_MISSING_VALUES is enabled
+             * The Check is for missing values. Incase of missing values in an array, the next token will be either ',' or ']'.
+             * This case, decrements the already incremented _inputPtr in the buffer in case of comma(,)
+             * so that the existing flow goes back to checking the next token which will be comma again and
+             * it continues the parsing.
+             * Also the case returns NULL as current token in case of ',' or ']'.
+             */
+            case ',':
+            case ']':
+                if ((_formatReadFeatures & FEAT_MASK_ALLOW_MISSING) != 0) {
+                    --_inputPtr;
+                    return (_currToken = JsonToken.VALUE_NULL);
+                }
         }
         return (_currToken = _handleOddValue(i));
     }
+
     // note: identical to one in UTF8StreamJsonParser
     @Override
-    public final String nextTextValue() throws IOException
-    {
+    public final String nextTextValue() throws IOException {
         if (_currToken == JsonToken.FIELD_NAME) { // mostly copied from '_nextAfterName'
             _nameCopied = false;
             JsonToken t = _nextToken;
@@ -1162,8 +1137,7 @@ public class ReaderBasedJsonParser
 
     // note: identical to one in Utf8StreamParser
     @Override
-    public final int nextIntValue(int defaultValue) throws IOException
-    {
+    public final int nextIntValue(int defaultValue) throws IOException {
         if (_currToken == JsonToken.FIELD_NAME) {
             _nameCopied = false;
             JsonToken t = _nextToken;
@@ -1185,8 +1159,7 @@ public class ReaderBasedJsonParser
 
     // note: identical to one in Utf8StreamParser
     @Override
-    public final long nextLongValue(long defaultValue) throws IOException
-    {
+    public final long nextLongValue(long defaultValue) throws IOException {
         if (_currToken == JsonToken.FIELD_NAME) { // mostly copied from '_nextAfterName'
             _nameCopied = false;
             JsonToken t = _nextToken;
@@ -1208,8 +1181,7 @@ public class ReaderBasedJsonParser
 
     // note: identical to one in UTF8StreamJsonParser
     @Override
-    public final Boolean nextBooleanValue() throws IOException
-    {
+    public final Boolean nextBooleanValue() throws IOException {
         if (_currToken == JsonToken.FIELD_NAME) { // mostly copied from '_nextAfterName'
             _nameCopied = false;
             JsonToken t = _nextToken;
@@ -1251,22 +1223,21 @@ public class ReaderBasedJsonParser
      * as a floating point number. The basic rule is that if the number
      * has no fractional or exponential part, it is an integer; otherwise
      * a floating point number.
-     *<p>
+     * <p>
      * Because much of input has to be processed in any case, no partial
      * parsing is done: all input text will be stored for further
      * processing. However, actual numeric value conversion will be
      * deferred, since it is usually the most complicated and costliest
      * part of processing.
      */
-    protected final JsonToken _parsePosNumber(int ch) throws IOException
-    {
+    protected final JsonToken _parsePosNumber(int ch) throws IOException {
         /* Although we will always be complete with respect to textual
          * representation (that is, all characters will be parsed),
          * actual conversion to a number is deferred. Thus, need to
          * note that no representations are valid yet
          */
         int ptr = _inputPtr;
-        int startPtr = ptr-1; // to include digit already read
+        int startPtr = ptr - 1; // to include digit already read
         final int inputLen = _inputEnd;
 
         // One special case, leading zero(es):
@@ -1306,14 +1277,13 @@ public class ReaderBasedJsonParser
         if (_parsingContext.inRoot()) {
             _verifyRootSpace(ch);
         }
-        int len = ptr-startPtr;
+        int len = ptr - startPtr;
         _textBuffer.resetWithShared(_inputBuffer, startPtr, len);
         return resetInt(false, intLen);
     }
 
     private final JsonToken _parseFloat(int ch, int startPtr, int ptr, boolean neg, int intLen)
-        throws IOException
-    {
+            throws IOException {
         final int inputLen = _inputEnd;
         int fractLen = 0;
 
@@ -1369,16 +1339,15 @@ public class ReaderBasedJsonParser
         if (_parsingContext.inRoot()) {
             _verifyRootSpace(ch);
         }
-        int len = ptr-startPtr;
+        int len = ptr - startPtr;
         _textBuffer.resetWithShared(_inputBuffer, startPtr, len);
         // And there we have it!
         return resetFloat(neg, intLen, fractLen, expLen);
     }
 
-    protected final JsonToken _parseNegNumber() throws IOException
-    {
+    protected final JsonToken _parseNegNumber() throws IOException {
         int ptr = _inputPtr;
-        int startPtr = ptr-1; // to include sign/digit already read
+        int startPtr = ptr - 1; // to include sign/digit already read
         final int inputLen = _inputEnd;
 
         if (ptr >= inputLen) {
@@ -1418,7 +1387,7 @@ public class ReaderBasedJsonParser
         if (_parsingContext.inRoot()) {
             _verifyRootSpace(ch);
         }
-        int len = ptr-startPtr;
+        int len = ptr - startPtr;
         _textBuffer.resetWithShared(_inputBuffer, startPtr, len);
         return resetInt(true, intLen);
     }
@@ -1430,9 +1399,8 @@ public class ReaderBasedJsonParser
      * that it has to explicitly copy contents to the text buffer
      * instead of just sharing the main input buffer.
      */
-    private final JsonToken _parseNumber2(boolean neg, int startPtr) throws IOException
-    {
-        _inputPtr = neg ? (startPtr+1) : startPtr;
+    private final JsonToken _parseNumber2(boolean neg, int startPtr) throws IOException {
+        _inputPtr = neg ? (startPtr + 1) : startPtr;
         char[] outBuf = _textBuffer.emptyAndGetCurrentSegment();
         int outPtr = 0;
 
@@ -1513,7 +1481,7 @@ public class ReaderBasedJsonParser
             outBuf[outPtr++] = c;
             // Not optional, can require that we get one more char
             c = (_inputPtr < _inputEnd) ? _inputBuffer[_inputPtr++]
-                : getNextChar("expected a digit for number exponent", JsonToken.VALUE_NUMBER_FLOAT);
+                    : getNextChar("expected a digit for number exponent", JsonToken.VALUE_NUMBER_FLOAT);
             // Sign indicator?
             if (c == '-' || c == '+') {
                 if (outPtr >= outBuf.length) {
@@ -1523,7 +1491,7 @@ public class ReaderBasedJsonParser
                 outBuf[outPtr++] = c;
                 // Likewise, non optional:
                 c = (_inputPtr < _inputEnd) ? _inputBuffer[_inputPtr++]
-                    : getNextChar("expected a digit for number exponent", JsonToken.VALUE_NUMBER_FLOAT);
+                        : getNextChar("expected a digit for number exponent", JsonToken.VALUE_NUMBER_FLOAT);
             }
 
             exp_loop:
@@ -1562,8 +1530,7 @@ public class ReaderBasedJsonParser
      * Method called when we have seen one zero, and want to ensure
      * it is not followed by another
      */
-    private final char _verifyNoLeadingZeroes() throws IOException
-    {
+    private final char _verifyNoLeadingZeroes() throws IOException {
         // Fast case first:
         if (_inputPtr < _inputEnd) {
             char ch = _inputBuffer[_inputPtr];
@@ -1576,8 +1543,7 @@ public class ReaderBasedJsonParser
         return _verifyNLZ2();
     }
 
-    private char _verifyNLZ2() throws IOException
-    {
+    private char _verifyNLZ2() throws IOException {
         if (_inputPtr >= _inputEnd && !_loadMore()) {
             return '0';
         }
@@ -1609,8 +1575,7 @@ public class ReaderBasedJsonParser
      * Method called if expected numeric value (due to leading sign) does not
      * look like a number
      */
-    protected JsonToken _handleInvalidNumberStart(int ch, boolean negative) throws IOException
-    {
+    protected JsonToken _handleInvalidNumberStart(int ch, boolean negative) throws IOException {
         if (ch == 'I') {
             if (_inputPtr >= _inputEnd) {
                 if (!_loadMore()) {
@@ -1619,19 +1584,19 @@ public class ReaderBasedJsonParser
             }
             ch = _inputBuffer[_inputPtr++];
             if (ch == 'N') {
-                String match = negative ? "-INF" :"+INF";
+                String match = negative ? "-INF" : "+INF";
                 _matchToken(match, 3);
                 if (isEnabled(JsonReadFeature.ALLOW_NON_NUMERIC_NUMBERS)) {
                     return resetAsNaN(match, negative ? Double.NEGATIVE_INFINITY : Double.POSITIVE_INFINITY);
                 }
-                _reportError("Non-standard token '"+match+"': enable JsonParser.Feature.ALLOW_NON_NUMERIC_NUMBERS to allow");
+                _reportError("Non-standard token '" + match + "': enable JsonParser.Feature.ALLOW_NON_NUMERIC_NUMBERS to allow");
             } else if (ch == 'n') {
-                String match = negative ? "-Infinity" :"+Infinity";
+                String match = negative ? "-Infinity" : "+Infinity";
                 _matchToken(match, 3);
                 if (isEnabled(JsonReadFeature.ALLOW_NON_NUMERIC_NUMBERS)) {
                     return resetAsNaN(match, negative ? Double.NEGATIVE_INFINITY : Double.POSITIVE_INFINITY);
                 }
-                _reportError("Non-standard token '"+match+"': enable JsonParser.Feature.ALLOW_NON_NUMERIC_NUMBERS to allow");
+                _reportError("Non-standard token '" + match + "': enable JsonParser.Feature.ALLOW_NON_NUMERIC_NUMBERS to allow");
             }
         }
         reportUnexpectedNumberChar(ch, "expected digit (0-9) to follow minus sign, for valid numeric value");
@@ -1641,25 +1606,24 @@ public class ReaderBasedJsonParser
     /**
      * Method called to ensure that a root-value is followed by a space
      * token.
-     *<p>
+     * <p>
      * NOTE: caller MUST ensure there is at least one character available;
      * and that input pointer is AT given char (not past)
      */
-    private final void _verifyRootSpace(int ch) throws IOException
-    {
+    private final void _verifyRootSpace(int ch) throws IOException {
         // caller had pushed it back, before calling; reset
         ++_inputPtr;
         switch (ch) {
-        case ' ':
-        case '\t':
-            return;
-        case '\r':
-            _skipCR();
-            return;
-        case '\n':
-            ++_currInputRow;
-            _currInputRowStart = _inputPtr;
-            return;
+            case ' ':
+            case '\t':
+                return;
+            case '\r':
+                _skipCR();
+                return;
+            case '\n':
+                ++_currInputRow;
+                _currInputRowStart = _inputPtr;
+                return;
         }
         _reportMissingRootWS(ch);
     }
@@ -1670,8 +1634,7 @@ public class ReaderBasedJsonParser
     /**********************************************************
      */
 
-    protected final String _parseName() throws IOException
-    {
+    protected final String _parseName() throws IOException {
         // First: let's try to see if we have a simple name: one that does
         // not cross input buffer boundary, and does not contain escape sequences.
         int ptr = _inputPtr;
@@ -1683,7 +1646,7 @@ public class ReaderBasedJsonParser
             if (ch < codes.length && codes[ch] != 0) {
                 if (ch == '"') {
                     int start = _inputPtr;
-                    _inputPtr = ptr+1; // to skip the quote
+                    _inputPtr = ptr + 1; // to skip the quote
                     return _symbols.findSymbol(_inputBuffer, start, ptr - start, hash);
                 }
                 break;
@@ -1696,8 +1659,7 @@ public class ReaderBasedJsonParser
         return _parseName2(start, hash, INT_QUOTE);
     }
 
-    private String _parseName2(int startPtr, int hash, int endChar) throws IOException
-    {
+    private String _parseName2(int startPtr, int hash, int endChar) throws IOException {
         _textBuffer.resetWithShared(_inputBuffer, startPtr, (_inputPtr - startPtr));
 
         /* Output pointers; calls will also ensure that the buffer is
@@ -1756,8 +1718,7 @@ public class ReaderBasedJsonParser
      * In standard mode will just throw an expection; but
      * in non-standard modes may be able to parse name.
      */
-    protected String _handleOddName(int i) throws IOException
-    {
+    protected String _handleOddName(int i) throws IOException {
         // Allow single quotes?
         if (i == '\'' && isEnabled(JsonReadFeature.ALLOW_SINGLE_QUOTES)) {
             return _parseAposName();
@@ -1789,12 +1750,12 @@ public class ReaderBasedJsonParser
                 int ch = _inputBuffer[ptr];
                 if (ch < maxCode) {
                     if (codes[ch] != 0) {
-                        int start = _inputPtr-1; // -1 to bring back first char
+                        int start = _inputPtr - 1; // -1 to bring back first char
                         _inputPtr = ptr;
                         return _symbols.findSymbol(_inputBuffer, start, ptr - start, hash);
                     }
                 } else if (!Character.isJavaIdentifierPart((char) ch)) {
-                    int start = _inputPtr-1; // -1 to bring back first char
+                    int start = _inputPtr - 1; // -1 to bring back first char
                     _inputPtr = ptr;
                     return _symbols.findSymbol(_inputBuffer, start, ptr - start, hash);
                 }
@@ -1802,13 +1763,12 @@ public class ReaderBasedJsonParser
                 ++ptr;
             } while (ptr < inputLen);
         }
-        int start = _inputPtr-1;
+        int start = _inputPtr - 1;
         _inputPtr = ptr;
         return _handleOddName2(start, hash, codes);
     }
 
-    protected String _parseAposName() throws IOException
-    {
+    protected String _parseAposName() throws IOException {
         // Note: mostly copy of_parseFieldName
         int ptr = _inputPtr;
         int hash = _hashSeed;
@@ -1822,7 +1782,7 @@ public class ReaderBasedJsonParser
                 int ch = _inputBuffer[ptr];
                 if (ch == '\'') {
                     int start = _inputPtr;
-                    _inputPtr = ptr+1; // to skip the quote
+                    _inputPtr = ptr + 1; // to skip the quote
                     return _symbols.findSymbol(_inputBuffer, start, ptr - start, hash);
                 }
                 if (ch < maxCode && codes[ch] != 0) {
@@ -1843,67 +1803,65 @@ public class ReaderBasedJsonParser
      * Method for handling cases where first non-space character
      * of an expected value token is not legal for standard JSON content.
      */
-    protected JsonToken _handleOddValue(int i) throws IOException
-    {
+    protected JsonToken _handleOddValue(int i) throws IOException {
         // Most likely an error, unless we are to allow single-quote-strings
         switch (i) {
-        case '\'':
-            /* Allow single quotes? Unlike with regular Strings, we'll eagerly parse
-             * contents; this so that there'sno need to store information on quote char used.
-             * Also, no separation to fast/slow parsing; we'll just do
-             * one regular (~= slowish) parsing, to keep code simple
-             */
-            if (isEnabled(JsonReadFeature.ALLOW_SINGLE_QUOTES)) {
-                return _handleApos();
-            }
-            break;
-        case ']':
-            // 28-Mar-2016: [core#116]: If Feature.ALLOW_MISSING_VALUES is enabled
-            //   we may allow "missing values", that is, encountering a trailing
-            //   comma or closing marker where value would be expected
-            if (!_parsingContext.inArray()) {
-                break;
-            }
-            // fall through
-        case ',':
-            if ((_formatReadFeatures & FEAT_MASK_ALLOW_MISSING) != 0) {
-                --_inputPtr;
-                return JsonToken.VALUE_NULL;
-            }
-            break;
-        case 'N':
-            _matchToken("NaN", 1);
-            if (isEnabled(JsonReadFeature.ALLOW_NON_NUMERIC_NUMBERS)) {
-                return resetAsNaN("NaN", Double.NaN);
-            }
-            _reportError("Non-standard token 'NaN': enable JsonParser.Feature.ALLOW_NON_NUMERIC_NUMBERS to allow");
-            break;
-        case 'I':
-            _matchToken("Infinity", 1);
-            if (isEnabled(JsonReadFeature.ALLOW_NON_NUMERIC_NUMBERS)) {
-                return resetAsNaN("Infinity", Double.POSITIVE_INFINITY);
-            }
-            _reportError("Non-standard token 'Infinity': enable JsonParser.Feature.ALLOW_NON_NUMERIC_NUMBERS to allow");
-            break;
-        case '+': // note: '-' is taken as number
-            if (_inputPtr >= _inputEnd) {
-                if (!_loadMore()) {
-                    _reportInvalidEOFInValue(JsonToken.VALUE_NUMBER_INT);
+            case '\'':
+                /* Allow single quotes? Unlike with regular Strings, we'll eagerly parse
+                 * contents; this so that there'sno need to store information on quote char used.
+                 * Also, no separation to fast/slow parsing; we'll just do
+                 * one regular (~= slowish) parsing, to keep code simple
+                 */
+                if (isEnabled(JsonReadFeature.ALLOW_SINGLE_QUOTES)) {
+                    return _handleApos();
                 }
-            }
-            return _handleInvalidNumberStart(_inputBuffer[_inputPtr++], false);
+                break;
+            case ']':
+                // 28-Mar-2016: [core#116]: If Feature.ALLOW_MISSING_VALUES is enabled
+                //   we may allow "missing values", that is, encountering a trailing
+                //   comma or closing marker where value would be expected
+                if (!_parsingContext.inArray()) {
+                    break;
+                }
+                // fall through
+            case ',':
+                if ((_formatReadFeatures & FEAT_MASK_ALLOW_MISSING) != 0) {
+                    --_inputPtr;
+                    return JsonToken.VALUE_NULL;
+                }
+                break;
+            case 'N':
+                _matchToken("NaN", 1);
+                if (isEnabled(JsonReadFeature.ALLOW_NON_NUMERIC_NUMBERS)) {
+                    return resetAsNaN("NaN", Double.NaN);
+                }
+                _reportError("Non-standard token 'NaN': enable JsonParser.Feature.ALLOW_NON_NUMERIC_NUMBERS to allow");
+                break;
+            case 'I':
+                _matchToken("Infinity", 1);
+                if (isEnabled(JsonReadFeature.ALLOW_NON_NUMERIC_NUMBERS)) {
+                    return resetAsNaN("Infinity", Double.POSITIVE_INFINITY);
+                }
+                _reportError("Non-standard token 'Infinity': enable JsonParser.Feature.ALLOW_NON_NUMERIC_NUMBERS to allow");
+                break;
+            case '+': // note: '-' is taken as number
+                if (_inputPtr >= _inputEnd) {
+                    if (!_loadMore()) {
+                        _reportInvalidEOFInValue(JsonToken.VALUE_NUMBER_INT);
+                    }
+                }
+                return _handleInvalidNumberStart(_inputBuffer[_inputPtr++], false);
         }
         // [core#77] Try to decode most likely token
         if (Character.isJavaIdentifierStart(i)) {
-            _reportInvalidToken(""+((char) i), "('true', 'false' or 'null')");
+            _reportInvalidToken("" + ((char) i), "('true', 'false' or 'null')");
         }
         // but if it doesn't look like a token:
         _reportUnexpectedChar(i, "expected a valid value (number, String, array, object, 'true', 'false' or 'null')");
         return null;
     }
 
-    protected JsonToken _handleApos() throws IOException
-    {
+    protected JsonToken _handleApos() throws IOException {
         char[] outBuf = _textBuffer.emptyAndGetCurrentSegment();
         int outPtr = _textBuffer.getCurrentSegmentSize();
 
@@ -1944,8 +1902,7 @@ public class ReaderBasedJsonParser
         return JsonToken.VALUE_STRING;
     }
 
-    private String _handleOddName2(int startPtr, int hash, int[] codes) throws IOException
-    {
+    private String _handleOddName2(int startPtr, int hash, int[] codes) throws IOException {
         _textBuffer.resetWithShared(_inputBuffer, startPtr, (_inputPtr - startPtr));
         char[] outBuf = _textBuffer.getCurrentSegment();
         int outPtr = _textBuffer.getCurrentSegmentSize();
@@ -1988,8 +1945,7 @@ public class ReaderBasedJsonParser
         }
     }
 
-    protected final void _finishString() throws IOException
-    {
+    protected final void _finishString() throws IOException {
         /* First: let's try to see if we have simple String value: one
          * that does not cross input buffer boundary, and does not
          * contain escape sequences.
@@ -2005,8 +1961,8 @@ public class ReaderBasedJsonParser
                 int ch = _inputBuffer[ptr];
                 if (ch < maxCode && codes[ch] != 0) {
                     if (ch == '"') {
-                        _textBuffer.resetWithShared(_inputBuffer, _inputPtr, (ptr-_inputPtr));
-                        _inputPtr = ptr+1;
+                        _textBuffer.resetWithShared(_inputBuffer, _inputPtr, (ptr - _inputPtr));
+                        _inputPtr = ptr + 1;
                         // Yes, we got it all
                         return;
                     }
@@ -2017,13 +1973,12 @@ public class ReaderBasedJsonParser
         }
 
         // Either ran out of input, or bumped into an escape sequence...
-        _textBuffer.resetWithCopy(_inputBuffer, _inputPtr, (ptr-_inputPtr));
+        _textBuffer.resetWithCopy(_inputBuffer, _inputPtr, (ptr - _inputPtr));
         _inputPtr = ptr;
         _finishString2();
     }
 
-    protected void _finishString2() throws IOException
-    {
+    protected void _finishString2() throws IOException {
         char[] outBuf = _textBuffer.getCurrentSegment();
         int outPtr = _textBuffer.getCurrentSegmentSize();
         final int[] codes = _icLatin1;
@@ -2067,8 +2022,7 @@ public class ReaderBasedJsonParser
      * if it is not needed. This can be done bit faster if contents
      * need not be stored for future access.
      */
-    protected final void _skipString() throws IOException
-    {
+    protected final void _skipString() throws IOException {
         _tokenIncomplete = false;
 
         int inPtr = _inputPtr;
@@ -2092,7 +2046,8 @@ public class ReaderBasedJsonParser
                     // Although chars outside of BMP are to be escaped as an UTF-16 surrogate pair,
                     // does that affect decoding? For now let's assume it does not.
                     _inputPtr = inPtr;
-                    /*c = */ _decodeEscaped();
+                    /*c = */
+                    _decodeEscaped();
                     inPtr = _inputPtr;
                     inLen = _inputEnd;
                 } else if (i <= INT_QUOTE) {
@@ -2129,8 +2084,7 @@ public class ReaderBasedJsonParser
         _currInputRowStart = _inputPtr;
     }
 
-    private final int _skipColon() throws IOException
-    {
+    private final int _skipColon() throws IOException {
         if ((_inputPtr + 4) >= _inputEnd) {
             return _skipColon2(false);
         }
@@ -2183,8 +2137,7 @@ public class ReaderBasedJsonParser
         return _skipColon2(false);
     }
 
-    private final int _skipColon2(boolean gotColon) throws IOException
-    {
+    private final int _skipColon2(boolean gotColon) throws IOException {
         while (_inputPtr < _inputEnd || _loadMore()) {
             int i = (int) _inputBuffer[_inputPtr++];
             if (i > INT_SPACE) {
@@ -2217,14 +2170,13 @@ public class ReaderBasedJsonParser
                 }
             }
         }
-        _reportInvalidEOF(" within/between "+_parsingContext.typeDesc()+" entries",
+        _reportInvalidEOF(" within/between " + _parsingContext.typeDesc() + " entries",
                 null);
         return -1;
     }
 
     // Variant called when we know there's at least 4 more bytes available
-    private final int _skipColonFast(int ptr) throws IOException
-    {
+    private final int _skipColonFast(int ptr) throws IOException {
         int i = (int) _inputBuffer[ptr++];
         if (i == INT_COLON) { // common case, no leading space
             i = _inputBuffer[ptr++];
@@ -2242,7 +2194,7 @@ public class ReaderBasedJsonParser
                     }
                 }
             }
-            _inputPtr = ptr-1;
+            _inputPtr = ptr - 1;
             return _skipColon2(true); // true -> skipped colon
         }
         if (i == INT_SPACE || i == INT_TAB) {
@@ -2266,15 +2218,14 @@ public class ReaderBasedJsonParser
                 }
             }
         }
-        _inputPtr = ptr-1;
+        _inputPtr = ptr - 1;
         return _skipColon2(gotColon);
     }
 
     // Primary loop: no reloading, comment handling
-    private final int _skipComma(int i) throws IOException
-    {
+    private final int _skipComma(int i) throws IOException {
         if (i != INT_COMMA) {
-            _reportUnexpectedChar(i, "was expecting comma to separate "+_parsingContext.typeDesc()+" entries");
+            _reportUnexpectedChar(i, "was expecting comma to separate " + _parsingContext.typeDesc() + " entries");
         }
         while (_inputPtr < _inputEnd) {
             i = (int) _inputBuffer[_inputPtr++];
@@ -2299,8 +2250,7 @@ public class ReaderBasedJsonParser
         return _skipAfterComma2();
     }
 
-    private final int _skipAfterComma2() throws IOException
-    {
+    private final int _skipAfterComma2() throws IOException {
         while (_inputPtr < _inputEnd || _loadMore()) {
             int i = (int) _inputBuffer[_inputPtr++];
             if (i > INT_SPACE) {
@@ -2326,11 +2276,10 @@ public class ReaderBasedJsonParser
                 }
             }
         }
-        throw _constructError("Unexpected end-of-input within/between "+_parsingContext.typeDesc()+" entries");
+        throw _constructError("Unexpected end-of-input within/between " + _parsingContext.typeDesc() + " entries");
     }
 
-    private final int _skipWSOrEnd() throws IOException
-    {
+    private final int _skipWSOrEnd() throws IOException {
         // Let's handle first character separately since it is likely that
         // it is either non-whitespace; or we have longer run of white space
         if (_inputPtr >= _inputEnd) {
@@ -2380,8 +2329,7 @@ public class ReaderBasedJsonParser
         return _skipWSOrEnd2();
     }
 
-    private int _skipWSOrEnd2() throws IOException
-    {
+    private int _skipWSOrEnd2() throws IOException {
         while (true) {
             if (_inputPtr >= _inputEnd) {
                 if (!_loadMore()) { // We ran out of input...
@@ -2413,8 +2361,7 @@ public class ReaderBasedJsonParser
         }
     }
 
-    private void _skipComment() throws IOException
-    {
+    private void _skipComment() throws IOException {
         if (!isEnabled(JsonReadFeature.ALLOW_JAVA_COMMENTS)) {
             _reportUnexpectedChar('/', "maybe a (non-standard) comment? (not recognized as one since Feature 'ALLOW_COMMENTS' not enabled for parser)");
         }
@@ -2432,8 +2379,7 @@ public class ReaderBasedJsonParser
         }
     }
 
-    private void _skipCComment() throws IOException
-    {
+    private void _skipCComment() throws IOException {
         // Ok: need the matching '*/'
         while ((_inputPtr < _inputEnd) || _loadMore()) {
             int i = (int) _inputBuffer[_inputPtr++];
@@ -2463,8 +2409,7 @@ public class ReaderBasedJsonParser
         _reportInvalidEOF(" in a comment", null);
     }
 
-    private boolean _skipYAMLComment() throws IOException
-    {
+    private boolean _skipYAMLComment() throws IOException {
         if (!isEnabled(JsonReadFeature.ALLOW_YAML_COMMENTS)) {
             return false;
         }
@@ -2472,8 +2417,7 @@ public class ReaderBasedJsonParser
         return true;
     }
 
-    private void _skipLine() throws IOException
-    {
+    private void _skipLine() throws IOException {
         // Ok: need to find EOF or linefeed
         while ((_inputPtr < _inputEnd) || _loadMore()) {
             int i = (int) _inputBuffer[_inputPtr++];
@@ -2493,8 +2437,7 @@ public class ReaderBasedJsonParser
     }
 
     @Override
-    protected char _decodeEscaped() throws IOException
-    {
+    protected char _decodeEscaped() throws IOException {
         if (_inputPtr >= _inputEnd) {
             if (!_loadMore()) {
                 _reportInvalidEOF(" in character escape sequence", JsonToken.VALUE_STRING);
@@ -2504,28 +2447,28 @@ public class ReaderBasedJsonParser
 
         switch ((int) c) {
             // First, ones that are mapped
-        case 'b':
-            return '\b';
-        case 't':
-            return '\t';
-        case 'n':
-            return '\n';
-        case 'f':
-            return '\f';
-        case 'r':
-            return '\r';
+            case 'b':
+                return '\b';
+            case 't':
+                return '\t';
+            case 'n':
+                return '\n';
+            case 'f':
+                return '\f';
+            case 'r':
+                return '\r';
 
             // And these are to be returned as they are
-        case '"':
-        case '/':
-        case '\\':
-            return c;
+            case '"':
+            case '/':
+            case '\\':
+                return c;
 
-        case 'u': // and finally hex-escaped
-            break;
+            case 'u': // and finally hex-escaped
+                break;
 
-        default:
-            return _handleUnrecognizedCharacterEscape(c);
+            default:
+                return _handleUnrecognizedCharacterEscape(c);
         }
 
         // Ok, a hex escape. Need 4 characters
@@ -2597,8 +2540,7 @@ public class ReaderBasedJsonParser
     /**
      * Helper method for checking whether input matches expected token
      */
-    protected final void _matchToken(String matchStr, int i) throws IOException
-    {
+    protected final void _matchToken(String matchStr, int i) throws IOException {
         final int len = matchStr.length();
         if ((_inputPtr + len) >= _inputEnd) {
             _matchToken2(matchStr, i);
@@ -2617,17 +2559,16 @@ public class ReaderBasedJsonParser
         }
     }
 
-    private final void _matchToken2(String matchStr, int i) throws IOException
-    {
+    private final void _matchToken2(String matchStr, int i) throws IOException {
         final int len = matchStr.length();
         do {
             if (((_inputPtr >= _inputEnd) && !_loadMore())
-                ||  (_inputBuffer[_inputPtr] != matchStr.charAt(i))) {
+                    || (_inputBuffer[_inputPtr] != matchStr.charAt(i))) {
                 _reportInvalidToken(matchStr.substring(0, i));
             }
             ++_inputPtr;
         } while (++i < len);
-    
+
         // but let's also ensure we either get EOF, or non-alphanum char...
         if (_inputPtr >= _inputEnd && !_loadMore()) {
             return;
@@ -2657,8 +2598,7 @@ public class ReaderBasedJsonParser
      * textual content.
      */
     @SuppressWarnings("resource")
-    protected byte[] _decodeBase64(Base64Variant b64variant) throws IOException
-    {
+    protected byte[] _decodeBase64(Base64Variant b64variant) throws IOException {
         ByteArrayBuilder builder = _getByteArrayBuilder();
 
         //main_loop:
@@ -2725,7 +2665,7 @@ public class ReaderBasedJsonParser
                     ch = _inputBuffer[_inputPtr++];
                     if (!b64variant.usesPaddingChar(ch)) {
                         if (_decodeBase64Escape(b64variant, ch, 3) != Base64Variant.BASE64_VALUE_PADDING) {
-                            throw reportInvalidBase64Char(b64variant, ch, 3, "expected padding character '"+b64variant.getPaddingChar()+"'");
+                            throw reportInvalidBase64Char(b64variant, ch, 3, "expected padding character '" + b64variant.getPaddingChar() + "'");
                         }
                     }
                     // Got 12 bits, only need 8, need to shift
@@ -2782,15 +2722,14 @@ public class ReaderBasedJsonParser
      */
 
     @Override
-    public JsonLocation getTokenLocation()
-    {
+    public JsonLocation getTokenLocation() {
         if (_currToken == JsonToken.FIELD_NAME) {
-            long total = _currInputProcessed + (_nameStartOffset-1);
+            long total = _currInputProcessed + (_nameStartOffset - 1);
             return new JsonLocation(_getSourceReference(),
                     -1L, total, _nameStartRow, _nameStartCol);
         }
         return new JsonLocation(_getSourceReference(),
-                -1L, _tokenInputTotal-1, _tokenInputRow, _tokenInputCol);
+                -1L, _tokenInputTotal - 1, _tokenInputRow, _tokenInputCol);
     }
 
     @Override
@@ -2802,8 +2741,7 @@ public class ReaderBasedJsonParser
     }
 
     // @since 2.7
-    private final void _updateLocation()
-    {
+    private final void _updateLocation() {
         int ptr = _inputPtr;
         _tokenInputTotal = _currInputProcessed + ptr;
         _tokenInputRow = _currInputRow;
@@ -2811,8 +2749,7 @@ public class ReaderBasedJsonParser
     }
 
     // @since 2.7
-    private final void _updateNameLocation()
-    {
+    private final void _updateNameLocation() {
         int ptr = _inputPtr;
         _nameStartOffset = ptr;
         _nameStartRow = _currInputRow;
@@ -2829,8 +2766,7 @@ public class ReaderBasedJsonParser
         _reportInvalidToken(matchedPart, "'null', 'true', 'false' or NaN");
     }
 
-    protected void _reportInvalidToken(String matchedPart, String msg) throws IOException
-    {
+    protected void _reportInvalidToken(String matchedPart, String msg) throws IOException {
         /* Let's just try to find what appears to be the token, using
          * regular Java identifier character rules. It's just a heuristic,
          * nothing fancy here.

--- a/src/main/java/com/fasterxml/jackson/core/json/ReaderBasedJsonParser.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/ReaderBasedJsonParser.java
@@ -1,16 +1,13 @@
 package com.fasterxml.jackson.core.json;
 
+import java.io.*;
+
 import com.fasterxml.jackson.core.*;
 import com.fasterxml.jackson.core.io.CharTypes;
 import com.fasterxml.jackson.core.io.IOContext;
 import com.fasterxml.jackson.core.sym.CharsToNameCanonicalizer;
 import com.fasterxml.jackson.core.util.ByteArrayBuilder;
 import com.fasterxml.jackson.core.util.TextBuffer;
-
-import java.io.IOException;
-import java.io.OutputStream;
-import java.io.Reader;
-import java.io.Writer;
 
 import static com.fasterxml.jackson.core.JsonTokenId.*;
 

--- a/src/main/java/com/fasterxml/jackson/core/json/ReaderBasedJsonParser.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/ReaderBasedJsonParser.java
@@ -1,14 +1,30 @@
 package com.fasterxml.jackson.core.json;
 
-import java.io.*;
-
-import com.fasterxml.jackson.core.*;
+import com.fasterxml.jackson.core.Base64Variant;
+import com.fasterxml.jackson.core.JsonLocation;
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.core.ObjectReadContext;
+import com.fasterxml.jackson.core.SerializableString;
+import com.fasterxml.jackson.core.StreamReadFeature;
 import com.fasterxml.jackson.core.io.CharTypes;
 import com.fasterxml.jackson.core.io.IOContext;
 import com.fasterxml.jackson.core.sym.CharsToNameCanonicalizer;
-import com.fasterxml.jackson.core.util.*;
+import com.fasterxml.jackson.core.util.ByteArrayBuilder;
+import com.fasterxml.jackson.core.util.TextBuffer;
 
-import static com.fasterxml.jackson.core.JsonTokenId.*;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.Reader;
+import java.io.Writer;
+
+import static com.fasterxml.jackson.core.JsonTokenId.ID_FALSE;
+import static com.fasterxml.jackson.core.JsonTokenId.ID_FIELD_NAME;
+import static com.fasterxml.jackson.core.JsonTokenId.ID_NUMBER_FLOAT;
+import static com.fasterxml.jackson.core.JsonTokenId.ID_NUMBER_INT;
+import static com.fasterxml.jackson.core.JsonTokenId.ID_STRING;
+import static com.fasterxml.jackson.core.JsonTokenId.ID_TRUE;
 
 /**
  * This is a concrete implementation of {@link JsonParser}, which is
@@ -217,19 +233,19 @@ public class ReaderBasedJsonParser
     {
         final int bufSize = _inputEnd;
 
-        _currInputProcessed += bufSize;
-        _currInputRowStart -= bufSize;
-
-        // 26-Nov-2015, tatu: Since name-offset requires it too, must offset
-        //   this increase to avoid "moving" name-offset, resulting most likely
-        //   in negative value, which is fine as combine value remains unchanged.
-        _nameStartOffset -= bufSize;
-
         if (_reader != null) {
             int count = _reader.read(_inputBuffer, 0, _inputBuffer.length);
             if (count > 0) {
                 _inputPtr = 0;
                 _inputEnd = count;
+                _currInputProcessed += bufSize;
+                _currInputRowStart -= bufSize;
+
+                // 26-Nov-2015, tatu: Since name-offset requires it too, must offset
+                //   this increase to avoid "moving" name-offset, resulting most likely
+                //   in negative value, which is fine as combine value remains unchanged.
+                _nameStartOffset -= bufSize;
+
                 return true;
             }
             // End of input

--- a/src/main/java/com/fasterxml/jackson/core/json/UTF8StreamJsonParser.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/UTF8StreamJsonParser.java
@@ -7,7 +7,7 @@ import com.fasterxml.jackson.core.io.CharTypes;
 import com.fasterxml.jackson.core.io.IOContext;
 import com.fasterxml.jackson.core.sym.ByteQuadsCanonicalizer;
 import com.fasterxml.jackson.core.sym.FieldNameMatcher;
-import com.fasterxml.jackson.core.util.ByteArrayBuilder;
+import com.fasterxml.jackson.core.util.*;
 
 import static com.fasterxml.jackson.core.JsonTokenId.*;
 
@@ -16,7 +16,8 @@ import static com.fasterxml.jackson.core.JsonTokenId.*;
  * based on a {@link java.io.InputStream} as the input source.
  */
 public class UTF8StreamJsonParser
-        extends JsonParserBase {
+    extends JsonParserBase
+{
     final static byte BYTE_LF = (byte) '\n';
 
     private final static int FEAT_MASK_TRAILING_COMMA = JsonReadFeature.ALLOW_TRAILING_COMMA.getMask();
@@ -67,14 +68,14 @@ public class UTF8StreamJsonParser
      * Temporary input pointer
      */
     private int _quadPtr;
-
+    
     /**
      * Value of {@link #_inputPtr} at the time when the first character of
      * name token was read. Used for calculating token location when requested;
      * combined with {@link #_currInputProcessed}, may be updated appropriately
      * as needed.
      */
-    protected int _nameStartOffset;
+    protected int _nameStartOffset; 
 
     protected int _nameStartRow;
 
@@ -104,7 +105,7 @@ public class UTF8StreamJsonParser
     /**
      * Flag that indicates whether the input buffer is recycable (and
      * needs to be returned to recycler once we are done) or not.
-     * <p>
+     *<p>
      * If it is not, it also means that parser can NOT modify underlying
      * buffer.
      */
@@ -132,11 +133,12 @@ public class UTF8StreamJsonParser
     */
 
     public UTF8StreamJsonParser(ObjectReadContext readCtxt, IOContext ctxt,
-                                int stdFeatures, int formatReadFeatures,
-                                InputStream in,
-                                ByteQuadsCanonicalizer sym,
-                                byte[] inputBuffer, int start, int end, int bytesPreProcessed,
-                                boolean bufferRecyclable) {
+            int stdFeatures, int formatReadFeatures,
+            InputStream in,
+            ByteQuadsCanonicalizer sym,
+            byte[] inputBuffer, int start, int end, int bytesPreProcessed,
+            boolean bufferRecyclable)
+    {
         super(readCtxt, ctxt, stdFeatures, formatReadFeatures);
         _inputStream = in;
         _symbols = sym;
@@ -156,7 +158,8 @@ public class UTF8StreamJsonParser
      */
 
     @Override
-    public int releaseBuffered(OutputStream out) throws IOException {
+    public int releaseBuffered(OutputStream out) throws IOException
+    {
         int count = _inputEnd - _inputPtr;
         if (count < 1) {
             return 0;
@@ -178,7 +181,8 @@ public class UTF8StreamJsonParser
     /**********************************************************
      */
 
-    protected final boolean _loadMore() throws IOException {
+    protected final boolean _loadMore() throws IOException
+    {
         final int bufSize = _inputEnd;
 
         if (_inputStream != null) {
@@ -186,7 +190,7 @@ public class UTF8StreamJsonParser
             if (space == 0) { // only occurs when we've been closed
                 return false;
             }
-
+            
             int count = _inputStream.read(_inputBuffer, 0, space);
             if (count > 0) {
                 _inputPtr = 0;
@@ -206,14 +210,15 @@ public class UTF8StreamJsonParser
             _closeInput();
             // Should never return 0, so let's fail
             if (count == 0) {
-                throw new IOException("InputStream.read() returned 0 characters when trying to read " + _inputBuffer.length + " bytes");
+                throw new IOException("InputStream.read() returned 0 characters when trying to read "+_inputBuffer.length+" bytes");
             }
         }
         return false;
     }
 
     @Override
-    protected void _closeInput() throws IOException {
+    protected void _closeInput() throws IOException
+    {
         // We are not to call close() on the underlying InputStream
         // unless we "own" it, or auto-closing feature is enabled.
         if (_inputStream != null) {
@@ -231,7 +236,8 @@ public class UTF8StreamJsonParser
      * separately (if need be).
      */
     @Override
-    protected void _releaseBuffers() throws IOException {
+    protected void _releaseBuffers() throws IOException
+    {
         super._releaseBuffers();
         // Merge found symbols, if any:
         _symbols.release();
@@ -253,7 +259,8 @@ public class UTF8StreamJsonParser
      */
 
     @Override
-    public String getText() throws IOException {
+    public String getText() throws IOException
+    {
         if (_currToken == JsonToken.VALUE_STRING) {
             if (_tokenIncomplete) {
                 _tokenIncomplete = false;
@@ -265,7 +272,8 @@ public class UTF8StreamJsonParser
     }
 
     @Override
-    public int getText(Writer writer) throws IOException {
+    public int getText(Writer writer) throws IOException
+    {
         JsonToken t = _currToken;
         if (t == JsonToken.VALUE_STRING) {
             if (_tokenIncomplete) {
@@ -293,7 +301,8 @@ public class UTF8StreamJsonParser
     // // // Let's override default impls for improved performance
 
     @Override
-    public String getValueAsString() throws IOException {
+    public String getValueAsString() throws IOException
+    {
         if (_currToken == JsonToken.VALUE_STRING) {
             if (_tokenIncomplete) {
                 _tokenIncomplete = false;
@@ -308,7 +317,8 @@ public class UTF8StreamJsonParser
     }
 
     @Override
-    public String getValueAsString(String defValue) throws IOException {
+    public String getValueAsString(String defValue) throws IOException
+    {
         if (_currToken == JsonToken.VALUE_STRING) {
             if (_tokenIncomplete) {
                 _tokenIncomplete = false;
@@ -324,7 +334,8 @@ public class UTF8StreamJsonParser
 
     // since 2.6
     @Override
-    public int getValueAsInt() throws IOException {
+    public int getValueAsInt() throws IOException
+    {
         JsonToken t = _currToken;
         if ((t == JsonToken.VALUE_NUMBER_INT) || (t == JsonToken.VALUE_NUMBER_FLOAT)) {
             // inlined 'getIntValue()'
@@ -343,7 +354,8 @@ public class UTF8StreamJsonParser
 
     // since 2.6
     @Override
-    public int getValueAsInt(int defValue) throws IOException {
+    public int getValueAsInt(int defValue) throws IOException
+    {
         JsonToken t = _currToken;
         if ((t == JsonToken.VALUE_NUMBER_INT) || (t == JsonToken.VALUE_NUMBER_FLOAT)) {
             // inlined 'getIntValue()'
@@ -360,118 +372,123 @@ public class UTF8StreamJsonParser
         return super.getValueAsInt(defValue);
     }
 
-    protected final String _getText2(JsonToken t) {
+    protected final String _getText2(JsonToken t)
+    {
         if (t == null) {
             return null;
         }
         switch (t.id()) {
-            case ID_FIELD_NAME:
-                return _parsingContext.currentName();
+        case ID_FIELD_NAME:
+            return _parsingContext.currentName();
 
-            case ID_STRING:
-                // fall through
-            case ID_NUMBER_INT:
-            case ID_NUMBER_FLOAT:
-                return _textBuffer.contentsAsString();
-            default:
-                return t.asString();
+        case ID_STRING:
+            // fall through
+        case ID_NUMBER_INT:
+        case ID_NUMBER_FLOAT:
+            return _textBuffer.contentsAsString();
+        default:
+        	return t.asString();
         }
     }
 
     @Override
-    public char[] getTextCharacters() throws IOException {
+    public char[] getTextCharacters() throws IOException
+    {
         if (_currToken != null) { // null only before/after document
             switch (_currToken.id()) {
-
-                case ID_FIELD_NAME:
-                    if (!_nameCopied) {
-                        String name = _parsingContext.currentName();
-                        int nameLen = name.length();
-                        if (_nameCopyBuffer == null) {
-                            _nameCopyBuffer = _ioContext.allocNameCopyBuffer(nameLen);
-                        } else if (_nameCopyBuffer.length < nameLen) {
-                            _nameCopyBuffer = new char[nameLen];
-                        }
-                        name.getChars(0, nameLen, _nameCopyBuffer, 0);
-                        _nameCopied = true;
+                
+            case ID_FIELD_NAME:
+                if (!_nameCopied) {
+                    String name = _parsingContext.currentName();
+                    int nameLen = name.length();
+                    if (_nameCopyBuffer == null) {
+                        _nameCopyBuffer = _ioContext.allocNameCopyBuffer(nameLen);
+                    } else if (_nameCopyBuffer.length < nameLen) {
+                        _nameCopyBuffer = new char[nameLen];
                     }
-                    return _nameCopyBuffer;
-
-                case ID_STRING:
-                    if (_tokenIncomplete) {
-                        _tokenIncomplete = false;
-                        _finishString(); // only strings can be incomplete
-                    }
-                    // fall through
-                case ID_NUMBER_INT:
-                case ID_NUMBER_FLOAT:
-                    return _textBuffer.getTextBuffer();
-
-                default:
-                    return _currToken.asCharArray();
+                    name.getChars(0, nameLen, _nameCopyBuffer, 0);
+                    _nameCopied = true;
+                }
+                return _nameCopyBuffer;
+    
+            case ID_STRING:
+                if (_tokenIncomplete) {
+                    _tokenIncomplete = false;
+                    _finishString(); // only strings can be incomplete
+                }
+                // fall through
+            case ID_NUMBER_INT:
+            case ID_NUMBER_FLOAT:
+                return _textBuffer.getTextBuffer();
+                
+            default:
+                return _currToken.asCharArray();
             }
         }
         return null;
     }
 
     @Override
-    public int getTextLength() throws IOException {
+    public int getTextLength() throws IOException
+    {
         if (_currToken != null) { // null only before/after document
             switch (_currToken.id()) {
-
-                case ID_FIELD_NAME:
-                    return _parsingContext.currentName().length();
-                case ID_STRING:
-                    if (_tokenIncomplete) {
-                        _tokenIncomplete = false;
-                        _finishString(); // only strings can be incomplete
-                    }
-                    // fall through
-                case ID_NUMBER_INT:
-                case ID_NUMBER_FLOAT:
-                    return _textBuffer.size();
-
-                default:
-                    return _currToken.asCharArray().length;
+                
+            case ID_FIELD_NAME:
+                return _parsingContext.currentName().length();
+            case ID_STRING:
+                if (_tokenIncomplete) {
+                    _tokenIncomplete = false;
+                    _finishString(); // only strings can be incomplete
+                }
+                // fall through
+            case ID_NUMBER_INT:
+            case ID_NUMBER_FLOAT:
+                return _textBuffer.size();
+                
+            default:
+                return _currToken.asCharArray().length;
             }
         }
         return 0;
     }
 
     @Override
-    public int getTextOffset() throws IOException {
+    public int getTextOffset() throws IOException
+    {
         // Most have offset of 0, only some may have other values:
         if (_currToken != null) {
             switch (_currToken.id()) {
-                case ID_FIELD_NAME:
-                    return 0;
-                case ID_STRING:
-                    if (_tokenIncomplete) {
-                        _tokenIncomplete = false;
-                        _finishString(); // only strings can be incomplete
-                    }
-                    // fall through
-                case ID_NUMBER_INT:
-                case ID_NUMBER_FLOAT:
-                    return _textBuffer.getTextOffset();
-                default:
+            case ID_FIELD_NAME:
+                return 0;
+            case ID_STRING:
+                if (_tokenIncomplete) {
+                    _tokenIncomplete = false;
+                    _finishString(); // only strings can be incomplete
+                }
+                // fall through
+            case ID_NUMBER_INT:
+            case ID_NUMBER_FLOAT:
+                return _textBuffer.getTextOffset();
+            default:
             }
         }
         return 0;
     }
 
     @Override
-    public byte[] getBinaryValue(Base64Variant b64variant) throws IOException {
+    public byte[] getBinaryValue(Base64Variant b64variant) throws IOException
+    {
         if (_currToken != JsonToken.VALUE_STRING &&
                 (_currToken != JsonToken.VALUE_EMBEDDED_OBJECT || _binaryValue == null)) {
-            _reportError("Current token (" + _currToken + ") not VALUE_STRING or VALUE_EMBEDDED_OBJECT, can not access as binary");
+            _reportError("Current token ("+_currToken+") not VALUE_STRING or VALUE_EMBEDDED_OBJECT, can not access as binary");
         }
         // To ensure that we won't see inconsistent data, better clear up state...
         if (_tokenIncomplete) {
             try {
                 _binaryValue = _decodeBase64(b64variant);
             } catch (IllegalArgumentException iae) {
-                throw _constructError("Failed to decode VALUE_STRING as base64 (" + b64variant + "): " + iae.getMessage());
+                throw _constructError("Failed to decode VALUE_STRING as base64 ("+b64variant+"): "+iae.getMessage());
             }
             // let's clear incomplete only now; allows for accessing other textual content in error cases
             _tokenIncomplete = false;
@@ -487,7 +504,8 @@ public class UTF8StreamJsonParser
     }
 
     @Override
-    public int readBinaryValue(Base64Variant b64variant, OutputStream out) throws IOException {
+    public int readBinaryValue(Base64Variant b64variant, OutputStream out) throws IOException
+    {
         // if we have already read the token, just use whatever we may have
         if (!_tokenIncomplete || _currToken != JsonToken.VALUE_STRING) {
             byte[] b = getBinaryValue(b64variant);
@@ -504,7 +522,8 @@ public class UTF8StreamJsonParser
     }
 
     protected int _readBinary(Base64Variant b64variant, OutputStream out,
-                              byte[] buffer) throws IOException {
+                              byte[] buffer) throws IOException
+    {
         int outputPtr = 0;
         final int outputEnd = buffer.length - 3;
         int outputCount = 0;
@@ -580,7 +599,7 @@ public class UTF8StreamJsonParser
                     ch = _inputBuffer[_inputPtr++] & 0xFF;
                     if (!b64variant.usesPaddingChar(ch)) {
                         if (_decodeBase64Escape(b64variant, ch, 3) != Base64Variant.BASE64_VALUE_PADDING) {
-                            throw reportInvalidBase64Char(b64variant, ch, 3, "expected padding character '" + b64variant.getPaddingChar() + "'");
+                            throw reportInvalidBase64Char(b64variant, ch, 3, "expected padding character '"+b64variant.getPaddingChar()+"'");
                         }
                     }
                     // Got 12 bits, only need 8, need to shift
@@ -647,10 +666,11 @@ public class UTF8StreamJsonParser
 
     /**
      * @return Next token from the stream, if any found, or null
-     * to indicate end-of-input
+     *   to indicate end-of-input
      */
     @Override
-    public JsonToken nextToken() throws IOException {
+    public JsonToken nextToken() throws IOException
+    {
         /* First: field names are special -- we will always tokenize
          * (part of) value along with field name to simplify
          * state handling. If so, can and need to use secondary token:
@@ -686,7 +706,7 @@ public class UTF8StreamJsonParser
         // Nope: do we then expect a comma?
         if (_parsingContext.expectComma()) {
             if (i != INT_COMMA) {
-                _reportUnexpectedChar(i, "was expecting comma to separate " + _parsingContext.typeDesc() + " entries");
+                _reportUnexpectedChar(i, "was expecting comma to separate "+_parsingContext.typeDesc()+" entries");
             }
             i = _skipWS();
             // Was that a trailing comma?
@@ -718,102 +738,104 @@ public class UTF8StreamJsonParser
             _tokenIncomplete = true;
             _nextToken = JsonToken.VALUE_STRING;
             return _currToken;
-        }
+        }        
         JsonToken t;
 
         switch (i) {
-            case '-':
-                t = _parseNegNumber();
-                break;
+        case '-':
+            t = _parseNegNumber();
+            break;
 
             // Should we have separate handling for plus? Although it is not allowed per se,
             // it may be erroneously used, and could be indicate by a more specific error message.
-            case '0':
-            case '1':
-            case '2':
-            case '3':
-            case '4':
-            case '5':
-            case '6':
-            case '7':
-            case '8':
-            case '9':
-                t = _parsePosNumber(i);
-                break;
-            case 'f':
-                _matchFalse();
-                t = JsonToken.VALUE_FALSE;
-                break;
-            case 'n':
-                _matchNull();
-                t = JsonToken.VALUE_NULL;
-                break;
-            case 't':
-                _matchTrue();
-                t = JsonToken.VALUE_TRUE;
-                break;
-            case '[':
-                t = JsonToken.START_ARRAY;
-                break;
-            case '{':
-                t = JsonToken.START_OBJECT;
-                break;
+        case '0':
+        case '1':
+        case '2':
+        case '3':
+        case '4':
+        case '5':
+        case '6':
+        case '7':
+        case '8':
+        case '9':
+            t = _parsePosNumber(i);
+            break;
+        case 'f':
+            _matchFalse();
+             t = JsonToken.VALUE_FALSE;
+            break;
+        case 'n':
+            _matchNull();
+            t = JsonToken.VALUE_NULL;
+            break;
+        case 't':
+            _matchTrue();
+            t = JsonToken.VALUE_TRUE;
+            break;
+        case '[':
+            t = JsonToken.START_ARRAY;
+            break;
+        case '{':
+            t = JsonToken.START_OBJECT;
+            break;
 
-            default:
-                t = _handleUnexpectedValue(i);
+        default:
+            t = _handleUnexpectedValue(i);
         }
         _nextToken = t;
         return _currToken;
     }
 
-    private final JsonToken _nextTokenNotInObject(int i) throws IOException {
+    private final JsonToken _nextTokenNotInObject(int i) throws IOException
+    {
         if (i == INT_QUOTE) {
             _tokenIncomplete = true;
             return (_currToken = JsonToken.VALUE_STRING);
         }
         switch (i) {
-            case '[':
-                _parsingContext = _parsingContext.createChildArrayContext(_tokenInputRow, _tokenInputCol);
-                return (_currToken = JsonToken.START_ARRAY);
-            case '{':
-                _parsingContext = _parsingContext.createChildObjectContext(_tokenInputRow, _tokenInputCol);
-                return (_currToken = JsonToken.START_OBJECT);
-            case 't':
-                _matchTrue();
-                return (_currToken = JsonToken.VALUE_TRUE);
-            case 'f':
-                _matchFalse();
-                return (_currToken = JsonToken.VALUE_FALSE);
-            case 'n':
-                _matchNull();
-                return (_currToken = JsonToken.VALUE_NULL);
-            case '-':
-                return (_currToken = _parseNegNumber());
+        case '[':
+            _parsingContext = _parsingContext.createChildArrayContext(_tokenInputRow, _tokenInputCol);
+            return (_currToken = JsonToken.START_ARRAY);
+        case '{':
+            _parsingContext = _parsingContext.createChildObjectContext(_tokenInputRow, _tokenInputCol);
+            return (_currToken = JsonToken.START_OBJECT);
+        case 't':
+            _matchTrue();
+            return (_currToken = JsonToken.VALUE_TRUE);
+        case 'f':
+            _matchFalse();
+            return (_currToken = JsonToken.VALUE_FALSE);
+        case 'n':
+            _matchNull();
+            return (_currToken = JsonToken.VALUE_NULL);
+        case '-':
+            return (_currToken = _parseNegNumber());
 
             // Should we have separate handling for plus? Although it is not allowed per se,
             // it may be erroneously used, and could be indicate by a more specific error message.
-            case '0':
-            case '1':
-            case '2':
-            case '3':
-            case '4':
-            case '5':
-            case '6':
-            case '7':
-            case '8':
-            case '9':
-                return (_currToken = _parsePosNumber(i));
+        case '0':
+        case '1':
+        case '2':
+        case '3':
+        case '4':
+        case '5':
+        case '6':
+        case '7':
+        case '8':
+        case '9':
+            return (_currToken = _parsePosNumber(i));
         }
         return (_currToken = _handleUnexpectedValue(i));
     }
-
-    private final JsonToken _nextAfterName() {
+    
+    private final JsonToken _nextAfterName()
+    {
         _nameCopied = false; // need to invalidate if it was copied
         JsonToken t = _nextToken;
         _nextToken = null;
 
-        // !!! 16-Nov-2015, tatu: TODO: fix [databind#37], copy next location to current here
-
+ // !!! 16-Nov-2015, tatu: TODO: fix [databind#37], copy next location to current here
+        
         // Also: may need to start new context?
         if (t == JsonToken.START_ARRAY) {
             _parsingContext = _parsingContext.createChildArrayContext(_tokenInputRow, _tokenInputCol);
@@ -838,7 +860,8 @@ public class UTF8StreamJsonParser
      */
 
     @Override
-    public String nextFieldName() throws IOException {
+    public String nextFieldName() throws IOException
+    {
         // // // Note: this is almost a verbatim copy of nextToken()
 
         _numTypesValid = NR_UNKNOWN;
@@ -871,7 +894,7 @@ public class UTF8StreamJsonParser
         // Nope: do we then expect a comma?
         if (_parsingContext.expectComma()) {
             if (i != INT_COMMA) {
-                _reportUnexpectedChar(i, "was expecting comma to separate " + _parsingContext.typeDesc() + " entries");
+                _reportUnexpectedChar(i, "was expecting comma to separate "+_parsingContext.typeDesc()+" entries");
             }
             i = _skipWS();
             // Was that a trailing comma?
@@ -903,49 +926,50 @@ public class UTF8StreamJsonParser
         }
         JsonToken t;
         switch (i) {
-            case '-':
-                t = _parseNegNumber();
-                break;
-            case '0':
-            case '1':
-            case '2':
-            case '3':
-            case '4':
-            case '5':
-            case '6':
-            case '7':
-            case '8':
-            case '9':
-                t = _parsePosNumber(i);
-                break;
-            case 'f':
-                _matchFalse();
-                t = JsonToken.VALUE_FALSE;
-                break;
-            case 'n':
-                _matchNull();
-                t = JsonToken.VALUE_NULL;
-                break;
-            case 't':
-                _matchTrue();
-                t = JsonToken.VALUE_TRUE;
-                break;
-            case '[':
-                t = JsonToken.START_ARRAY;
-                break;
-            case '{':
-                t = JsonToken.START_OBJECT;
-                break;
+        case '-':
+            t = _parseNegNumber();
+            break;
+        case '0':
+        case '1':
+        case '2':
+        case '3':
+        case '4':
+        case '5':
+        case '6':
+        case '7':
+        case '8':
+        case '9':
+            t = _parsePosNumber(i);
+            break;
+        case 'f':
+            _matchFalse();
+             t = JsonToken.VALUE_FALSE;
+            break;
+        case 'n':
+            _matchNull();
+            t = JsonToken.VALUE_NULL;
+            break;
+        case 't':
+            _matchTrue();
+            t = JsonToken.VALUE_TRUE;
+            break;
+        case '[':
+            t = JsonToken.START_ARRAY;
+            break;
+        case '{':
+            t = JsonToken.START_OBJECT;
+            break;
 
-            default:
-                t = _handleUnexpectedValue(i);
+        default:
+            t = _handleUnexpectedValue(i);
         }
         _nextToken = t;
         return nameStr;
     }
 
     @Override
-    public boolean nextFieldName(SerializableString str) throws IOException {
+    public boolean nextFieldName(SerializableString str) throws IOException
+    {
         // // // Note: most of code below is copied from nextToken()
         _numTypesValid = NR_UNKNOWN;
         if (_currToken == JsonToken.FIELD_NAME) { // can't have name right after name
@@ -978,7 +1002,7 @@ public class UTF8StreamJsonParser
         // Nope: do we then expect a comma?
         if (_parsingContext.expectComma()) {
             if (i != INT_COMMA) {
-                _reportUnexpectedChar(i, "was expecting comma to separate " + _parsingContext.typeDesc() + " entries");
+                _reportUnexpectedChar(i, "was expecting comma to separate "+_parsingContext.typeDesc()+" entries");
             }
             i = _skipWS();
 
@@ -995,7 +1019,7 @@ public class UTF8StreamJsonParser
             _nextTokenNotInObject(i);
             return false;
         }
-
+        
         // // // This part differs, name parsing
         _updateNameLocation();
         if (i == INT_QUOTE) {
@@ -1006,14 +1030,14 @@ public class UTF8StreamJsonParser
             //    of colon that follows name
             if ((_inputPtr + len + 4) < _inputEnd) { // maybe...
                 // first check length match by
-                final int end = _inputPtr + len;
+                final int end = _inputPtr+len;
                 if (_inputBuffer[end] == INT_QUOTE) {
                     int offset = 0;
                     int ptr = _inputPtr;
                     while (true) {
                         if (ptr == end) { // yes, match!
                             _parsingContext.setCurrentName(str.getValue());
-                            i = _skipColonFast(ptr + 1);
+                            i = _skipColonFast(ptr+1);
                             _isNextTokenNameYes(i);
                             return true;
                         }
@@ -1030,7 +1054,8 @@ public class UTF8StreamJsonParser
     }
 
     @Override
-    public int nextFieldName(FieldNameMatcher matcher) throws IOException {
+    public int nextFieldName(FieldNameMatcher matcher) throws IOException
+    {
         // // // Note: this is almost a verbatim copy of nextToken()
         _numTypesValid = NR_UNKNOWN;
         if (_currToken == JsonToken.FIELD_NAME) {
@@ -1062,7 +1087,7 @@ public class UTF8StreamJsonParser
         // Nope: do we then expect a comma?
         if (_parsingContext.expectComma()) {
             if (i != INT_COMMA) {
-                _reportUnexpectedChar(i, "was expecting comma to separate " + _parsingContext.typeDesc() + " entries");
+                _reportUnexpectedChar(i, "was expecting comma to separate "+_parsingContext.typeDesc()+" entries");
             }
             i = _skipWS();
             // Was that a trailing comma?
@@ -1113,49 +1138,50 @@ public class UTF8StreamJsonParser
         }
         JsonToken t;
         switch (i) {
-            case '-':
-                t = _parseNegNumber();
-                break;
-            case '0':
-            case '1':
-            case '2':
-            case '3':
-            case '4':
-            case '5':
-            case '6':
-            case '7':
-            case '8':
-            case '9':
-                t = _parsePosNumber(i);
-                break;
-            case 'f':
-                _matchFalse();
-                t = JsonToken.VALUE_FALSE;
-                break;
-            case 'n':
-                _matchNull();
-                t = JsonToken.VALUE_NULL;
-                break;
-            case 't':
-                _matchTrue();
-                t = JsonToken.VALUE_TRUE;
-                break;
-            case '[':
-                t = JsonToken.START_ARRAY;
-                break;
-            case '{':
-                t = JsonToken.START_OBJECT;
-                break;
+        case '-':
+            t = _parseNegNumber();
+            break;
+        case '0':
+        case '1':
+        case '2':
+        case '3':
+        case '4':
+        case '5':
+        case '6':
+        case '7':
+        case '8':
+        case '9':
+            t = _parsePosNumber(i);
+            break;
+        case 'f':
+            _matchFalse();
+             t = JsonToken.VALUE_FALSE;
+            break;
+        case 'n':
+            _matchNull();
+            t = JsonToken.VALUE_NULL;
+            break;
+        case 't':
+            _matchTrue();
+            t = JsonToken.VALUE_TRUE;
+            break;
+        case '[':
+            t = JsonToken.START_ARRAY;
+            break;
+        case '{':
+            t = JsonToken.START_OBJECT;
+            break;
 
-            default:
-                t = _handleUnexpectedValue(i);
+        default:
+            t = _handleUnexpectedValue(i);
         }
         _nextToken = t;
         return match;
     }
 
     // Variant called when we know there's at least 4 more bytes available
-    private final int _skipColonFast(int ptr) throws IOException {
+    private final int _skipColonFast(int ptr) throws IOException
+    {
         int i = _inputBuffer[ptr++];
         if (i == INT_COLON) { // common case, no leading space
             i = _inputBuffer[ptr++];
@@ -1173,7 +1199,7 @@ public class UTF8StreamJsonParser
                     }
                 }
             }
-            _inputPtr = ptr - 1;
+            _inputPtr = ptr-1;
             return _skipColon2(true); // true -> skipped colon
         }
         if (i == INT_SPACE || i == INT_TAB) {
@@ -1195,60 +1221,62 @@ public class UTF8StreamJsonParser
                     }
                 }
             }
-            _inputPtr = ptr - 1;
+            _inputPtr = ptr-1;
             return _skipColon2(true);
         }
-        _inputPtr = ptr - 1;
+        _inputPtr = ptr-1;
         return _skipColon2(false);
     }
 
-    private final void _isNextTokenNameYes(int i) throws IOException {
+    private final void _isNextTokenNameYes(int i) throws IOException
+    {
         _currToken = JsonToken.FIELD_NAME;
         _updateLocation();
 
         switch (i) {
-            case '"':
-                _tokenIncomplete = true;
-                _nextToken = JsonToken.VALUE_STRING;
-                return;
-            case '[':
-                _nextToken = JsonToken.START_ARRAY;
-                return;
-            case '{':
-                _nextToken = JsonToken.START_OBJECT;
-                return;
-            case 't':
-                _matchTrue();
-                _nextToken = JsonToken.VALUE_TRUE;
-                return;
-            case 'f':
-                _matchFalse();
-                _nextToken = JsonToken.VALUE_FALSE;
-                return;
-            case 'n':
-                _matchNull();
-                _nextToken = JsonToken.VALUE_NULL;
-                return;
-            case '-':
-                _nextToken = _parseNegNumber();
-                return;
-            case '0':
-            case '1':
-            case '2':
-            case '3':
-            case '4':
-            case '5':
-            case '6':
-            case '7':
-            case '8':
-            case '9':
-                _nextToken = _parsePosNumber(i);
-                return;
+        case '"':
+            _tokenIncomplete = true;
+            _nextToken = JsonToken.VALUE_STRING;
+            return;
+        case '[':
+            _nextToken = JsonToken.START_ARRAY;
+            return;
+        case '{':
+            _nextToken = JsonToken.START_OBJECT;
+            return;
+        case 't':
+            _matchTrue();
+            _nextToken = JsonToken.VALUE_TRUE;
+            return;
+        case 'f':
+            _matchFalse();
+            _nextToken = JsonToken.VALUE_FALSE;
+            return;
+        case 'n':
+            _matchNull();
+            _nextToken = JsonToken.VALUE_NULL;
+            return;
+        case '-':
+            _nextToken = _parseNegNumber();
+            return;
+        case '0':
+        case '1':
+        case '2':
+        case '3':
+        case '4':
+        case '5':
+        case '6':
+        case '7':
+        case '8':
+        case '9':
+            _nextToken = _parsePosNumber(i);
+            return;
         }
         _nextToken = _handleUnexpectedValue(i);
     }
 
-    private final boolean _isNextTokenNameMaybe(int i, SerializableString str) throws IOException {
+    private final boolean _isNextTokenNameMaybe(int i, SerializableString str) throws IOException
+    {
         // // // and this is back to standard nextToken()
 
         String n = _parseName(i);
@@ -1267,47 +1295,48 @@ public class UTF8StreamJsonParser
         JsonToken t;
 
         switch (i) {
-            case '[':
-                t = JsonToken.START_ARRAY;
-                break;
-            case '{':
-                t = JsonToken.START_OBJECT;
-                break;
-            case 't':
-                _matchTrue();
-                t = JsonToken.VALUE_TRUE;
-                break;
-            case 'f':
-                _matchFalse();
-                t = JsonToken.VALUE_FALSE;
-                break;
-            case 'n':
-                _matchNull();
-                t = JsonToken.VALUE_NULL;
-                break;
-            case '-':
-                t = _parseNegNumber();
-                break;
-            case '0':
-            case '1':
-            case '2':
-            case '3':
-            case '4':
-            case '5':
-            case '6':
-            case '7':
-            case '8':
-            case '9':
-                t = _parsePosNumber(i);
-                break;
-            default:
-                t = _handleUnexpectedValue(i);
+        case '[':
+            t = JsonToken.START_ARRAY;
+            break;
+        case '{':
+            t = JsonToken.START_OBJECT;
+            break;
+        case 't':
+            _matchTrue();
+            t = JsonToken.VALUE_TRUE;
+            break;
+        case 'f':
+            _matchFalse();
+             t = JsonToken.VALUE_FALSE;
+            break;
+        case 'n':
+            _matchNull();
+            t = JsonToken.VALUE_NULL;
+            break;
+        case '-':
+            t = _parseNegNumber();
+            break;
+        case '0':
+        case '1':
+        case '2':
+        case '3':
+        case '4':
+        case '5':
+        case '6':
+        case '7':
+        case '8':
+        case '9':
+            t = _parsePosNumber(i);
+            break;
+        default:
+            t = _handleUnexpectedValue(i);
         }
         _nextToken = t;
         return match;
     }
 
-    protected final int _matchName(FieldNameMatcher matcher, int i) throws IOException {
+    protected final int _matchName(FieldNameMatcher matcher, int i) throws IOException
+    {
         if (i != INT_QUOTE) {
             return -1;
         }
@@ -1328,7 +1357,7 @@ public class UTF8StreamJsonParser
             }
             return -1;
         }
-
+            
         i = input[qptr++] & 0xFF;
         if (codes[i] != 0) {
             if (i != INT_QUOTE) {
@@ -1364,7 +1393,7 @@ public class UTF8StreamJsonParser
                     if (i != INT_QUOTE) {
                         return -1;
                     }
-                }
+                }                
             }
         }
         _quadPtr = qptr;
@@ -1372,7 +1401,8 @@ public class UTF8StreamJsonParser
         return matcher.matchByQuad(q);
     }
 
-    protected final int _matchMediumName(FieldNameMatcher matcher, int qptr, int q2) throws IOException {
+    protected final int _matchMediumName(FieldNameMatcher matcher, int qptr, int q2) throws IOException
+    {
         final byte[] input = _inputBuffer;
         final int[] codes = _icLatin1;
 
@@ -1417,7 +1447,8 @@ public class UTF8StreamJsonParser
     }
 
     protected final int _matchMediumName2(FieldNameMatcher matcher, int qptr,
-                                          int q3, final int q2) throws IOException {
+            int q3, final int q2) throws IOException
+    {
         final byte[] input = _inputBuffer;
         final int[] codes = _icLatin1;
 
@@ -1464,7 +1495,8 @@ public class UTF8StreamJsonParser
     }
 
     protected final int _matchLongName(FieldNameMatcher matcher, int qptr,
-                                       int q) throws IOException {
+            int q) throws IOException
+    {
         final byte[] input = _inputBuffer;
         final int[] codes = _icLatin1;
         int qlen = 3;
@@ -1531,9 +1563,10 @@ public class UTF8StreamJsonParser
     /* Public API, traversal, nextXxxValue() variants
     /**********************************************************
      */
-
+    
     @Override
-    public String nextTextValue() throws IOException {
+    public String nextTextValue() throws IOException
+    {
         // two distinct cases; either got name and we know next type, or 'other'
         if (_currToken == JsonToken.FIELD_NAME) { // mostly copied from '_nextAfterName'
             _nameCopied = false;
@@ -1559,7 +1592,8 @@ public class UTF8StreamJsonParser
     }
 
     @Override
-    public int nextIntValue(int defaultValue) throws IOException {
+    public int nextIntValue(int defaultValue) throws IOException
+    {
         // two distinct cases; either got name and we know next type, or 'other'
         if (_currToken == JsonToken.FIELD_NAME) { // mostly copied from '_nextAfterName'
             _nameCopied = false;
@@ -1581,7 +1615,8 @@ public class UTF8StreamJsonParser
     }
 
     @Override
-    public long nextLongValue(long defaultValue) throws IOException {
+    public long nextLongValue(long defaultValue) throws IOException
+    {
         // two distinct cases; either got name and we know next type, or 'other'
         if (_currToken == JsonToken.FIELD_NAME) { // mostly copied from '_nextAfterName'
             _nameCopied = false;
@@ -1603,7 +1638,8 @@ public class UTF8StreamJsonParser
     }
 
     @Override
-    public Boolean nextBooleanValue() throws IOException {
+    public Boolean nextBooleanValue() throws IOException
+    {
         // two distinct cases; either got name and we know next type, or 'other'
         if (_currToken == JsonToken.FIELD_NAME) { // mostly copied from '_nextAfterName'
             _nameCopied = false;
@@ -1648,14 +1684,15 @@ public class UTF8StreamJsonParser
      * as a floating point number. The basic rule is that if the number
      * has no fractional or exponential part, it is an integer; otherwise
      * a floating point number.
-     * <p>
+     *<p>
      * Because much of input has to be processed in any case, no partial
      * parsing is done: all input text will be stored for further
      * processing. However, actual numeric value conversion will be
      * deferred, since it is usually the most complicated and costliest
      * part of processing.
      */
-    protected JsonToken _parsePosNumber(int c) throws IOException {
+    protected JsonToken _parsePosNumber(int c) throws IOException
+    {
         char[] outBuf = _textBuffer.emptyAndGetCurrentSegment();
         // One special case: if first char is 0, must not be followed by a digit
         if (c == INT_0) {
@@ -1692,8 +1729,9 @@ public class UTF8StreamJsonParser
         // And there we have it!
         return resetInt(false, intLen);
     }
-
-    protected JsonToken _parseNegNumber() throws IOException {
+    
+    protected JsonToken _parseNegNumber() throws IOException
+    {
         char[] outBuf = _textBuffer.emptyAndGetCurrentSegment();
         int outPtr = 0;
 
@@ -1714,7 +1752,7 @@ public class UTF8StreamJsonParser
         } else if (c > INT_9) {
             return _handleInvalidNumberStart(c, true);
         }
-
+        
         // Ok: we can first just add digit we saw first:
         outBuf[outPtr++] = (char) c;
         int intLen = 1;
@@ -1738,7 +1776,7 @@ public class UTF8StreamJsonParser
         if (c == INT_PERIOD || c == INT_e || c == INT_E) {
             return _parseFloat(outBuf, outPtr, c, true, intLen);
         }
-
+        
         --_inputPtr; // to push back trailing char (comma etc)
         _textBuffer.setCurrentLength(outPtr);
         // As per #105, need separating space between root values; check here
@@ -1755,7 +1793,8 @@ public class UTF8StreamJsonParser
      * (or output is longer than segment used to store it)
      */
     private final JsonToken _parseNumber2(char[] outBuf, int outPtr, boolean negative,
-                                          int intPartLength) throws IOException {
+            int intPartLength) throws IOException
+    {
         // Ok, parse the rest
         while (true) {
             if (_inputPtr >= _inputEnd && !_loadMore()) {
@@ -1785,14 +1824,15 @@ public class UTF8StreamJsonParser
 
         // And there we have it!
         return resetInt(negative, intPartLength);
-
+        
     }
-
+    
     /**
      * Method called when we have seen one zero, and want to ensure
      * it is not followed by another
      */
-    private final int _verifyNoLeadingZeroes() throws IOException {
+    private final int _verifyNoLeadingZeroes() throws IOException
+    {
         // Ok to have plain "0"
         if (_inputPtr >= _inputEnd && !_loadMore()) {
             return INT_0;
@@ -1822,9 +1862,10 @@ public class UTF8StreamJsonParser
         }
         return ch;
     }
-
+    
     private final JsonToken _parseFloat(char[] outBuf, int outPtr, int c,
-                                        boolean negative, int integerPartLength) throws IOException {
+            boolean negative, int integerPartLength) throws IOException
+    {
         int fractLen = 0;
         boolean eof = false;
 
@@ -1922,25 +1963,26 @@ public class UTF8StreamJsonParser
     /**
      * Method called to ensure that a root-value is followed by a space
      * token.
-     * <p>
+     *<p>
      * NOTE: caller MUST ensure there is at least one character available;
      * and that input pointer is AT given char (not past)
      */
-    private final void _verifyRootSpace(int ch) throws IOException {
+    private final void _verifyRootSpace(int ch) throws IOException
+    {
         // caller had pushed it back, before calling; reset
         ++_inputPtr;
         // TODO? Handle UTF-8 char decoding for error reporting
         switch (ch) {
-            case ' ':
-            case '\t':
-                return;
-            case '\r':
-                _skipCR();
-                return;
-            case '\n':
-                ++_currInputRow;
-                _currInputRowStart = _inputPtr;
-                return;
+        case ' ':
+        case '\t':
+            return;
+        case '\r':
+            _skipCR();
+            return;
+        case '\n':
+            ++_currInputRow;
+            _currInputRowStart = _inputPtr;
+            return;
         }
         _reportMissingRootWS(ch);
     }
@@ -1951,7 +1993,8 @@ public class UTF8StreamJsonParser
     /**********************************************************
      */
 
-    protected final String _parseName(int i) throws IOException {
+    protected final String _parseName(int i) throws IOException
+    {
         if (i != INT_QUOTE) {
             return _handleOddName(i);
         }
@@ -1995,7 +2038,7 @@ public class UTF8StreamJsonParser
                         return findName(q, 3);
                     }
                     return parseName(q, i, 3);
-                }
+                }                
                 if (i == INT_QUOTE) { // 2 byte/char case or broken
                     return findName(q, 2);
                 }
@@ -2005,14 +2048,15 @@ public class UTF8StreamJsonParser
                 return findName(q, 1);
             }
             return parseName(q, i, 1);
-        }
+        }     
         if (q == INT_QUOTE) { // special case, ""
             return "";
         }
         return parseName(0, q, 0); // quoting or invalid char
     }
 
-    protected final String parseMediumName(int q2) throws IOException {
+    protected final String parseMediumName(int q2) throws IOException
+    {
         final byte[] input = _inputBuffer;
         final int[] codes = _icLatin1;
 
@@ -2051,7 +2095,8 @@ public class UTF8StreamJsonParser
         return parseMediumName2(i, q2);
     }
 
-    protected final String parseMediumName2(int q3, final int q2) throws IOException {
+    protected final String parseMediumName2(int q3, final int q2) throws IOException
+    {
         final byte[] input = _inputBuffer;
         final int[] codes = _icLatin1;
 
@@ -2089,8 +2134,9 @@ public class UTF8StreamJsonParser
         }
         return parseLongName(i, q2, q3);
     }
-
-    protected final String parseLongName(int q, final int q2, int q3) throws IOException {
+    
+    protected final String parseLongName(int q, final int q2, int q3) throws IOException
+    {
         _quadBuffer[0] = _quad1;
         _quadBuffer[1] = q2;
         _quadBuffer[2] = q3;
@@ -2156,7 +2202,8 @@ public class UTF8StreamJsonParser
      * to come consecutively. Happens rarely, so this is offlined;
      * plus we'll also do full checks for escaping etc.
      */
-    protected String slowParseName() throws IOException {
+    protected String slowParseName() throws IOException
+    {
         if (_inputPtr >= _inputEnd) {
             if (!_loadMore()) {
                 _reportInvalidEOF(": was expecting closing '\"' for name", JsonToken.FIELD_NAME);
@@ -2191,7 +2238,8 @@ public class UTF8StreamJsonParser
      * cases, gets slower, and hence is offlined to a separate method.
      */
     protected final String parseEscapedName(int[] quads, int qlen, int currQuad, int ch,
-                                            int currQuadBytes) throws IOException {
+            int currQuadBytes) throws IOException
+    {
         // This may seem weird, but here we do not want to worry about
         // UTF-8 decoding yet. Rather, we'll assume that part is ok (if not it will get
         // caught later on), and just handle quotes and backslashes here.
@@ -2285,7 +2333,8 @@ public class UTF8StreamJsonParser
      * In standard mode will just throw an exception; but
      * in non-standard modes may be able to parse name.
      */
-    protected String _handleOddName(int ch) throws IOException {
+    protected String _handleOddName(int ch) throws IOException
+    {
         // First: may allow single quotes
         if (ch == INT_APOS && isEnabled(JsonReadFeature.ALLOW_SINGLE_QUOTES)) {
             return _parseAposName();
@@ -2356,7 +2405,8 @@ public class UTF8StreamJsonParser
      * for valid JSON -- more alternatives, more code, generally
      * bit slower execution.
      */
-    protected String _parseAposName() throws IOException {
+    protected String _parseAposName() throws IOException
+    {
         if (_inputPtr >= _inputEnd) {
             if (!_loadMore()) {
                 _reportInvalidEOF(": was expecting closing '\'' for field name", JsonToken.FIELD_NAME);
@@ -2462,7 +2512,8 @@ public class UTF8StreamJsonParser
     /**********************************************************
      */
 
-    private final String findName(int q1, int lastQuadBytes) throws JsonParseException {
+    private final String findName(int q1, int lastQuadBytes) throws JsonParseException
+    {
         q1 = _padLastQuad(q1, lastQuadBytes);
         // Usually we'll find it from the canonical symbol table already
         String name = _symbols.findName(q1);
@@ -2474,7 +2525,8 @@ public class UTF8StreamJsonParser
         return addName(_quadBuffer, 1, lastQuadBytes);
     }
 
-    private final String findName(int q1, int q2, int lastQuadBytes) throws JsonParseException {
+    private final String findName(int q1, int q2, int lastQuadBytes) throws JsonParseException
+    {
         q2 = _padLastQuad(q2, lastQuadBytes);
         // Usually we'll find it from the canonical symbol table already
         String name = _symbols.findName(q1, q2);
@@ -2487,7 +2539,8 @@ public class UTF8StreamJsonParser
         return addName(_quadBuffer, 2, lastQuadBytes);
     }
 
-    private final String findName(int q1, int q2, int q3, int lastQuadBytes) throws JsonParseException {
+    private final String findName(int q1, int q2, int q3, int lastQuadBytes) throws JsonParseException
+    {
         q3 = _padLastQuad(q3, lastQuadBytes);
         String name = _symbols.findName(q1, q2, q3);
         if (name != null) {
@@ -2499,8 +2552,9 @@ public class UTF8StreamJsonParser
         quads[2] = _padLastQuad(q3, lastQuadBytes);
         return addName(quads, 3, lastQuadBytes);
     }
-
-    private final String findName(int[] quads, int qlen, int lastQuad, int lastQuadBytes) throws JsonParseException {
+    
+    private final String findName(int[] quads, int qlen, int lastQuad, int lastQuadBytes) throws JsonParseException
+    {
         if (qlen >= quads.length) {
             _quadBuffer = quads = growArrayBy(quads, quads.length);
         }
@@ -2518,7 +2572,8 @@ public class UTF8StreamJsonParser
      * multi-byte chars (if any), and then construct Name instance
      * and add it to the symbol table.
      */
-    private final String addName(int[] quads, int qlen, int lastQuadBytes) throws JsonParseException {
+    private final String addName(int[] quads, int qlen, int lastQuadBytes) throws JsonParseException
+    {
         /* Ok: must decode UTF-8 chars. No other validation is
          * needed, since unescaping has been done earlier as necessary
          * (as well as error reporting for unescaped control chars)
@@ -2534,9 +2589,9 @@ public class UTF8StreamJsonParser
         int lastQuad;
 
         if (lastQuadBytes < 4) {
-            lastQuad = quads[qlen - 1];
+            lastQuad = quads[qlen-1];
             // 8/16/24 bit left shift
-            quads[qlen - 1] = (lastQuad << ((4 - lastQuadBytes) << 3));
+            quads[qlen-1] = (lastQuad << ((4 - lastQuadBytes) << 3));
         } else {
             lastQuad = 0;
         }
@@ -2569,13 +2624,13 @@ public class UTF8StreamJsonParser
                 if ((ix + needed) > byteLen) {
                     _reportInvalidEOF(" in field name", JsonToken.FIELD_NAME);
                 }
-
+                
                 // Ok, always need at least one more:
                 int ch2 = quads[ix >> 2]; // current quad, need to shift+mask
                 byteIx = (ix & 3);
                 ch2 = (ch2 >> ((3 - byteIx) << 3));
                 ++ix;
-
+                
                 if ((ch2 & 0xC0) != 0x080) {
                     _reportInvalidOther(ch2);
                 }
@@ -2585,7 +2640,7 @@ public class UTF8StreamJsonParser
                     byteIx = (ix & 3);
                     ch2 = (ch2 >> ((3 - byteIx) << 3));
                     ++ix;
-
+                    
                     if ((ch2 & 0xC0) != 0x080) {
                         _reportInvalidOther(ch2);
                     }
@@ -2620,7 +2675,7 @@ public class UTF8StreamJsonParser
         String baseName = new String(cbuf, 0, cix);
         // And finally, un-align if necessary
         if (lastQuadBytes < 4) {
-            quads[qlen - 1] = lastQuad;
+            quads[qlen-1] = lastQuad;
         }
         return _symbols.addName(baseName, quads, qlen);
     }
@@ -2639,12 +2694,11 @@ public class UTF8StreamJsonParser
      */
 
     protected void _loadMoreGuaranteed() throws IOException {
-        if (!_loadMore()) {
-            _reportInvalidEOF();
-        }
+        if (!_loadMore()) { _reportInvalidEOF(); }
     }
 
-    protected void _finishString() throws IOException {
+    protected void _finishString() throws IOException
+    {
         // First, single tight loop for ASCII content, not split across input buffer boundary:        
         int ptr = _inputPtr;
         if (ptr >= _inputEnd) {
@@ -2661,7 +2715,7 @@ public class UTF8StreamJsonParser
             int c = (int) inputBuffer[ptr] & 0xFF;
             if (codes[c] != 0) {
                 if (c == INT_QUOTE) {
-                    _inputPtr = ptr + 1;
+                    _inputPtr = ptr+1;
                     _textBuffer.setCurrentLength(outPtr);
                     return;
                 }
@@ -2674,7 +2728,8 @@ public class UTF8StreamJsonParser
         _finishString2(outBuf, outPtr);
     }
 
-    protected String _finishAndReturnString() throws IOException {
+    protected String _finishAndReturnString() throws IOException
+    {
         // First, single tight loop for ASCII content, not split across input buffer boundary:        
         int ptr = _inputPtr;
         if (ptr >= _inputEnd) {
@@ -2691,7 +2746,7 @@ public class UTF8StreamJsonParser
             int c = (int) inputBuffer[ptr] & 0xFF;
             if (codes[c] != 0) {
                 if (c == INT_QUOTE) {
-                    _inputPtr = ptr + 1;
+                    _inputPtr = ptr+1;
                     return _textBuffer.setCurrentAndReturn(outPtr);
                 }
                 break;
@@ -2703,9 +2758,10 @@ public class UTF8StreamJsonParser
         _finishString2(outBuf, outPtr);
         return _textBuffer.contentsAsString();
     }
-
+    
     private final void _finishString2(char[] outBuf, int outPtr)
-            throws IOException {
+        throws IOException
+    {
         int c;
 
         // Here we do want to do full decoding, hence:
@@ -2743,38 +2799,38 @@ public class UTF8StreamJsonParser
             }
 
             switch (codes[c]) {
-                case 1: // backslash
-                    c = _decodeEscaped();
-                    break;
-                case 2: // 2-byte UTF
-                    c = _decodeUtf8_2(c);
-                    break;
-                case 3: // 3-byte UTF
-                    if ((_inputEnd - _inputPtr) >= 2) {
-                        c = _decodeUtf8_3fast(c);
-                    } else {
-                        c = _decodeUtf8_3(c);
-                    }
-                    break;
-                case 4: // 4-byte UTF
-                    c = _decodeUtf8_4(c);
-                    // Let's add first part right away:
-                    outBuf[outPtr++] = (char) (0xD800 | (c >> 10));
-                    if (outPtr >= outBuf.length) {
-                        outBuf = _textBuffer.finishCurrentSegment();
-                        outPtr = 0;
-                    }
-                    c = 0xDC00 | (c & 0x3FF);
-                    // And let the other char output down below
-                    break;
-                default:
-                    if (c < INT_SPACE) {
-                        // As per [JACKSON-208], call can now return:
-                        _throwUnquotedSpace(c, "string value");
-                    } else {
-                        // Is this good enough error message?
-                        _reportInvalidChar(c);
-                    }
+            case 1: // backslash
+                c = _decodeEscaped();
+                break;
+            case 2: // 2-byte UTF
+                c = _decodeUtf8_2(c);
+                break;
+            case 3: // 3-byte UTF
+                if ((_inputEnd - _inputPtr) >= 2) {
+                    c = _decodeUtf8_3fast(c);
+                } else {
+                    c = _decodeUtf8_3(c);
+                }
+                break;
+            case 4: // 4-byte UTF
+                c = _decodeUtf8_4(c);
+                // Let's add first part right away:
+                outBuf[outPtr++] = (char) (0xD800 | (c >> 10));
+                if (outPtr >= outBuf.length) {
+                    outBuf = _textBuffer.finishCurrentSegment();
+                    outPtr = 0;
+                }
+                c = 0xDC00 | (c & 0x3FF);
+                // And let the other char output down below
+                break;
+            default:
+                if (c < INT_SPACE) {
+                    // As per [JACKSON-208], call can now return:
+                    _throwUnquotedSpace(c, "string value");
+                } else {
+                    // Is this good enough error message?
+                    _reportInvalidChar(c);
+                }
             }
             // Need more room?
             if (outPtr >= outBuf.length) {
@@ -2792,7 +2848,8 @@ public class UTF8StreamJsonParser
      * if it is not needed. This can be done bit faster if contents
      * need not be stored for future access.
      */
-    protected void _skipString() throws IOException {
+    protected void _skipString() throws IOException
+    {
         _tokenIncomplete = false;
 
         // Need to be fully UTF-8 aware here:
@@ -2825,27 +2882,27 @@ public class UTF8StreamJsonParser
             if (c == INT_QUOTE) {
                 break main_loop;
             }
-
+            
             switch (codes[c]) {
-                case 1: // backslash
-                    _decodeEscaped();
-                    break;
-                case 2: // 2-byte UTF
-                    _skipUtf8_2();
-                    break;
-                case 3: // 3-byte UTF
-                    _skipUtf8_3();
-                    break;
-                case 4: // 4-byte UTF
-                    _skipUtf8_4(c);
-                    break;
-                default:
-                    if (c < INT_SPACE) {
-                        _throwUnquotedSpace(c, "string value");
-                    } else {
-                        // Is this good enough error message?
-                        _reportInvalidChar(c);
-                    }
+            case 1: // backslash
+                _decodeEscaped();
+                break;
+            case 2: // 2-byte UTF
+                _skipUtf8_2();
+                break;
+            case 3: // 3-byte UTF
+                _skipUtf8_3();
+                break;
+            case 4: // 4-byte UTF
+                _skipUtf8_4(c);
+                break;
+            default:
+                if (c < INT_SPACE) {
+                    _throwUnquotedSpace(c, "string value");
+                } else {
+                    // Is this good enough error message?
+                    _reportInvalidChar(c);
+                }
             }
         }
     }
@@ -2854,71 +2911,73 @@ public class UTF8StreamJsonParser
      * Method for handling cases where first non-space character
      * of an expected value token is not legal for standard JSON content.
      */
-    protected JsonToken _handleUnexpectedValue(int c) throws IOException {
+    protected JsonToken _handleUnexpectedValue(int c) throws IOException
+    {
         // Most likely an error, unless we are to allow single-quote-strings
         switch (c) {
-            /* This check proceeds only if `Feature.ALLOW_MISSING_VALUES` is enabled;
-             * it is for missing values. In case of missing values in an array the next token
-             * will be either ',' or ']'. This case, decrements the already incremented _inputPtr
-             * in the buffer in case of comma (`,`) so that the existing flow goes back to checking
-             * the next token which will be comma again and  it parsing continues.
-             * Also the case returns NULL as current token in case of ',' or ']'.
-             */
-            case ']':
-                if (!_parsingContext.inArray()) {
-                    break;
-                }
-                // fall through
-            case ',':
-                // 28-Mar-2016: [core#116]: If Feature.ALLOW_MISSING_VALUES is enabled
-                //   we may allow "missing values", that is, encountering a trailing
-                //   comma or closing marker where value would be expected
-                if ((_formatReadFeatures & FEAT_MASK_ALLOW_MISSING) != 0) {
-                    --_inputPtr;
-                    return JsonToken.VALUE_NULL;
-                }
-                // fall through
-            case '}':
-                // Error: neither is valid at this point; valid closers have
-                // been handled earlier
-                _reportUnexpectedChar(c, "expected a value");
-            case '\'':
-                if (isEnabled(JsonReadFeature.ALLOW_SINGLE_QUOTES)) {
-                    return _handleApos();
-                }
+        /* This check proceeds only if `Feature.ALLOW_MISSING_VALUES` is enabled;
+         * it is for missing values. In case of missing values in an array the next token
+         * will be either ',' or ']'. This case, decrements the already incremented _inputPtr
+         * in the buffer in case of comma (`,`) so that the existing flow goes back to checking
+         * the next token which will be comma again and  it parsing continues.
+         * Also the case returns NULL as current token in case of ',' or ']'.    
+         */
+        case ']':
+            if (!_parsingContext.inArray()) {
                 break;
-            case 'N':
-                _matchToken("NaN", 1);
-                if (isEnabled(JsonReadFeature.ALLOW_NON_NUMERIC_NUMBERS)) {
-                    return resetAsNaN("NaN", Double.NaN);
+            }
+            // fall through
+        case ',':
+            // 28-Mar-2016: [core#116]: If Feature.ALLOW_MISSING_VALUES is enabled
+            //   we may allow "missing values", that is, encountering a trailing
+            //   comma or closing marker where value would be expected
+            if ((_formatReadFeatures & FEAT_MASK_ALLOW_MISSING) != 0) {
+                --_inputPtr;
+                return JsonToken.VALUE_NULL;
+            }
+            // fall through
+        case '}':
+            // Error: neither is valid at this point; valid closers have
+            // been handled earlier
+            _reportUnexpectedChar(c, "expected a value");
+        case '\'':
+            if (isEnabled(JsonReadFeature.ALLOW_SINGLE_QUOTES)) {
+                return _handleApos();
+            }
+            break;
+        case 'N':
+            _matchToken("NaN", 1);
+            if (isEnabled(JsonReadFeature.ALLOW_NON_NUMERIC_NUMBERS)) {
+                return resetAsNaN("NaN", Double.NaN);
+            }
+            _reportError("Non-standard token 'NaN': enable JsonParser.Feature.ALLOW_NON_NUMERIC_NUMBERS to allow");
+            break;
+        case 'I':
+            _matchToken("Infinity", 1);
+            if (isEnabled(JsonReadFeature.ALLOW_NON_NUMERIC_NUMBERS)) {
+                return resetAsNaN("Infinity", Double.POSITIVE_INFINITY);
+            }
+            _reportError("Non-standard token 'Infinity': enable JsonParser.Feature.ALLOW_NON_NUMERIC_NUMBERS to allow");
+            break;
+        case '+': // note: '-' is taken as number
+            if (_inputPtr >= _inputEnd) {
+                if (!_loadMore()) {
+                    _reportInvalidEOFInValue(JsonToken.VALUE_NUMBER_INT);
                 }
-                _reportError("Non-standard token 'NaN': enable JsonParser.Feature.ALLOW_NON_NUMERIC_NUMBERS to allow");
-                break;
-            case 'I':
-                _matchToken("Infinity", 1);
-                if (isEnabled(JsonReadFeature.ALLOW_NON_NUMERIC_NUMBERS)) {
-                    return resetAsNaN("Infinity", Double.POSITIVE_INFINITY);
-                }
-                _reportError("Non-standard token 'Infinity': enable JsonParser.Feature.ALLOW_NON_NUMERIC_NUMBERS to allow");
-                break;
-            case '+': // note: '-' is taken as number
-                if (_inputPtr >= _inputEnd) {
-                    if (!_loadMore()) {
-                        _reportInvalidEOFInValue(JsonToken.VALUE_NUMBER_INT);
-                    }
-                }
-                return _handleInvalidNumberStart(_inputBuffer[_inputPtr++] & 0xFF, false);
+            }
+            return _handleInvalidNumberStart(_inputBuffer[_inputPtr++] & 0xFF, false);
         }
         // [core#77] Try to decode most likely token
         if (Character.isJavaIdentifierStart(c)) {
-            _reportInvalidToken("" + ((char) c), "('true', 'false' or 'null')");
+            _reportInvalidToken(""+((char) c), "('true', 'false' or 'null')");
         }
         // but if it doesn't look like a token:
         _reportUnexpectedChar(c, "expected a valid value (number, String, array, object, 'true', 'false' or 'null')");
         return null;
     }
 
-    protected JsonToken _handleApos() throws IOException {
+    protected JsonToken _handleApos() throws IOException
+    {
         int c = 0;
         // Otherwise almost verbatim copy of _finishString()
         int outPtr = 0;
@@ -2962,36 +3021,36 @@ public class UTF8StreamJsonParser
             }
 
             switch (codes[c]) {
-                case 1: // backslash
-                    c = _decodeEscaped();
-                    break;
-                case 2: // 2-byte UTF
-                    c = _decodeUtf8_2(c);
-                    break;
-                case 3: // 3-byte UTF
-                    if ((_inputEnd - _inputPtr) >= 2) {
-                        c = _decodeUtf8_3fast(c);
-                    } else {
-                        c = _decodeUtf8_3(c);
-                    }
-                    break;
-                case 4: // 4-byte UTF
-                    c = _decodeUtf8_4(c);
-                    // Let's add first part right away:
-                    outBuf[outPtr++] = (char) (0xD800 | (c >> 10));
-                    if (outPtr >= outBuf.length) {
-                        outBuf = _textBuffer.finishCurrentSegment();
-                        outPtr = 0;
-                    }
-                    c = 0xDC00 | (c & 0x3FF);
-                    // And let the other char output down below
-                    break;
-                default:
-                    if (c < INT_SPACE) {
-                        _throwUnquotedSpace(c, "string value");
-                    }
-                    // Is this good enough error message?
-                    _reportInvalidChar(c);
+            case 1: // backslash
+                c = _decodeEscaped();
+                break;
+            case 2: // 2-byte UTF
+                c = _decodeUtf8_2(c);
+                break;
+            case 3: // 3-byte UTF
+                if ((_inputEnd - _inputPtr) >= 2) {
+                    c = _decodeUtf8_3fast(c);
+                } else {
+                    c = _decodeUtf8_3(c);
+                }
+                break;
+            case 4: // 4-byte UTF
+                c = _decodeUtf8_4(c);
+                // Let's add first part right away:
+                outBuf[outPtr++] = (char) (0xD800 | (c >> 10));
+                if (outPtr >= outBuf.length) {
+                    outBuf = _textBuffer.finishCurrentSegment();
+                    outPtr = 0;
+                }
+                c = 0xDC00 | (c & 0x3FF);
+                // And let the other char output down below
+                break;
+            default:
+                if (c < INT_SPACE) {
+                    _throwUnquotedSpace(c, "string value");
+                }
+                // Is this good enough error message?
+                _reportInvalidChar(c);
             }
             // Need more room?
             if (outPtr >= outBuf.length) {
@@ -3016,7 +3075,8 @@ public class UTF8StreamJsonParser
      * Method called if expected numeric value (due to leading sign) does not
      * look like a number
      */
-    protected JsonToken _handleInvalidNumberStart(int ch, boolean neg) throws IOException {
+    protected JsonToken _handleInvalidNumberStart(int ch, boolean neg) throws IOException
+    {
         while (ch == 'I') {
             if (_inputPtr >= _inputEnd) {
                 if (!_loadMore()) {
@@ -3026,9 +3086,9 @@ public class UTF8StreamJsonParser
             ch = _inputBuffer[_inputPtr++];
             String match;
             if (ch == 'N') {
-                match = neg ? "-INF" : "+INF";
+                match = neg ? "-INF" :"+INF";
             } else if (ch == 'n') {
-                match = neg ? "-Infinity" : "+Infinity";
+                match = neg ? "-Infinity" :"+Infinity";
             } else {
                 break;
             }
@@ -3044,13 +3104,14 @@ public class UTF8StreamJsonParser
     }
 
     // NOTE: first character already decoded
-    protected final void _matchTrue() throws IOException {
+    protected final void _matchTrue() throws IOException
+    {
         int ptr = _inputPtr;
         if ((ptr + 3) < _inputEnd) {
             byte[] buf = _inputBuffer;
-            if ((buf[ptr++] == 'r')
-                    && (buf[ptr++] == 'u')
-                    && (buf[ptr++] == 'e')) {
+            if ((buf[ptr++] == 'r') 
+                   && (buf[ptr++] == 'u')
+                   && (buf[ptr++] == 'e')) {
                 int ch = buf[ptr] & 0xFF;
                 if (ch < INT_0 || (ch == INT_RBRACKET) || (ch == INT_RCURLY)) { // expected/allowed chars
                     _inputPtr = ptr;
@@ -3061,14 +3122,15 @@ public class UTF8StreamJsonParser
         _matchToken2("true", 1);
     }
 
-    protected final void _matchFalse() throws IOException {
+    protected final void _matchFalse() throws IOException
+    {
         int ptr = _inputPtr;
         if ((ptr + 4) < _inputEnd) {
             byte[] buf = _inputBuffer;
-            if ((buf[ptr++] == 'a')
-                    && (buf[ptr++] == 'l')
-                    && (buf[ptr++] == 's')
-                    && (buf[ptr++] == 'e')) {
+            if ((buf[ptr++] == 'a') 
+                   && (buf[ptr++] == 'l')
+                   && (buf[ptr++] == 's')
+                   && (buf[ptr++] == 'e')) {
                 int ch = buf[ptr] & 0xFF;
                 if (ch < INT_0 || (ch == INT_RBRACKET) || (ch == INT_RCURLY)) { // expected/allowed chars
                     _inputPtr = ptr;
@@ -3079,13 +3141,14 @@ public class UTF8StreamJsonParser
         _matchToken2("false", 1);
     }
 
-    protected final void _matchNull() throws IOException {
+    protected final void _matchNull() throws IOException
+    {
         int ptr = _inputPtr;
         if ((ptr + 3) < _inputEnd) {
             byte[] buf = _inputBuffer;
-            if ((buf[ptr++] == 'u')
-                    && (buf[ptr++] == 'l')
-                    && (buf[ptr++] == 'l')) {
+            if ((buf[ptr++] == 'u') 
+                   && (buf[ptr++] == 'l')
+                   && (buf[ptr++] == 'l')) {
                 int ch = buf[ptr] & 0xFF;
                 if (ch < INT_0 || (ch == INT_RBRACKET) || (ch == INT_RCURLY)) { // expected/allowed chars
                     _inputPtr = ptr;
@@ -3095,8 +3158,9 @@ public class UTF8StreamJsonParser
         }
         _matchToken2("null", 1);
     }
-
-    protected final void _matchToken(String matchStr, int i) throws IOException {
+    
+    protected final void _matchToken(String matchStr, int i) throws IOException
+    {
         final int len = matchStr.length();
         if ((_inputPtr + len) >= _inputEnd) {
             _matchToken2(matchStr, i);
@@ -3108,23 +3172,24 @@ public class UTF8StreamJsonParser
             }
             ++_inputPtr;
         } while (++i < len);
-
+    
         int ch = _inputBuffer[_inputPtr] & 0xFF;
         if (ch >= '0' && ch != ']' && ch != '}') { // expected/allowed chars
             _checkMatchEnd(matchStr, i, ch);
         }
     }
 
-    private final void _matchToken2(String matchStr, int i) throws IOException {
+    private final void _matchToken2(String matchStr, int i) throws IOException
+    {
         final int len = matchStr.length();
         do {
             if (((_inputPtr >= _inputEnd) && !_loadMore())
-                    || (_inputBuffer[_inputPtr] != matchStr.charAt(i))) {
+                ||  (_inputBuffer[_inputPtr] != matchStr.charAt(i))) {
                 _reportInvalidToken(matchStr.substring(0, i));
             }
             ++_inputPtr;
         } while (++i < len);
-
+    
         // but let's also ensure we either get EOF, or non-alphanum char...
         if (_inputPtr >= _inputEnd && !_loadMore()) {
             return;
@@ -3149,7 +3214,8 @@ public class UTF8StreamJsonParser
     /**********************************************************
      */
 
-    private final int _skipWS() throws IOException {
+    private final int _skipWS() throws IOException
+    {
         while (_inputPtr < _inputEnd) {
             int i = _inputBuffer[_inputPtr++] & 0xFF;
             if (i > INT_SPACE) {
@@ -3173,7 +3239,8 @@ public class UTF8StreamJsonParser
         return _skipWS2();
     }
 
-    private final int _skipWS2() throws IOException {
+    private final int _skipWS2() throws IOException
+    {
         while (_inputPtr < _inputEnd || _loadMore()) {
             int i = _inputBuffer[_inputPtr++] & 0xFF;
             if (i > INT_SPACE) {
@@ -3198,11 +3265,12 @@ public class UTF8StreamJsonParser
                     _throwInvalidSpace(i);
                 }
             }
-        }
-        throw _constructError("Unexpected end-of-input within/between " + _parsingContext.typeDesc() + " entries");
+        }        
+        throw _constructError("Unexpected end-of-input within/between "+_parsingContext.typeDesc()+" entries");
     }
 
-    private final int _skipWSOrEnd() throws IOException {
+    private final int _skipWSOrEnd() throws IOException
+    {
         // Let's handle first character separately since it is likely that
         // it is either non-whitespace; or we have longer run of white space
         if (_inputPtr >= _inputEnd) {
@@ -3228,7 +3296,7 @@ public class UTF8StreamJsonParser
                 _throwInvalidSpace(i);
             }
         }
-
+        
         while (_inputPtr < _inputEnd) {
             i = _inputBuffer[_inputPtr++] & 0xFF;
             if (i > INT_SPACE) {
@@ -3252,7 +3320,8 @@ public class UTF8StreamJsonParser
         return _skipWSOrEnd2();
     }
 
-    private final int _skipWSOrEnd2() throws IOException {
+    private final int _skipWSOrEnd2() throws IOException
+    {
         while ((_inputPtr < _inputEnd) || _loadMore()) {
             int i = _inputBuffer[_inputPtr++] & 0xFF;
             if (i > INT_SPACE) {
@@ -3281,7 +3350,8 @@ public class UTF8StreamJsonParser
         return _eofAsNextChar();
     }
 
-    private final int _skipColon() throws IOException {
+    private final int _skipColon() throws IOException
+    {
         if ((_inputPtr + 4) >= _inputEnd) {
             return _skipColon2(false);
         }
@@ -3302,7 +3372,7 @@ public class UTF8StreamJsonParser
                     if (i == INT_SLASH || i == INT_HASH) {
                         return _skipColon2(true);
                     }
-                    ++_inputPtr;
+                    ++_inputPtr;                    
                     return i;
                 }
             }
@@ -3335,7 +3405,8 @@ public class UTF8StreamJsonParser
         return _skipColon2(false);
     }
 
-    private final int _skipColon2(boolean gotColon) throws IOException {
+    private final int _skipColon2(boolean gotColon) throws IOException
+    {
         while (_inputPtr < _inputEnd || _loadMore()) {
             int i = _inputBuffer[_inputPtr++] & 0xFF;
 
@@ -3367,12 +3438,13 @@ public class UTF8StreamJsonParser
                 }
             }
         }
-        _reportInvalidEOF(" within/between " + _parsingContext.typeDesc() + " entries",
+        _reportInvalidEOF(" within/between "+_parsingContext.typeDesc()+" entries",
                 null);
         return -1;
     }
 
-    private final void _skipComment() throws IOException {
+    private final void _skipComment() throws IOException
+    {
         if (!isEnabled(JsonReadFeature.ALLOW_JAVA_COMMENTS)) {
             _reportUnexpectedChar('/', "maybe a (non-standard) comment? (not recognized as one since Feature 'ALLOW_COMMENTS' not enabled for parser)");
         }
@@ -3390,7 +3462,8 @@ public class UTF8StreamJsonParser
         }
     }
 
-    private final void _skipCComment() throws IOException {
+    private final void _skipCComment() throws IOException
+    {
         // Need to be UTF-8 aware here to decode content (for skipping)
         final int[] codes = CharTypes.getInputCodeComment();
 
@@ -3401,41 +3474,42 @@ public class UTF8StreamJsonParser
             int code = codes[i];
             if (code != 0) {
                 switch (code) {
-                    case '*':
-                        if (_inputPtr >= _inputEnd && !_loadMore()) {
-                            break main_loop;
-                        }
-                        if (_inputBuffer[_inputPtr] == INT_SLASH) {
-                            ++_inputPtr;
-                            return;
-                        }
-                        break;
-                    case INT_LF:
-                        ++_currInputRow;
-                        _currInputRowStart = _inputPtr;
-                        break;
-                    case INT_CR:
-                        _skipCR();
-                        break;
-                    case 2: // 2-byte UTF
-                        _skipUtf8_2();
-                        break;
-                    case 3: // 3-byte UTF
-                        _skipUtf8_3();
-                        break;
-                    case 4: // 4-byte UTF
-                        _skipUtf8_4(i);
-                        break;
-                    default: // e.g. -1
-                        // Is this good enough error message?
-                        _reportInvalidChar(i);
+                case '*':
+                    if (_inputPtr >= _inputEnd && !_loadMore()) {
+                        break main_loop;
+                    }
+                    if (_inputBuffer[_inputPtr] == INT_SLASH) {
+                        ++_inputPtr;
+                        return;
+                    }
+                    break;
+                case INT_LF:
+                    ++_currInputRow;
+                    _currInputRowStart = _inputPtr;
+                    break;
+                case INT_CR:
+                    _skipCR();
+                    break;
+                case 2: // 2-byte UTF
+                    _skipUtf8_2();
+                    break;
+                case 3: // 3-byte UTF
+                    _skipUtf8_3();
+                    break;
+                case 4: // 4-byte UTF
+                    _skipUtf8_4(i);
+                    break;
+                default: // e.g. -1
+                    // Is this good enough error message?
+                    _reportInvalidChar(i);
                 }
             }
         }
         _reportInvalidEOF(" in a comment", null);
     }
 
-    private final boolean _skipYAMLComment() throws IOException {
+    private final boolean _skipYAMLComment() throws IOException
+    {
         if (!isEnabled(JsonReadFeature.ALLOW_YAML_COMMENTS)) {
             return false;
         }
@@ -3447,7 +3521,8 @@ public class UTF8StreamJsonParser
      * Method for skipping contents of an input line; usually for CPP
      * and YAML style comments.
      */
-    private final void _skipLine() throws IOException {
+    private final void _skipLine() throws IOException
+    {
         // Ok: need to find EOF or linefeed
         final int[] codes = CharTypes.getInputCodeComment();
         while ((_inputPtr < _inputEnd) || _loadMore()) {
@@ -3455,36 +3530,37 @@ public class UTF8StreamJsonParser
             int code = codes[i];
             if (code != 0) {
                 switch (code) {
-                    case INT_LF:
-                        ++_currInputRow;
-                        _currInputRowStart = _inputPtr;
-                        return;
-                    case INT_CR:
-                        _skipCR();
-                        return;
-                    case '*': // nop for these comments
-                        break;
-                    case 2: // 2-byte UTF
-                        _skipUtf8_2();
-                        break;
-                    case 3: // 3-byte UTF
-                        _skipUtf8_3();
-                        break;
-                    case 4: // 4-byte UTF
-                        _skipUtf8_4(i);
-                        break;
-                    default: // e.g. -1
-                        if (code < 0) {
-                            // Is this good enough error message?
-                            _reportInvalidChar(i);
-                        }
+                case INT_LF:
+                    ++_currInputRow;
+                    _currInputRowStart = _inputPtr;
+                    return;
+                case INT_CR:
+                    _skipCR();
+                    return;
+                case '*': // nop for these comments
+                    break;
+                case 2: // 2-byte UTF
+                    _skipUtf8_2();
+                    break;
+                case 3: // 3-byte UTF
+                    _skipUtf8_3();
+                    break;
+                case 4: // 4-byte UTF
+                    _skipUtf8_4(i);
+                    break;
+                default: // e.g. -1
+                    if (code < 0) {
+                        // Is this good enough error message?
+                        _reportInvalidChar(i);
+                    }
                 }
             }
         }
     }
-
+    
     @Override
-    protected char _decodeEscaped() throws IOException {
+    protected char _decodeEscaped() throws IOException
+    {
         if (_inputPtr >= _inputEnd) {
             if (!_loadMore()) {
                 _reportInvalidEOF(" in character escape sequence", JsonToken.VALUE_STRING);
@@ -3494,28 +3570,28 @@ public class UTF8StreamJsonParser
 
         switch (c) {
             // First, ones that are mapped
-            case 'b':
-                return '\b';
-            case 't':
-                return '\t';
-            case 'n':
-                return '\n';
-            case 'f':
-                return '\f';
-            case 'r':
-                return '\r';
+        case 'b':
+            return '\b';
+        case 't':
+            return '\t';
+        case 'n':
+            return '\n';
+        case 'f':
+            return '\f';
+        case 'r':
+            return '\r';
 
             // And these are to be returned as they are
-            case '"':
-            case '/':
-            case '\\':
-                return (char) c;
+        case '"':
+        case '/':
+        case '\\':
+            return (char) c;
 
-            case 'u': // and finally hex-escaped
-                break;
+        case 'u': // and finally hex-escaped
+            break;
 
-            default:
-                return _handleUnrecognizedCharacterEscape((char) _decodeCharForError(c));
+        default:
+            return _handleUnrecognizedCharacterEscape((char) _decodeCharForError(c));
         }
 
         // Ok, a hex escape. Need 4 characters
@@ -3536,11 +3612,12 @@ public class UTF8StreamJsonParser
         return (char) value;
     }
 
-    protected int _decodeCharForError(int firstByte) throws IOException {
+    protected int _decodeCharForError(int firstByte) throws IOException
+    {
         int c = firstByte & 0xFF;
         if (c > 0x7F) { // if >= 0, is ascii and fine as is
             int needed;
-
+            
             // Ok; if we end here, we got multi-byte combination
             if ((c & 0xE0) == 0xC0) { // 2 bytes (0x0080 - 0x07FF)
                 c &= 0x1F;
@@ -3562,7 +3639,7 @@ public class UTF8StreamJsonParser
                 _reportInvalidOther(d & 0xFF);
             }
             c = (c << 6) | (d & 0x3F);
-
+            
             if (needed > 1) { // needed == 1 means 2 bytes total
                 d = nextByte(); // 3rd byte
                 if ((d & 0xC0) != 0x080) {
@@ -3587,7 +3664,8 @@ public class UTF8StreamJsonParser
     /**********************************************************
      */
 
-    private final int _decodeUtf8_2(int c) throws IOException {
+    private final int _decodeUtf8_2(int c) throws IOException
+    {
         if (_inputPtr >= _inputEnd) {
             _loadMoreGuaranteed();
         }
@@ -3598,7 +3676,8 @@ public class UTF8StreamJsonParser
         return ((c & 0x1F) << 6) | (d & 0x3F);
     }
 
-    private final int _decodeUtf8_3(int c1) throws IOException {
+    private final int _decodeUtf8_3(int c1) throws IOException
+    {
         if (_inputPtr >= _inputEnd) {
             _loadMoreGuaranteed();
         }
@@ -3619,7 +3698,8 @@ public class UTF8StreamJsonParser
         return c;
     }
 
-    private final int _decodeUtf8_3fast(int c1) throws IOException {
+    private final int _decodeUtf8_3fast(int c1) throws IOException
+    {
         c1 &= 0x0F;
         int d = (int) _inputBuffer[_inputPtr++];
         if ((d & 0xC0) != 0x080) {
@@ -3636,9 +3716,10 @@ public class UTF8StreamJsonParser
 
     /**
      * @return Character value <b>minus 0x10000</c>; this so that caller
-     * can readily expand it to actual surrogates
+     *    can readily expand it to actual surrogates
      */
-    private final int _decodeUtf8_4(int c) throws IOException {
+    private final int _decodeUtf8_4(int c) throws IOException
+    {
         if (_inputPtr >= _inputEnd) {
             _loadMoreGuaranteed();
         }
@@ -3670,7 +3751,8 @@ public class UTF8StreamJsonParser
         return ((c << 6) | (d & 0x3F)) - 0x10000;
     }
 
-    private final void _skipUtf8_2() throws IOException {
+    private final void _skipUtf8_2() throws IOException
+    {
         if (_inputPtr >= _inputEnd) {
             _loadMoreGuaranteed();
         }
@@ -3683,7 +3765,8 @@ public class UTF8StreamJsonParser
     /* Alas, can't heavily optimize skipping, since we still have to
      * do validity checks...
      */
-    private final void _skipUtf8_3() throws IOException {
+    private final void _skipUtf8_3() throws IOException
+    {
         if (_inputPtr >= _inputEnd) {
             _loadMoreGuaranteed();
         }
@@ -3701,7 +3784,8 @@ public class UTF8StreamJsonParser
         }
     }
 
-    private final void _skipUtf8_4(int c) throws IOException {
+    private final void _skipUtf8_4(int c) throws IOException
+    {
         if (_inputPtr >= _inputEnd) {
             _loadMoreGuaranteed();
         }
@@ -3735,7 +3819,8 @@ public class UTF8StreamJsonParser
      * We actually need to check the character value here
      * (to see if we have \n following \r).
      */
-    protected final void _skipCR() throws IOException {
+    protected final void _skipCR() throws IOException
+    {
         if (_inputPtr < _inputEnd || _loadMore()) {
             if (_inputBuffer[_inputPtr] == BYTE_LF) {
                 ++_inputPtr;
@@ -3745,7 +3830,8 @@ public class UTF8StreamJsonParser
         _currInputRowStart = _inputPtr;
     }
 
-    private int nextByte() throws IOException {
+        private int nextByte() throws IOException
+    {
         if (_inputPtr >= _inputEnd) {
             _loadMoreGuaranteed();
         }
@@ -3767,7 +3853,8 @@ public class UTF8StreamJsonParser
         _reportInvalidToken(matchedPart, "'null', 'true', 'false' or NaN");
     }
 
-    protected void _reportInvalidToken(String matchedPart, String msg) throws IOException {
+    protected void _reportInvalidToken(String matchedPart, String msg) throws IOException
+    {
         /* Let's just try to find what appears to be the token, using
          * regular Java identifier character rules. It's just a heuristic,
          * nothing fancy here (nor fast).
@@ -3790,7 +3877,8 @@ public class UTF8StreamJsonParser
         _reportError("Unrecognized token '%s': was expecting %s", sb, msg);
     }
 
-    protected void _reportInvalidChar(int c) throws JsonParseException {
+    protected void _reportInvalidChar(int c) throws JsonParseException
+    {
         // Either invalid WS or illegal UTF-8 start char
         if (c < INT_SPACE) {
             _throwInvalidSpace(c);
@@ -3799,15 +3887,16 @@ public class UTF8StreamJsonParser
     }
 
     protected void _reportInvalidInitial(int mask) throws JsonParseException {
-        _reportError("Invalid UTF-8 start byte 0x" + Integer.toHexString(mask));
+        _reportError("Invalid UTF-8 start byte 0x"+Integer.toHexString(mask));
     }
 
     protected void _reportInvalidOther(int mask) throws JsonParseException {
-        _reportError("Invalid UTF-8 middle byte 0x" + Integer.toHexString(mask));
+        _reportError("Invalid UTF-8 middle byte 0x"+Integer.toHexString(mask));
     }
 
     protected void _reportInvalidOther(int mask, int ptr)
-            throws JsonParseException {
+        throws JsonParseException
+    {
         _inputPtr = ptr;
         _reportInvalidOther(mask);
     }
@@ -3823,7 +3912,8 @@ public class UTF8StreamJsonParser
      * textual content.
      */
     @SuppressWarnings("resource")
-    protected final byte[] _decodeBase64(Base64Variant b64variant) throws IOException {
+    protected final byte[] _decodeBase64(Base64Variant b64variant) throws IOException
+    {
         ByteArrayBuilder builder = _getByteArrayBuilder();
 
         while (true) {
@@ -3846,9 +3936,9 @@ public class UTF8StreamJsonParser
                 }
             }
             int decodedData = bits;
-
+            
             // then second base64 char; can't get padding yet, nor ws
-
+            
             if (_inputPtr >= _inputEnd) {
                 _loadMoreGuaranteed();
             }
@@ -3858,7 +3948,7 @@ public class UTF8StreamJsonParser
                 bits = _decodeBase64Escape(b64variant, ch, 1);
             }
             decodedData = (decodedData << 6) | bits;
-
+            
             // third base64 char; can be padding, but not ws
             if (_inputPtr >= _inputEnd) {
                 _loadMoreGuaranteed();
@@ -3889,7 +3979,7 @@ public class UTF8StreamJsonParser
                     ch = _inputBuffer[_inputPtr++] & 0xFF;
                     if (!b64variant.usesPaddingChar(ch)) {
                         if (_decodeBase64Escape(b64variant, ch, 3) != Base64Variant.BASE64_VALUE_PADDING) {
-                            throw reportInvalidBase64Char(b64variant, ch, 3, "expected padding character '" + b64variant.getPaddingChar() + "'");
+                            throw reportInvalidBase64Char(b64variant, ch, 3, "expected padding character '"+b64variant.getPaddingChar()+"'");
                         }
                     }
                     // Got 12 bits, only need 8, need to shift
@@ -3943,33 +4033,37 @@ public class UTF8StreamJsonParser
 
     // As per [core#108], must ensure we call the right method
     @Override
-    public JsonLocation getTokenLocation() {
+    public JsonLocation getTokenLocation()
+    {
         if (_currToken == JsonToken.FIELD_NAME) {
-            long total = _currInputProcessed + (_nameStartOffset - 1);
+            long total = _currInputProcessed + (_nameStartOffset-1);
             return new JsonLocation(_getSourceReference(),
                     total, -1L, _nameStartRow, _nameStartCol);
         }
         return new JsonLocation(_getSourceReference(),
-                _tokenInputTotal - 1, -1L, _tokenInputRow, _tokenInputCol);
+                _tokenInputTotal-1, -1L, _tokenInputRow, _tokenInputCol);
     }
 
     // As per [core#108], must ensure we call the right method
     @Override
-    public JsonLocation getCurrentLocation() {
+    public JsonLocation getCurrentLocation()
+    {
         int col = _inputPtr - _currInputRowStart + 1; // 1-based
         return new JsonLocation(_getSourceReference(),
                 _currInputProcessed + _inputPtr, -1L, // bytes, chars
                 _currInputRow, col);
     }
 
-    private final void _updateLocation() {
+    private final void _updateLocation()
+    {
         _tokenInputRow = _currInputRow;
         final int ptr = _inputPtr;
         _tokenInputTotal = _currInputProcessed + ptr;
         _tokenInputCol = ptr - _currInputRowStart;
     }
 
-    private final void _updateNameLocation() {
+    private final void _updateNameLocation()
+    {
         _nameStartRow = _currInputRow;
         final int ptr = _inputPtr;
         _nameStartOffset = ptr;

--- a/src/main/java/com/fasterxml/jackson/core/json/UTF8StreamJsonParser.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/UTF8StreamJsonParser.java
@@ -1,5 +1,7 @@
 package com.fasterxml.jackson.core.json;
 
+import java.io.*;
+
 import com.fasterxml.jackson.core.*;
 import com.fasterxml.jackson.core.io.CharTypes;
 import com.fasterxml.jackson.core.io.IOContext;
@@ -7,23 +9,14 @@ import com.fasterxml.jackson.core.sym.ByteQuadsCanonicalizer;
 import com.fasterxml.jackson.core.sym.FieldNameMatcher;
 import com.fasterxml.jackson.core.util.ByteArrayBuilder;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.io.Writer;
-
-import static com.fasterxml.jackson.core.JsonTokenId.ID_FIELD_NAME;
-import static com.fasterxml.jackson.core.JsonTokenId.ID_NUMBER_FLOAT;
-import static com.fasterxml.jackson.core.JsonTokenId.ID_NUMBER_INT;
-import static com.fasterxml.jackson.core.JsonTokenId.ID_STRING;
+import static com.fasterxml.jackson.core.JsonTokenId.*;
 
 /**
  * This is a concrete implementation of {@link JsonParser}, which is
  * based on a {@link java.io.InputStream} as the input source.
  */
 public class UTF8StreamJsonParser
-    extends JsonParserBase
-{
+        extends JsonParserBase {
     final static byte BYTE_LF = (byte) '\n';
 
     private final static int FEAT_MASK_TRAILING_COMMA = JsonReadFeature.ALLOW_TRAILING_COMMA.getMask();
@@ -74,14 +67,14 @@ public class UTF8StreamJsonParser
      * Temporary input pointer
      */
     private int _quadPtr;
-    
+
     /**
      * Value of {@link #_inputPtr} at the time when the first character of
      * name token was read. Used for calculating token location when requested;
      * combined with {@link #_currInputProcessed}, may be updated appropriately
      * as needed.
      */
-    protected int _nameStartOffset; 
+    protected int _nameStartOffset;
 
     protected int _nameStartRow;
 
@@ -111,7 +104,7 @@ public class UTF8StreamJsonParser
     /**
      * Flag that indicates whether the input buffer is recycable (and
      * needs to be returned to recycler once we are done) or not.
-     *<p>
+     * <p>
      * If it is not, it also means that parser can NOT modify underlying
      * buffer.
      */
@@ -139,12 +132,11 @@ public class UTF8StreamJsonParser
     */
 
     public UTF8StreamJsonParser(ObjectReadContext readCtxt, IOContext ctxt,
-            int stdFeatures, int formatReadFeatures,
-            InputStream in,
-            ByteQuadsCanonicalizer sym,
-            byte[] inputBuffer, int start, int end, int bytesPreProcessed,
-            boolean bufferRecyclable)
-    {
+                                int stdFeatures, int formatReadFeatures,
+                                InputStream in,
+                                ByteQuadsCanonicalizer sym,
+                                byte[] inputBuffer, int start, int end, int bytesPreProcessed,
+                                boolean bufferRecyclable) {
         super(readCtxt, ctxt, stdFeatures, formatReadFeatures);
         _inputStream = in;
         _symbols = sym;
@@ -164,8 +156,7 @@ public class UTF8StreamJsonParser
      */
 
     @Override
-    public int releaseBuffered(OutputStream out) throws IOException
-    {
+    public int releaseBuffered(OutputStream out) throws IOException {
         int count = _inputEnd - _inputPtr;
         if (count < 1) {
             return 0;
@@ -187,8 +178,7 @@ public class UTF8StreamJsonParser
     /**********************************************************
      */
 
-    protected final boolean _loadMore() throws IOException
-    {
+    protected final boolean _loadMore() throws IOException {
         final int bufSize = _inputEnd;
 
         if (_inputStream != null) {
@@ -196,7 +186,7 @@ public class UTF8StreamJsonParser
             if (space == 0) { // only occurs when we've been closed
                 return false;
             }
-            
+
             int count = _inputStream.read(_inputBuffer, 0, space);
             if (count > 0) {
                 _inputPtr = 0;
@@ -216,15 +206,14 @@ public class UTF8StreamJsonParser
             _closeInput();
             // Should never return 0, so let's fail
             if (count == 0) {
-                throw new IOException("InputStream.read() returned 0 characters when trying to read "+_inputBuffer.length+" bytes");
+                throw new IOException("InputStream.read() returned 0 characters when trying to read " + _inputBuffer.length + " bytes");
             }
         }
         return false;
     }
 
     @Override
-    protected void _closeInput() throws IOException
-    {
+    protected void _closeInput() throws IOException {
         // We are not to call close() on the underlying InputStream
         // unless we "own" it, or auto-closing feature is enabled.
         if (_inputStream != null) {
@@ -242,8 +231,7 @@ public class UTF8StreamJsonParser
      * separately (if need be).
      */
     @Override
-    protected void _releaseBuffers() throws IOException
-    {
+    protected void _releaseBuffers() throws IOException {
         super._releaseBuffers();
         // Merge found symbols, if any:
         _symbols.release();
@@ -265,8 +253,7 @@ public class UTF8StreamJsonParser
      */
 
     @Override
-    public String getText() throws IOException
-    {
+    public String getText() throws IOException {
         if (_currToken == JsonToken.VALUE_STRING) {
             if (_tokenIncomplete) {
                 _tokenIncomplete = false;
@@ -278,8 +265,7 @@ public class UTF8StreamJsonParser
     }
 
     @Override
-    public int getText(Writer writer) throws IOException
-    {
+    public int getText(Writer writer) throws IOException {
         JsonToken t = _currToken;
         if (t == JsonToken.VALUE_STRING) {
             if (_tokenIncomplete) {
@@ -307,8 +293,7 @@ public class UTF8StreamJsonParser
     // // // Let's override default impls for improved performance
 
     @Override
-    public String getValueAsString() throws IOException
-    {
+    public String getValueAsString() throws IOException {
         if (_currToken == JsonToken.VALUE_STRING) {
             if (_tokenIncomplete) {
                 _tokenIncomplete = false;
@@ -323,8 +308,7 @@ public class UTF8StreamJsonParser
     }
 
     @Override
-    public String getValueAsString(String defValue) throws IOException
-    {
+    public String getValueAsString(String defValue) throws IOException {
         if (_currToken == JsonToken.VALUE_STRING) {
             if (_tokenIncomplete) {
                 _tokenIncomplete = false;
@@ -340,8 +324,7 @@ public class UTF8StreamJsonParser
 
     // since 2.6
     @Override
-    public int getValueAsInt() throws IOException
-    {
+    public int getValueAsInt() throws IOException {
         JsonToken t = _currToken;
         if ((t == JsonToken.VALUE_NUMBER_INT) || (t == JsonToken.VALUE_NUMBER_FLOAT)) {
             // inlined 'getIntValue()'
@@ -360,8 +343,7 @@ public class UTF8StreamJsonParser
 
     // since 2.6
     @Override
-    public int getValueAsInt(int defValue) throws IOException
-    {
+    public int getValueAsInt(int defValue) throws IOException {
         JsonToken t = _currToken;
         if ((t == JsonToken.VALUE_NUMBER_INT) || (t == JsonToken.VALUE_NUMBER_FLOAT)) {
             // inlined 'getIntValue()'
@@ -378,123 +360,118 @@ public class UTF8StreamJsonParser
         return super.getValueAsInt(defValue);
     }
 
-    protected final String _getText2(JsonToken t)
-    {
+    protected final String _getText2(JsonToken t) {
         if (t == null) {
             return null;
         }
         switch (t.id()) {
-        case ID_FIELD_NAME:
-            return _parsingContext.currentName();
+            case ID_FIELD_NAME:
+                return _parsingContext.currentName();
 
-        case ID_STRING:
-            // fall through
-        case ID_NUMBER_INT:
-        case ID_NUMBER_FLOAT:
-            return _textBuffer.contentsAsString();
-        default:
-        	return t.asString();
+            case ID_STRING:
+                // fall through
+            case ID_NUMBER_INT:
+            case ID_NUMBER_FLOAT:
+                return _textBuffer.contentsAsString();
+            default:
+                return t.asString();
         }
     }
 
     @Override
-    public char[] getTextCharacters() throws IOException
-    {
+    public char[] getTextCharacters() throws IOException {
         if (_currToken != null) { // null only before/after document
             switch (_currToken.id()) {
-                
-            case ID_FIELD_NAME:
-                if (!_nameCopied) {
-                    String name = _parsingContext.currentName();
-                    int nameLen = name.length();
-                    if (_nameCopyBuffer == null) {
-                        _nameCopyBuffer = _ioContext.allocNameCopyBuffer(nameLen);
-                    } else if (_nameCopyBuffer.length < nameLen) {
-                        _nameCopyBuffer = new char[nameLen];
+
+                case ID_FIELD_NAME:
+                    if (!_nameCopied) {
+                        String name = _parsingContext.currentName();
+                        int nameLen = name.length();
+                        if (_nameCopyBuffer == null) {
+                            _nameCopyBuffer = _ioContext.allocNameCopyBuffer(nameLen);
+                        } else if (_nameCopyBuffer.length < nameLen) {
+                            _nameCopyBuffer = new char[nameLen];
+                        }
+                        name.getChars(0, nameLen, _nameCopyBuffer, 0);
+                        _nameCopied = true;
                     }
-                    name.getChars(0, nameLen, _nameCopyBuffer, 0);
-                    _nameCopied = true;
-                }
-                return _nameCopyBuffer;
-    
-            case ID_STRING:
-                if (_tokenIncomplete) {
-                    _tokenIncomplete = false;
-                    _finishString(); // only strings can be incomplete
-                }
-                // fall through
-            case ID_NUMBER_INT:
-            case ID_NUMBER_FLOAT:
-                return _textBuffer.getTextBuffer();
-                
-            default:
-                return _currToken.asCharArray();
+                    return _nameCopyBuffer;
+
+                case ID_STRING:
+                    if (_tokenIncomplete) {
+                        _tokenIncomplete = false;
+                        _finishString(); // only strings can be incomplete
+                    }
+                    // fall through
+                case ID_NUMBER_INT:
+                case ID_NUMBER_FLOAT:
+                    return _textBuffer.getTextBuffer();
+
+                default:
+                    return _currToken.asCharArray();
             }
         }
         return null;
     }
 
     @Override
-    public int getTextLength() throws IOException
-    {
+    public int getTextLength() throws IOException {
         if (_currToken != null) { // null only before/after document
             switch (_currToken.id()) {
-                
-            case ID_FIELD_NAME:
-                return _parsingContext.currentName().length();
-            case ID_STRING:
-                if (_tokenIncomplete) {
-                    _tokenIncomplete = false;
-                    _finishString(); // only strings can be incomplete
-                }
-                // fall through
-            case ID_NUMBER_INT:
-            case ID_NUMBER_FLOAT:
-                return _textBuffer.size();
-                
-            default:
-                return _currToken.asCharArray().length;
+
+                case ID_FIELD_NAME:
+                    return _parsingContext.currentName().length();
+                case ID_STRING:
+                    if (_tokenIncomplete) {
+                        _tokenIncomplete = false;
+                        _finishString(); // only strings can be incomplete
+                    }
+                    // fall through
+                case ID_NUMBER_INT:
+                case ID_NUMBER_FLOAT:
+                    return _textBuffer.size();
+
+                default:
+                    return _currToken.asCharArray().length;
             }
         }
         return 0;
     }
 
     @Override
-    public int getTextOffset() throws IOException
-    {
+    public int getTextOffset() throws IOException {
         // Most have offset of 0, only some may have other values:
         if (_currToken != null) {
             switch (_currToken.id()) {
-            case ID_FIELD_NAME:
-                return 0;
-            case ID_STRING:
-                if (_tokenIncomplete) {
-                    _tokenIncomplete = false;
-                    _finishString(); // only strings can be incomplete
-                }
-                // fall through
-            case ID_NUMBER_INT:
-            case ID_NUMBER_FLOAT:
-                return _textBuffer.getTextOffset();
-            default:
+                case ID_FIELD_NAME:
+                    return 0;
+                case ID_STRING:
+                    if (_tokenIncomplete) {
+                        _tokenIncomplete = false;
+                        _finishString(); // only strings can be incomplete
+                    }
+                    // fall through
+                case ID_NUMBER_INT:
+                case ID_NUMBER_FLOAT:
+                    return _textBuffer.getTextOffset();
+                default:
             }
         }
         return 0;
     }
 
     @Override
-    public byte[] getBinaryValue(Base64Variant b64variant) throws IOException
-    {
+    public byte[] getBinaryValue(Base64Variant b64variant) throws IOException {
         if (_currToken != JsonToken.VALUE_STRING &&
                 (_currToken != JsonToken.VALUE_EMBEDDED_OBJECT || _binaryValue == null)) {
-            _reportError("Current token ("+_currToken+") not VALUE_STRING or VALUE_EMBEDDED_OBJECT, can not access as binary");
+            _reportError("Current token (" + _currToken + ") not VALUE_STRING or VALUE_EMBEDDED_OBJECT, can not access as binary");
         }
         // To ensure that we won't see inconsistent data, better clear up state...
         if (_tokenIncomplete) {
             try {
                 _binaryValue = _decodeBase64(b64variant);
             } catch (IllegalArgumentException iae) {
-                throw _constructError("Failed to decode VALUE_STRING as base64 ("+b64variant+"): "+iae.getMessage());
+                throw _constructError("Failed to decode VALUE_STRING as base64 (" + b64variant + "): " + iae.getMessage());
             }
             // let's clear incomplete only now; allows for accessing other textual content in error cases
             _tokenIncomplete = false;
@@ -510,8 +487,7 @@ public class UTF8StreamJsonParser
     }
 
     @Override
-    public int readBinaryValue(Base64Variant b64variant, OutputStream out) throws IOException
-    {
+    public int readBinaryValue(Base64Variant b64variant, OutputStream out) throws IOException {
         // if we have already read the token, just use whatever we may have
         if (!_tokenIncomplete || _currToken != JsonToken.VALUE_STRING) {
             byte[] b = getBinaryValue(b64variant);
@@ -528,8 +504,7 @@ public class UTF8StreamJsonParser
     }
 
     protected int _readBinary(Base64Variant b64variant, OutputStream out,
-                              byte[] buffer) throws IOException
-    {
+                              byte[] buffer) throws IOException {
         int outputPtr = 0;
         final int outputEnd = buffer.length - 3;
         int outputCount = 0;
@@ -605,7 +580,7 @@ public class UTF8StreamJsonParser
                     ch = _inputBuffer[_inputPtr++] & 0xFF;
                     if (!b64variant.usesPaddingChar(ch)) {
                         if (_decodeBase64Escape(b64variant, ch, 3) != Base64Variant.BASE64_VALUE_PADDING) {
-                            throw reportInvalidBase64Char(b64variant, ch, 3, "expected padding character '"+b64variant.getPaddingChar()+"'");
+                            throw reportInvalidBase64Char(b64variant, ch, 3, "expected padding character '" + b64variant.getPaddingChar() + "'");
                         }
                     }
                     // Got 12 bits, only need 8, need to shift
@@ -672,11 +647,10 @@ public class UTF8StreamJsonParser
 
     /**
      * @return Next token from the stream, if any found, or null
-     *   to indicate end-of-input
+     * to indicate end-of-input
      */
     @Override
-    public JsonToken nextToken() throws IOException
-    {
+    public JsonToken nextToken() throws IOException {
         /* First: field names are special -- we will always tokenize
          * (part of) value along with field name to simplify
          * state handling. If so, can and need to use secondary token:
@@ -712,7 +686,7 @@ public class UTF8StreamJsonParser
         // Nope: do we then expect a comma?
         if (_parsingContext.expectComma()) {
             if (i != INT_COMMA) {
-                _reportUnexpectedChar(i, "was expecting comma to separate "+_parsingContext.typeDesc()+" entries");
+                _reportUnexpectedChar(i, "was expecting comma to separate " + _parsingContext.typeDesc() + " entries");
             }
             i = _skipWS();
             // Was that a trailing comma?
@@ -744,104 +718,102 @@ public class UTF8StreamJsonParser
             _tokenIncomplete = true;
             _nextToken = JsonToken.VALUE_STRING;
             return _currToken;
-        }        
+        }
         JsonToken t;
 
         switch (i) {
-        case '-':
-            t = _parseNegNumber();
-            break;
+            case '-':
+                t = _parseNegNumber();
+                break;
 
             // Should we have separate handling for plus? Although it is not allowed per se,
             // it may be erroneously used, and could be indicate by a more specific error message.
-        case '0':
-        case '1':
-        case '2':
-        case '3':
-        case '4':
-        case '5':
-        case '6':
-        case '7':
-        case '8':
-        case '9':
-            t = _parsePosNumber(i);
-            break;
-        case 'f':
-            _matchFalse();
-             t = JsonToken.VALUE_FALSE;
-            break;
-        case 'n':
-            _matchNull();
-            t = JsonToken.VALUE_NULL;
-            break;
-        case 't':
-            _matchTrue();
-            t = JsonToken.VALUE_TRUE;
-            break;
-        case '[':
-            t = JsonToken.START_ARRAY;
-            break;
-        case '{':
-            t = JsonToken.START_OBJECT;
-            break;
+            case '0':
+            case '1':
+            case '2':
+            case '3':
+            case '4':
+            case '5':
+            case '6':
+            case '7':
+            case '8':
+            case '9':
+                t = _parsePosNumber(i);
+                break;
+            case 'f':
+                _matchFalse();
+                t = JsonToken.VALUE_FALSE;
+                break;
+            case 'n':
+                _matchNull();
+                t = JsonToken.VALUE_NULL;
+                break;
+            case 't':
+                _matchTrue();
+                t = JsonToken.VALUE_TRUE;
+                break;
+            case '[':
+                t = JsonToken.START_ARRAY;
+                break;
+            case '{':
+                t = JsonToken.START_OBJECT;
+                break;
 
-        default:
-            t = _handleUnexpectedValue(i);
+            default:
+                t = _handleUnexpectedValue(i);
         }
         _nextToken = t;
         return _currToken;
     }
 
-    private final JsonToken _nextTokenNotInObject(int i) throws IOException
-    {
+    private final JsonToken _nextTokenNotInObject(int i) throws IOException {
         if (i == INT_QUOTE) {
             _tokenIncomplete = true;
             return (_currToken = JsonToken.VALUE_STRING);
         }
         switch (i) {
-        case '[':
-            _parsingContext = _parsingContext.createChildArrayContext(_tokenInputRow, _tokenInputCol);
-            return (_currToken = JsonToken.START_ARRAY);
-        case '{':
-            _parsingContext = _parsingContext.createChildObjectContext(_tokenInputRow, _tokenInputCol);
-            return (_currToken = JsonToken.START_OBJECT);
-        case 't':
-            _matchTrue();
-            return (_currToken = JsonToken.VALUE_TRUE);
-        case 'f':
-            _matchFalse();
-            return (_currToken = JsonToken.VALUE_FALSE);
-        case 'n':
-            _matchNull();
-            return (_currToken = JsonToken.VALUE_NULL);
-        case '-':
-            return (_currToken = _parseNegNumber());
+            case '[':
+                _parsingContext = _parsingContext.createChildArrayContext(_tokenInputRow, _tokenInputCol);
+                return (_currToken = JsonToken.START_ARRAY);
+            case '{':
+                _parsingContext = _parsingContext.createChildObjectContext(_tokenInputRow, _tokenInputCol);
+                return (_currToken = JsonToken.START_OBJECT);
+            case 't':
+                _matchTrue();
+                return (_currToken = JsonToken.VALUE_TRUE);
+            case 'f':
+                _matchFalse();
+                return (_currToken = JsonToken.VALUE_FALSE);
+            case 'n':
+                _matchNull();
+                return (_currToken = JsonToken.VALUE_NULL);
+            case '-':
+                return (_currToken = _parseNegNumber());
 
             // Should we have separate handling for plus? Although it is not allowed per se,
             // it may be erroneously used, and could be indicate by a more specific error message.
-        case '0':
-        case '1':
-        case '2':
-        case '3':
-        case '4':
-        case '5':
-        case '6':
-        case '7':
-        case '8':
-        case '9':
-            return (_currToken = _parsePosNumber(i));
+            case '0':
+            case '1':
+            case '2':
+            case '3':
+            case '4':
+            case '5':
+            case '6':
+            case '7':
+            case '8':
+            case '9':
+                return (_currToken = _parsePosNumber(i));
         }
         return (_currToken = _handleUnexpectedValue(i));
     }
-    
-    private final JsonToken _nextAfterName()
-    {
+
+    private final JsonToken _nextAfterName() {
         _nameCopied = false; // need to invalidate if it was copied
         JsonToken t = _nextToken;
         _nextToken = null;
 
- // !!! 16-Nov-2015, tatu: TODO: fix [databind#37], copy next location to current here
-        
+        // !!! 16-Nov-2015, tatu: TODO: fix [databind#37], copy next location to current here
+
         // Also: may need to start new context?
         if (t == JsonToken.START_ARRAY) {
             _parsingContext = _parsingContext.createChildArrayContext(_tokenInputRow, _tokenInputCol);
@@ -866,8 +838,7 @@ public class UTF8StreamJsonParser
      */
 
     @Override
-    public String nextFieldName() throws IOException
-    {
+    public String nextFieldName() throws IOException {
         // // // Note: this is almost a verbatim copy of nextToken()
 
         _numTypesValid = NR_UNKNOWN;
@@ -900,7 +871,7 @@ public class UTF8StreamJsonParser
         // Nope: do we then expect a comma?
         if (_parsingContext.expectComma()) {
             if (i != INT_COMMA) {
-                _reportUnexpectedChar(i, "was expecting comma to separate "+_parsingContext.typeDesc()+" entries");
+                _reportUnexpectedChar(i, "was expecting comma to separate " + _parsingContext.typeDesc() + " entries");
             }
             i = _skipWS();
             // Was that a trailing comma?
@@ -932,50 +903,49 @@ public class UTF8StreamJsonParser
         }
         JsonToken t;
         switch (i) {
-        case '-':
-            t = _parseNegNumber();
-            break;
-        case '0':
-        case '1':
-        case '2':
-        case '3':
-        case '4':
-        case '5':
-        case '6':
-        case '7':
-        case '8':
-        case '9':
-            t = _parsePosNumber(i);
-            break;
-        case 'f':
-            _matchFalse();
-             t = JsonToken.VALUE_FALSE;
-            break;
-        case 'n':
-            _matchNull();
-            t = JsonToken.VALUE_NULL;
-            break;
-        case 't':
-            _matchTrue();
-            t = JsonToken.VALUE_TRUE;
-            break;
-        case '[':
-            t = JsonToken.START_ARRAY;
-            break;
-        case '{':
-            t = JsonToken.START_OBJECT;
-            break;
+            case '-':
+                t = _parseNegNumber();
+                break;
+            case '0':
+            case '1':
+            case '2':
+            case '3':
+            case '4':
+            case '5':
+            case '6':
+            case '7':
+            case '8':
+            case '9':
+                t = _parsePosNumber(i);
+                break;
+            case 'f':
+                _matchFalse();
+                t = JsonToken.VALUE_FALSE;
+                break;
+            case 'n':
+                _matchNull();
+                t = JsonToken.VALUE_NULL;
+                break;
+            case 't':
+                _matchTrue();
+                t = JsonToken.VALUE_TRUE;
+                break;
+            case '[':
+                t = JsonToken.START_ARRAY;
+                break;
+            case '{':
+                t = JsonToken.START_OBJECT;
+                break;
 
-        default:
-            t = _handleUnexpectedValue(i);
+            default:
+                t = _handleUnexpectedValue(i);
         }
         _nextToken = t;
         return nameStr;
     }
 
     @Override
-    public boolean nextFieldName(SerializableString str) throws IOException
-    {
+    public boolean nextFieldName(SerializableString str) throws IOException {
         // // // Note: most of code below is copied from nextToken()
         _numTypesValid = NR_UNKNOWN;
         if (_currToken == JsonToken.FIELD_NAME) { // can't have name right after name
@@ -1008,7 +978,7 @@ public class UTF8StreamJsonParser
         // Nope: do we then expect a comma?
         if (_parsingContext.expectComma()) {
             if (i != INT_COMMA) {
-                _reportUnexpectedChar(i, "was expecting comma to separate "+_parsingContext.typeDesc()+" entries");
+                _reportUnexpectedChar(i, "was expecting comma to separate " + _parsingContext.typeDesc() + " entries");
             }
             i = _skipWS();
 
@@ -1025,7 +995,7 @@ public class UTF8StreamJsonParser
             _nextTokenNotInObject(i);
             return false;
         }
-        
+
         // // // This part differs, name parsing
         _updateNameLocation();
         if (i == INT_QUOTE) {
@@ -1036,14 +1006,14 @@ public class UTF8StreamJsonParser
             //    of colon that follows name
             if ((_inputPtr + len + 4) < _inputEnd) { // maybe...
                 // first check length match by
-                final int end = _inputPtr+len;
+                final int end = _inputPtr + len;
                 if (_inputBuffer[end] == INT_QUOTE) {
                     int offset = 0;
                     int ptr = _inputPtr;
                     while (true) {
                         if (ptr == end) { // yes, match!
                             _parsingContext.setCurrentName(str.getValue());
-                            i = _skipColonFast(ptr+1);
+                            i = _skipColonFast(ptr + 1);
                             _isNextTokenNameYes(i);
                             return true;
                         }
@@ -1060,8 +1030,7 @@ public class UTF8StreamJsonParser
     }
 
     @Override
-    public int nextFieldName(FieldNameMatcher matcher) throws IOException
-    {
+    public int nextFieldName(FieldNameMatcher matcher) throws IOException {
         // // // Note: this is almost a verbatim copy of nextToken()
         _numTypesValid = NR_UNKNOWN;
         if (_currToken == JsonToken.FIELD_NAME) {
@@ -1093,7 +1062,7 @@ public class UTF8StreamJsonParser
         // Nope: do we then expect a comma?
         if (_parsingContext.expectComma()) {
             if (i != INT_COMMA) {
-                _reportUnexpectedChar(i, "was expecting comma to separate "+_parsingContext.typeDesc()+" entries");
+                _reportUnexpectedChar(i, "was expecting comma to separate " + _parsingContext.typeDesc() + " entries");
             }
             i = _skipWS();
             // Was that a trailing comma?
@@ -1144,50 +1113,49 @@ public class UTF8StreamJsonParser
         }
         JsonToken t;
         switch (i) {
-        case '-':
-            t = _parseNegNumber();
-            break;
-        case '0':
-        case '1':
-        case '2':
-        case '3':
-        case '4':
-        case '5':
-        case '6':
-        case '7':
-        case '8':
-        case '9':
-            t = _parsePosNumber(i);
-            break;
-        case 'f':
-            _matchFalse();
-             t = JsonToken.VALUE_FALSE;
-            break;
-        case 'n':
-            _matchNull();
-            t = JsonToken.VALUE_NULL;
-            break;
-        case 't':
-            _matchTrue();
-            t = JsonToken.VALUE_TRUE;
-            break;
-        case '[':
-            t = JsonToken.START_ARRAY;
-            break;
-        case '{':
-            t = JsonToken.START_OBJECT;
-            break;
+            case '-':
+                t = _parseNegNumber();
+                break;
+            case '0':
+            case '1':
+            case '2':
+            case '3':
+            case '4':
+            case '5':
+            case '6':
+            case '7':
+            case '8':
+            case '9':
+                t = _parsePosNumber(i);
+                break;
+            case 'f':
+                _matchFalse();
+                t = JsonToken.VALUE_FALSE;
+                break;
+            case 'n':
+                _matchNull();
+                t = JsonToken.VALUE_NULL;
+                break;
+            case 't':
+                _matchTrue();
+                t = JsonToken.VALUE_TRUE;
+                break;
+            case '[':
+                t = JsonToken.START_ARRAY;
+                break;
+            case '{':
+                t = JsonToken.START_OBJECT;
+                break;
 
-        default:
-            t = _handleUnexpectedValue(i);
+            default:
+                t = _handleUnexpectedValue(i);
         }
         _nextToken = t;
         return match;
     }
 
     // Variant called when we know there's at least 4 more bytes available
-    private final int _skipColonFast(int ptr) throws IOException
-    {
+    private final int _skipColonFast(int ptr) throws IOException {
         int i = _inputBuffer[ptr++];
         if (i == INT_COLON) { // common case, no leading space
             i = _inputBuffer[ptr++];
@@ -1205,7 +1173,7 @@ public class UTF8StreamJsonParser
                     }
                 }
             }
-            _inputPtr = ptr-1;
+            _inputPtr = ptr - 1;
             return _skipColon2(true); // true -> skipped colon
         }
         if (i == INT_SPACE || i == INT_TAB) {
@@ -1227,62 +1195,60 @@ public class UTF8StreamJsonParser
                     }
                 }
             }
-            _inputPtr = ptr-1;
+            _inputPtr = ptr - 1;
             return _skipColon2(true);
         }
-        _inputPtr = ptr-1;
+        _inputPtr = ptr - 1;
         return _skipColon2(false);
     }
 
-    private final void _isNextTokenNameYes(int i) throws IOException
-    {
+    private final void _isNextTokenNameYes(int i) throws IOException {
         _currToken = JsonToken.FIELD_NAME;
         _updateLocation();
 
         switch (i) {
-        case '"':
-            _tokenIncomplete = true;
-            _nextToken = JsonToken.VALUE_STRING;
-            return;
-        case '[':
-            _nextToken = JsonToken.START_ARRAY;
-            return;
-        case '{':
-            _nextToken = JsonToken.START_OBJECT;
-            return;
-        case 't':
-            _matchTrue();
-            _nextToken = JsonToken.VALUE_TRUE;
-            return;
-        case 'f':
-            _matchFalse();
-            _nextToken = JsonToken.VALUE_FALSE;
-            return;
-        case 'n':
-            _matchNull();
-            _nextToken = JsonToken.VALUE_NULL;
-            return;
-        case '-':
-            _nextToken = _parseNegNumber();
-            return;
-        case '0':
-        case '1':
-        case '2':
-        case '3':
-        case '4':
-        case '5':
-        case '6':
-        case '7':
-        case '8':
-        case '9':
-            _nextToken = _parsePosNumber(i);
-            return;
+            case '"':
+                _tokenIncomplete = true;
+                _nextToken = JsonToken.VALUE_STRING;
+                return;
+            case '[':
+                _nextToken = JsonToken.START_ARRAY;
+                return;
+            case '{':
+                _nextToken = JsonToken.START_OBJECT;
+                return;
+            case 't':
+                _matchTrue();
+                _nextToken = JsonToken.VALUE_TRUE;
+                return;
+            case 'f':
+                _matchFalse();
+                _nextToken = JsonToken.VALUE_FALSE;
+                return;
+            case 'n':
+                _matchNull();
+                _nextToken = JsonToken.VALUE_NULL;
+                return;
+            case '-':
+                _nextToken = _parseNegNumber();
+                return;
+            case '0':
+            case '1':
+            case '2':
+            case '3':
+            case '4':
+            case '5':
+            case '6':
+            case '7':
+            case '8':
+            case '9':
+                _nextToken = _parsePosNumber(i);
+                return;
         }
         _nextToken = _handleUnexpectedValue(i);
     }
 
-    private final boolean _isNextTokenNameMaybe(int i, SerializableString str) throws IOException
-    {
+    private final boolean _isNextTokenNameMaybe(int i, SerializableString str) throws IOException {
         // // // and this is back to standard nextToken()
 
         String n = _parseName(i);
@@ -1301,48 +1267,47 @@ public class UTF8StreamJsonParser
         JsonToken t;
 
         switch (i) {
-        case '[':
-            t = JsonToken.START_ARRAY;
-            break;
-        case '{':
-            t = JsonToken.START_OBJECT;
-            break;
-        case 't':
-            _matchTrue();
-            t = JsonToken.VALUE_TRUE;
-            break;
-        case 'f':
-            _matchFalse();
-             t = JsonToken.VALUE_FALSE;
-            break;
-        case 'n':
-            _matchNull();
-            t = JsonToken.VALUE_NULL;
-            break;
-        case '-':
-            t = _parseNegNumber();
-            break;
-        case '0':
-        case '1':
-        case '2':
-        case '3':
-        case '4':
-        case '5':
-        case '6':
-        case '7':
-        case '8':
-        case '9':
-            t = _parsePosNumber(i);
-            break;
-        default:
-            t = _handleUnexpectedValue(i);
+            case '[':
+                t = JsonToken.START_ARRAY;
+                break;
+            case '{':
+                t = JsonToken.START_OBJECT;
+                break;
+            case 't':
+                _matchTrue();
+                t = JsonToken.VALUE_TRUE;
+                break;
+            case 'f':
+                _matchFalse();
+                t = JsonToken.VALUE_FALSE;
+                break;
+            case 'n':
+                _matchNull();
+                t = JsonToken.VALUE_NULL;
+                break;
+            case '-':
+                t = _parseNegNumber();
+                break;
+            case '0':
+            case '1':
+            case '2':
+            case '3':
+            case '4':
+            case '5':
+            case '6':
+            case '7':
+            case '8':
+            case '9':
+                t = _parsePosNumber(i);
+                break;
+            default:
+                t = _handleUnexpectedValue(i);
         }
         _nextToken = t;
         return match;
     }
 
-    protected final int _matchName(FieldNameMatcher matcher, int i) throws IOException
-    {
+    protected final int _matchName(FieldNameMatcher matcher, int i) throws IOException {
         if (i != INT_QUOTE) {
             return -1;
         }
@@ -1363,7 +1328,7 @@ public class UTF8StreamJsonParser
             }
             return -1;
         }
-            
+
         i = input[qptr++] & 0xFF;
         if (codes[i] != 0) {
             if (i != INT_QUOTE) {
@@ -1399,7 +1364,7 @@ public class UTF8StreamJsonParser
                     if (i != INT_QUOTE) {
                         return -1;
                     }
-                }                
+                }
             }
         }
         _quadPtr = qptr;
@@ -1407,8 +1372,7 @@ public class UTF8StreamJsonParser
         return matcher.matchByQuad(q);
     }
 
-    protected final int _matchMediumName(FieldNameMatcher matcher, int qptr, int q2) throws IOException
-    {
+    protected final int _matchMediumName(FieldNameMatcher matcher, int qptr, int q2) throws IOException {
         final byte[] input = _inputBuffer;
         final int[] codes = _icLatin1;
 
@@ -1453,8 +1417,7 @@ public class UTF8StreamJsonParser
     }
 
     protected final int _matchMediumName2(FieldNameMatcher matcher, int qptr,
-            int q3, final int q2) throws IOException
-    {
+                                          int q3, final int q2) throws IOException {
         final byte[] input = _inputBuffer;
         final int[] codes = _icLatin1;
 
@@ -1501,8 +1464,7 @@ public class UTF8StreamJsonParser
     }
 
     protected final int _matchLongName(FieldNameMatcher matcher, int qptr,
-            int q) throws IOException
-    {
+                                       int q) throws IOException {
         final byte[] input = _inputBuffer;
         final int[] codes = _icLatin1;
         int qlen = 3;
@@ -1569,10 +1531,9 @@ public class UTF8StreamJsonParser
     /* Public API, traversal, nextXxxValue() variants
     /**********************************************************
      */
-    
+
     @Override
-    public String nextTextValue() throws IOException
-    {
+    public String nextTextValue() throws IOException {
         // two distinct cases; either got name and we know next type, or 'other'
         if (_currToken == JsonToken.FIELD_NAME) { // mostly copied from '_nextAfterName'
             _nameCopied = false;
@@ -1598,8 +1559,7 @@ public class UTF8StreamJsonParser
     }
 
     @Override
-    public int nextIntValue(int defaultValue) throws IOException
-    {
+    public int nextIntValue(int defaultValue) throws IOException {
         // two distinct cases; either got name and we know next type, or 'other'
         if (_currToken == JsonToken.FIELD_NAME) { // mostly copied from '_nextAfterName'
             _nameCopied = false;
@@ -1621,8 +1581,7 @@ public class UTF8StreamJsonParser
     }
 
     @Override
-    public long nextLongValue(long defaultValue) throws IOException
-    {
+    public long nextLongValue(long defaultValue) throws IOException {
         // two distinct cases; either got name and we know next type, or 'other'
         if (_currToken == JsonToken.FIELD_NAME) { // mostly copied from '_nextAfterName'
             _nameCopied = false;
@@ -1644,8 +1603,7 @@ public class UTF8StreamJsonParser
     }
 
     @Override
-    public Boolean nextBooleanValue() throws IOException
-    {
+    public Boolean nextBooleanValue() throws IOException {
         // two distinct cases; either got name and we know next type, or 'other'
         if (_currToken == JsonToken.FIELD_NAME) { // mostly copied from '_nextAfterName'
             _nameCopied = false;
@@ -1690,15 +1648,14 @@ public class UTF8StreamJsonParser
      * as a floating point number. The basic rule is that if the number
      * has no fractional or exponential part, it is an integer; otherwise
      * a floating point number.
-     *<p>
+     * <p>
      * Because much of input has to be processed in any case, no partial
      * parsing is done: all input text will be stored for further
      * processing. However, actual numeric value conversion will be
      * deferred, since it is usually the most complicated and costliest
      * part of processing.
      */
-    protected JsonToken _parsePosNumber(int c) throws IOException
-    {
+    protected JsonToken _parsePosNumber(int c) throws IOException {
         char[] outBuf = _textBuffer.emptyAndGetCurrentSegment();
         // One special case: if first char is 0, must not be followed by a digit
         if (c == INT_0) {
@@ -1735,9 +1692,8 @@ public class UTF8StreamJsonParser
         // And there we have it!
         return resetInt(false, intLen);
     }
-    
-    protected JsonToken _parseNegNumber() throws IOException
-    {
+
+    protected JsonToken _parseNegNumber() throws IOException {
         char[] outBuf = _textBuffer.emptyAndGetCurrentSegment();
         int outPtr = 0;
 
@@ -1758,7 +1714,7 @@ public class UTF8StreamJsonParser
         } else if (c > INT_9) {
             return _handleInvalidNumberStart(c, true);
         }
-        
+
         // Ok: we can first just add digit we saw first:
         outBuf[outPtr++] = (char) c;
         int intLen = 1;
@@ -1782,7 +1738,7 @@ public class UTF8StreamJsonParser
         if (c == INT_PERIOD || c == INT_e || c == INT_E) {
             return _parseFloat(outBuf, outPtr, c, true, intLen);
         }
-        
+
         --_inputPtr; // to push back trailing char (comma etc)
         _textBuffer.setCurrentLength(outPtr);
         // As per #105, need separating space between root values; check here
@@ -1799,8 +1755,7 @@ public class UTF8StreamJsonParser
      * (or output is longer than segment used to store it)
      */
     private final JsonToken _parseNumber2(char[] outBuf, int outPtr, boolean negative,
-            int intPartLength) throws IOException
-    {
+                                          int intPartLength) throws IOException {
         // Ok, parse the rest
         while (true) {
             if (_inputPtr >= _inputEnd && !_loadMore()) {
@@ -1830,15 +1785,14 @@ public class UTF8StreamJsonParser
 
         // And there we have it!
         return resetInt(negative, intPartLength);
-        
+
     }
-    
+
     /**
      * Method called when we have seen one zero, and want to ensure
      * it is not followed by another
      */
-    private final int _verifyNoLeadingZeroes() throws IOException
-    {
+    private final int _verifyNoLeadingZeroes() throws IOException {
         // Ok to have plain "0"
         if (_inputPtr >= _inputEnd && !_loadMore()) {
             return INT_0;
@@ -1868,10 +1822,9 @@ public class UTF8StreamJsonParser
         }
         return ch;
     }
-    
+
     private final JsonToken _parseFloat(char[] outBuf, int outPtr, int c,
-            boolean negative, int integerPartLength) throws IOException
-    {
+                                        boolean negative, int integerPartLength) throws IOException {
         int fractLen = 0;
         boolean eof = false;
 
@@ -1969,26 +1922,25 @@ public class UTF8StreamJsonParser
     /**
      * Method called to ensure that a root-value is followed by a space
      * token.
-     *<p>
+     * <p>
      * NOTE: caller MUST ensure there is at least one character available;
      * and that input pointer is AT given char (not past)
      */
-    private final void _verifyRootSpace(int ch) throws IOException
-    {
+    private final void _verifyRootSpace(int ch) throws IOException {
         // caller had pushed it back, before calling; reset
         ++_inputPtr;
         // TODO? Handle UTF-8 char decoding for error reporting
         switch (ch) {
-        case ' ':
-        case '\t':
-            return;
-        case '\r':
-            _skipCR();
-            return;
-        case '\n':
-            ++_currInputRow;
-            _currInputRowStart = _inputPtr;
-            return;
+            case ' ':
+            case '\t':
+                return;
+            case '\r':
+                _skipCR();
+                return;
+            case '\n':
+                ++_currInputRow;
+                _currInputRowStart = _inputPtr;
+                return;
         }
         _reportMissingRootWS(ch);
     }
@@ -1999,8 +1951,7 @@ public class UTF8StreamJsonParser
     /**********************************************************
      */
 
-    protected final String _parseName(int i) throws IOException
-    {
+    protected final String _parseName(int i) throws IOException {
         if (i != INT_QUOTE) {
             return _handleOddName(i);
         }
@@ -2044,7 +1995,7 @@ public class UTF8StreamJsonParser
                         return findName(q, 3);
                     }
                     return parseName(q, i, 3);
-                }                
+                }
                 if (i == INT_QUOTE) { // 2 byte/char case or broken
                     return findName(q, 2);
                 }
@@ -2054,15 +2005,14 @@ public class UTF8StreamJsonParser
                 return findName(q, 1);
             }
             return parseName(q, i, 1);
-        }     
+        }
         if (q == INT_QUOTE) { // special case, ""
             return "";
         }
         return parseName(0, q, 0); // quoting or invalid char
     }
 
-    protected final String parseMediumName(int q2) throws IOException
-    {
+    protected final String parseMediumName(int q2) throws IOException {
         final byte[] input = _inputBuffer;
         final int[] codes = _icLatin1;
 
@@ -2101,8 +2051,7 @@ public class UTF8StreamJsonParser
         return parseMediumName2(i, q2);
     }
 
-    protected final String parseMediumName2(int q3, final int q2) throws IOException
-    {
+    protected final String parseMediumName2(int q3, final int q2) throws IOException {
         final byte[] input = _inputBuffer;
         final int[] codes = _icLatin1;
 
@@ -2140,9 +2089,8 @@ public class UTF8StreamJsonParser
         }
         return parseLongName(i, q2, q3);
     }
-    
-    protected final String parseLongName(int q, final int q2, int q3) throws IOException
-    {
+
+    protected final String parseLongName(int q, final int q2, int q3) throws IOException {
         _quadBuffer[0] = _quad1;
         _quadBuffer[1] = q2;
         _quadBuffer[2] = q3;
@@ -2208,8 +2156,7 @@ public class UTF8StreamJsonParser
      * to come consecutively. Happens rarely, so this is offlined;
      * plus we'll also do full checks for escaping etc.
      */
-    protected String slowParseName() throws IOException
-    {
+    protected String slowParseName() throws IOException {
         if (_inputPtr >= _inputEnd) {
             if (!_loadMore()) {
                 _reportInvalidEOF(": was expecting closing '\"' for name", JsonToken.FIELD_NAME);
@@ -2244,8 +2191,7 @@ public class UTF8StreamJsonParser
      * cases, gets slower, and hence is offlined to a separate method.
      */
     protected final String parseEscapedName(int[] quads, int qlen, int currQuad, int ch,
-            int currQuadBytes) throws IOException
-    {
+                                            int currQuadBytes) throws IOException {
         // This may seem weird, but here we do not want to worry about
         // UTF-8 decoding yet. Rather, we'll assume that part is ok (if not it will get
         // caught later on), and just handle quotes and backslashes here.
@@ -2339,8 +2285,7 @@ public class UTF8StreamJsonParser
      * In standard mode will just throw an exception; but
      * in non-standard modes may be able to parse name.
      */
-    protected String _handleOddName(int ch) throws IOException
-    {
+    protected String _handleOddName(int ch) throws IOException {
         // First: may allow single quotes
         if (ch == INT_APOS && isEnabled(JsonReadFeature.ALLOW_SINGLE_QUOTES)) {
             return _parseAposName();
@@ -2411,8 +2356,7 @@ public class UTF8StreamJsonParser
      * for valid JSON -- more alternatives, more code, generally
      * bit slower execution.
      */
-    protected String _parseAposName() throws IOException
-    {
+    protected String _parseAposName() throws IOException {
         if (_inputPtr >= _inputEnd) {
             if (!_loadMore()) {
                 _reportInvalidEOF(": was expecting closing '\'' for field name", JsonToken.FIELD_NAME);
@@ -2518,8 +2462,7 @@ public class UTF8StreamJsonParser
     /**********************************************************
      */
 
-    private final String findName(int q1, int lastQuadBytes) throws JsonParseException
-    {
+    private final String findName(int q1, int lastQuadBytes) throws JsonParseException {
         q1 = _padLastQuad(q1, lastQuadBytes);
         // Usually we'll find it from the canonical symbol table already
         String name = _symbols.findName(q1);
@@ -2531,8 +2474,7 @@ public class UTF8StreamJsonParser
         return addName(_quadBuffer, 1, lastQuadBytes);
     }
 
-    private final String findName(int q1, int q2, int lastQuadBytes) throws JsonParseException
-    {
+    private final String findName(int q1, int q2, int lastQuadBytes) throws JsonParseException {
         q2 = _padLastQuad(q2, lastQuadBytes);
         // Usually we'll find it from the canonical symbol table already
         String name = _symbols.findName(q1, q2);
@@ -2545,8 +2487,7 @@ public class UTF8StreamJsonParser
         return addName(_quadBuffer, 2, lastQuadBytes);
     }
 
-    private final String findName(int q1, int q2, int q3, int lastQuadBytes) throws JsonParseException
-    {
+    private final String findName(int q1, int q2, int q3, int lastQuadBytes) throws JsonParseException {
         q3 = _padLastQuad(q3, lastQuadBytes);
         String name = _symbols.findName(q1, q2, q3);
         if (name != null) {
@@ -2558,9 +2499,8 @@ public class UTF8StreamJsonParser
         quads[2] = _padLastQuad(q3, lastQuadBytes);
         return addName(quads, 3, lastQuadBytes);
     }
-    
-    private final String findName(int[] quads, int qlen, int lastQuad, int lastQuadBytes) throws JsonParseException
-    {
+
+    private final String findName(int[] quads, int qlen, int lastQuad, int lastQuadBytes) throws JsonParseException {
         if (qlen >= quads.length) {
             _quadBuffer = quads = growArrayBy(quads, quads.length);
         }
@@ -2578,8 +2518,7 @@ public class UTF8StreamJsonParser
      * multi-byte chars (if any), and then construct Name instance
      * and add it to the symbol table.
      */
-    private final String addName(int[] quads, int qlen, int lastQuadBytes) throws JsonParseException
-    {
+    private final String addName(int[] quads, int qlen, int lastQuadBytes) throws JsonParseException {
         /* Ok: must decode UTF-8 chars. No other validation is
          * needed, since unescaping has been done earlier as necessary
          * (as well as error reporting for unescaped control chars)
@@ -2595,9 +2534,9 @@ public class UTF8StreamJsonParser
         int lastQuad;
 
         if (lastQuadBytes < 4) {
-            lastQuad = quads[qlen-1];
+            lastQuad = quads[qlen - 1];
             // 8/16/24 bit left shift
-            quads[qlen-1] = (lastQuad << ((4 - lastQuadBytes) << 3));
+            quads[qlen - 1] = (lastQuad << ((4 - lastQuadBytes) << 3));
         } else {
             lastQuad = 0;
         }
@@ -2630,13 +2569,13 @@ public class UTF8StreamJsonParser
                 if ((ix + needed) > byteLen) {
                     _reportInvalidEOF(" in field name", JsonToken.FIELD_NAME);
                 }
-                
+
                 // Ok, always need at least one more:
                 int ch2 = quads[ix >> 2]; // current quad, need to shift+mask
                 byteIx = (ix & 3);
                 ch2 = (ch2 >> ((3 - byteIx) << 3));
                 ++ix;
-                
+
                 if ((ch2 & 0xC0) != 0x080) {
                     _reportInvalidOther(ch2);
                 }
@@ -2646,7 +2585,7 @@ public class UTF8StreamJsonParser
                     byteIx = (ix & 3);
                     ch2 = (ch2 >> ((3 - byteIx) << 3));
                     ++ix;
-                    
+
                     if ((ch2 & 0xC0) != 0x080) {
                         _reportInvalidOther(ch2);
                     }
@@ -2681,7 +2620,7 @@ public class UTF8StreamJsonParser
         String baseName = new String(cbuf, 0, cix);
         // And finally, un-align if necessary
         if (lastQuadBytes < 4) {
-            quads[qlen-1] = lastQuad;
+            quads[qlen - 1] = lastQuad;
         }
         return _symbols.addName(baseName, quads, qlen);
     }
@@ -2700,11 +2639,12 @@ public class UTF8StreamJsonParser
      */
 
     protected void _loadMoreGuaranteed() throws IOException {
-        if (!_loadMore()) { _reportInvalidEOF(); }
+        if (!_loadMore()) {
+            _reportInvalidEOF();
+        }
     }
 
-    protected void _finishString() throws IOException
-    {
+    protected void _finishString() throws IOException {
         // First, single tight loop for ASCII content, not split across input buffer boundary:        
         int ptr = _inputPtr;
         if (ptr >= _inputEnd) {
@@ -2721,7 +2661,7 @@ public class UTF8StreamJsonParser
             int c = (int) inputBuffer[ptr] & 0xFF;
             if (codes[c] != 0) {
                 if (c == INT_QUOTE) {
-                    _inputPtr = ptr+1;
+                    _inputPtr = ptr + 1;
                     _textBuffer.setCurrentLength(outPtr);
                     return;
                 }
@@ -2734,8 +2674,7 @@ public class UTF8StreamJsonParser
         _finishString2(outBuf, outPtr);
     }
 
-    protected String _finishAndReturnString() throws IOException
-    {
+    protected String _finishAndReturnString() throws IOException {
         // First, single tight loop for ASCII content, not split across input buffer boundary:        
         int ptr = _inputPtr;
         if (ptr >= _inputEnd) {
@@ -2752,7 +2691,7 @@ public class UTF8StreamJsonParser
             int c = (int) inputBuffer[ptr] & 0xFF;
             if (codes[c] != 0) {
                 if (c == INT_QUOTE) {
-                    _inputPtr = ptr+1;
+                    _inputPtr = ptr + 1;
                     return _textBuffer.setCurrentAndReturn(outPtr);
                 }
                 break;
@@ -2764,10 +2703,9 @@ public class UTF8StreamJsonParser
         _finishString2(outBuf, outPtr);
         return _textBuffer.contentsAsString();
     }
-    
+
     private final void _finishString2(char[] outBuf, int outPtr)
-        throws IOException
-    {
+            throws IOException {
         int c;
 
         // Here we do want to do full decoding, hence:
@@ -2805,38 +2743,38 @@ public class UTF8StreamJsonParser
             }
 
             switch (codes[c]) {
-            case 1: // backslash
-                c = _decodeEscaped();
-                break;
-            case 2: // 2-byte UTF
-                c = _decodeUtf8_2(c);
-                break;
-            case 3: // 3-byte UTF
-                if ((_inputEnd - _inputPtr) >= 2) {
-                    c = _decodeUtf8_3fast(c);
-                } else {
-                    c = _decodeUtf8_3(c);
-                }
-                break;
-            case 4: // 4-byte UTF
-                c = _decodeUtf8_4(c);
-                // Let's add first part right away:
-                outBuf[outPtr++] = (char) (0xD800 | (c >> 10));
-                if (outPtr >= outBuf.length) {
-                    outBuf = _textBuffer.finishCurrentSegment();
-                    outPtr = 0;
-                }
-                c = 0xDC00 | (c & 0x3FF);
-                // And let the other char output down below
-                break;
-            default:
-                if (c < INT_SPACE) {
-                    // As per [JACKSON-208], call can now return:
-                    _throwUnquotedSpace(c, "string value");
-                } else {
-                    // Is this good enough error message?
-                    _reportInvalidChar(c);
-                }
+                case 1: // backslash
+                    c = _decodeEscaped();
+                    break;
+                case 2: // 2-byte UTF
+                    c = _decodeUtf8_2(c);
+                    break;
+                case 3: // 3-byte UTF
+                    if ((_inputEnd - _inputPtr) >= 2) {
+                        c = _decodeUtf8_3fast(c);
+                    } else {
+                        c = _decodeUtf8_3(c);
+                    }
+                    break;
+                case 4: // 4-byte UTF
+                    c = _decodeUtf8_4(c);
+                    // Let's add first part right away:
+                    outBuf[outPtr++] = (char) (0xD800 | (c >> 10));
+                    if (outPtr >= outBuf.length) {
+                        outBuf = _textBuffer.finishCurrentSegment();
+                        outPtr = 0;
+                    }
+                    c = 0xDC00 | (c & 0x3FF);
+                    // And let the other char output down below
+                    break;
+                default:
+                    if (c < INT_SPACE) {
+                        // As per [JACKSON-208], call can now return:
+                        _throwUnquotedSpace(c, "string value");
+                    } else {
+                        // Is this good enough error message?
+                        _reportInvalidChar(c);
+                    }
             }
             // Need more room?
             if (outPtr >= outBuf.length) {
@@ -2854,8 +2792,7 @@ public class UTF8StreamJsonParser
      * if it is not needed. This can be done bit faster if contents
      * need not be stored for future access.
      */
-    protected void _skipString() throws IOException
-    {
+    protected void _skipString() throws IOException {
         _tokenIncomplete = false;
 
         // Need to be fully UTF-8 aware here:
@@ -2888,27 +2825,27 @@ public class UTF8StreamJsonParser
             if (c == INT_QUOTE) {
                 break main_loop;
             }
-            
+
             switch (codes[c]) {
-            case 1: // backslash
-                _decodeEscaped();
-                break;
-            case 2: // 2-byte UTF
-                _skipUtf8_2();
-                break;
-            case 3: // 3-byte UTF
-                _skipUtf8_3();
-                break;
-            case 4: // 4-byte UTF
-                _skipUtf8_4(c);
-                break;
-            default:
-                if (c < INT_SPACE) {
-                    _throwUnquotedSpace(c, "string value");
-                } else {
-                    // Is this good enough error message?
-                    _reportInvalidChar(c);
-                }
+                case 1: // backslash
+                    _decodeEscaped();
+                    break;
+                case 2: // 2-byte UTF
+                    _skipUtf8_2();
+                    break;
+                case 3: // 3-byte UTF
+                    _skipUtf8_3();
+                    break;
+                case 4: // 4-byte UTF
+                    _skipUtf8_4(c);
+                    break;
+                default:
+                    if (c < INT_SPACE) {
+                        _throwUnquotedSpace(c, "string value");
+                    } else {
+                        // Is this good enough error message?
+                        _reportInvalidChar(c);
+                    }
             }
         }
     }
@@ -2917,73 +2854,71 @@ public class UTF8StreamJsonParser
      * Method for handling cases where first non-space character
      * of an expected value token is not legal for standard JSON content.
      */
-    protected JsonToken _handleUnexpectedValue(int c) throws IOException
-    {
+    protected JsonToken _handleUnexpectedValue(int c) throws IOException {
         // Most likely an error, unless we are to allow single-quote-strings
         switch (c) {
-        /* This check proceeds only if `Feature.ALLOW_MISSING_VALUES` is enabled;
-         * it is for missing values. In case of missing values in an array the next token
-         * will be either ',' or ']'. This case, decrements the already incremented _inputPtr
-         * in the buffer in case of comma (`,`) so that the existing flow goes back to checking
-         * the next token which will be comma again and  it parsing continues.
-         * Also the case returns NULL as current token in case of ',' or ']'.    
-         */
-        case ']':
-            if (!_parsingContext.inArray()) {
-                break;
-            }
-            // fall through
-        case ',':
-            // 28-Mar-2016: [core#116]: If Feature.ALLOW_MISSING_VALUES is enabled
-            //   we may allow "missing values", that is, encountering a trailing
-            //   comma or closing marker where value would be expected
-            if ((_formatReadFeatures & FEAT_MASK_ALLOW_MISSING) != 0) {
-                --_inputPtr;
-                return JsonToken.VALUE_NULL;
-            }
-            // fall through
-        case '}':
-            // Error: neither is valid at this point; valid closers have
-            // been handled earlier
-            _reportUnexpectedChar(c, "expected a value");
-        case '\'':
-            if (isEnabled(JsonReadFeature.ALLOW_SINGLE_QUOTES)) {
-                return _handleApos();
-            }
-            break;
-        case 'N':
-            _matchToken("NaN", 1);
-            if (isEnabled(JsonReadFeature.ALLOW_NON_NUMERIC_NUMBERS)) {
-                return resetAsNaN("NaN", Double.NaN);
-            }
-            _reportError("Non-standard token 'NaN': enable JsonParser.Feature.ALLOW_NON_NUMERIC_NUMBERS to allow");
-            break;
-        case 'I':
-            _matchToken("Infinity", 1);
-            if (isEnabled(JsonReadFeature.ALLOW_NON_NUMERIC_NUMBERS)) {
-                return resetAsNaN("Infinity", Double.POSITIVE_INFINITY);
-            }
-            _reportError("Non-standard token 'Infinity': enable JsonParser.Feature.ALLOW_NON_NUMERIC_NUMBERS to allow");
-            break;
-        case '+': // note: '-' is taken as number
-            if (_inputPtr >= _inputEnd) {
-                if (!_loadMore()) {
-                    _reportInvalidEOFInValue(JsonToken.VALUE_NUMBER_INT);
+            /* This check proceeds only if `Feature.ALLOW_MISSING_VALUES` is enabled;
+             * it is for missing values. In case of missing values in an array the next token
+             * will be either ',' or ']'. This case, decrements the already incremented _inputPtr
+             * in the buffer in case of comma (`,`) so that the existing flow goes back to checking
+             * the next token which will be comma again and  it parsing continues.
+             * Also the case returns NULL as current token in case of ',' or ']'.
+             */
+            case ']':
+                if (!_parsingContext.inArray()) {
+                    break;
                 }
-            }
-            return _handleInvalidNumberStart(_inputBuffer[_inputPtr++] & 0xFF, false);
+                // fall through
+            case ',':
+                // 28-Mar-2016: [core#116]: If Feature.ALLOW_MISSING_VALUES is enabled
+                //   we may allow "missing values", that is, encountering a trailing
+                //   comma or closing marker where value would be expected
+                if ((_formatReadFeatures & FEAT_MASK_ALLOW_MISSING) != 0) {
+                    --_inputPtr;
+                    return JsonToken.VALUE_NULL;
+                }
+                // fall through
+            case '}':
+                // Error: neither is valid at this point; valid closers have
+                // been handled earlier
+                _reportUnexpectedChar(c, "expected a value");
+            case '\'':
+                if (isEnabled(JsonReadFeature.ALLOW_SINGLE_QUOTES)) {
+                    return _handleApos();
+                }
+                break;
+            case 'N':
+                _matchToken("NaN", 1);
+                if (isEnabled(JsonReadFeature.ALLOW_NON_NUMERIC_NUMBERS)) {
+                    return resetAsNaN("NaN", Double.NaN);
+                }
+                _reportError("Non-standard token 'NaN': enable JsonParser.Feature.ALLOW_NON_NUMERIC_NUMBERS to allow");
+                break;
+            case 'I':
+                _matchToken("Infinity", 1);
+                if (isEnabled(JsonReadFeature.ALLOW_NON_NUMERIC_NUMBERS)) {
+                    return resetAsNaN("Infinity", Double.POSITIVE_INFINITY);
+                }
+                _reportError("Non-standard token 'Infinity': enable JsonParser.Feature.ALLOW_NON_NUMERIC_NUMBERS to allow");
+                break;
+            case '+': // note: '-' is taken as number
+                if (_inputPtr >= _inputEnd) {
+                    if (!_loadMore()) {
+                        _reportInvalidEOFInValue(JsonToken.VALUE_NUMBER_INT);
+                    }
+                }
+                return _handleInvalidNumberStart(_inputBuffer[_inputPtr++] & 0xFF, false);
         }
         // [core#77] Try to decode most likely token
         if (Character.isJavaIdentifierStart(c)) {
-            _reportInvalidToken(""+((char) c), "('true', 'false' or 'null')");
+            _reportInvalidToken("" + ((char) c), "('true', 'false' or 'null')");
         }
         // but if it doesn't look like a token:
         _reportUnexpectedChar(c, "expected a valid value (number, String, array, object, 'true', 'false' or 'null')");
         return null;
     }
 
-    protected JsonToken _handleApos() throws IOException
-    {
+    protected JsonToken _handleApos() throws IOException {
         int c = 0;
         // Otherwise almost verbatim copy of _finishString()
         int outPtr = 0;
@@ -3027,36 +2962,36 @@ public class UTF8StreamJsonParser
             }
 
             switch (codes[c]) {
-            case 1: // backslash
-                c = _decodeEscaped();
-                break;
-            case 2: // 2-byte UTF
-                c = _decodeUtf8_2(c);
-                break;
-            case 3: // 3-byte UTF
-                if ((_inputEnd - _inputPtr) >= 2) {
-                    c = _decodeUtf8_3fast(c);
-                } else {
-                    c = _decodeUtf8_3(c);
-                }
-                break;
-            case 4: // 4-byte UTF
-                c = _decodeUtf8_4(c);
-                // Let's add first part right away:
-                outBuf[outPtr++] = (char) (0xD800 | (c >> 10));
-                if (outPtr >= outBuf.length) {
-                    outBuf = _textBuffer.finishCurrentSegment();
-                    outPtr = 0;
-                }
-                c = 0xDC00 | (c & 0x3FF);
-                // And let the other char output down below
-                break;
-            default:
-                if (c < INT_SPACE) {
-                    _throwUnquotedSpace(c, "string value");
-                }
-                // Is this good enough error message?
-                _reportInvalidChar(c);
+                case 1: // backslash
+                    c = _decodeEscaped();
+                    break;
+                case 2: // 2-byte UTF
+                    c = _decodeUtf8_2(c);
+                    break;
+                case 3: // 3-byte UTF
+                    if ((_inputEnd - _inputPtr) >= 2) {
+                        c = _decodeUtf8_3fast(c);
+                    } else {
+                        c = _decodeUtf8_3(c);
+                    }
+                    break;
+                case 4: // 4-byte UTF
+                    c = _decodeUtf8_4(c);
+                    // Let's add first part right away:
+                    outBuf[outPtr++] = (char) (0xD800 | (c >> 10));
+                    if (outPtr >= outBuf.length) {
+                        outBuf = _textBuffer.finishCurrentSegment();
+                        outPtr = 0;
+                    }
+                    c = 0xDC00 | (c & 0x3FF);
+                    // And let the other char output down below
+                    break;
+                default:
+                    if (c < INT_SPACE) {
+                        _throwUnquotedSpace(c, "string value");
+                    }
+                    // Is this good enough error message?
+                    _reportInvalidChar(c);
             }
             // Need more room?
             if (outPtr >= outBuf.length) {
@@ -3081,8 +3016,7 @@ public class UTF8StreamJsonParser
      * Method called if expected numeric value (due to leading sign) does not
      * look like a number
      */
-    protected JsonToken _handleInvalidNumberStart(int ch, boolean neg) throws IOException
-    {
+    protected JsonToken _handleInvalidNumberStart(int ch, boolean neg) throws IOException {
         while (ch == 'I') {
             if (_inputPtr >= _inputEnd) {
                 if (!_loadMore()) {
@@ -3092,9 +3026,9 @@ public class UTF8StreamJsonParser
             ch = _inputBuffer[_inputPtr++];
             String match;
             if (ch == 'N') {
-                match = neg ? "-INF" :"+INF";
+                match = neg ? "-INF" : "+INF";
             } else if (ch == 'n') {
-                match = neg ? "-Infinity" :"+Infinity";
+                match = neg ? "-Infinity" : "+Infinity";
             } else {
                 break;
             }
@@ -3110,14 +3044,13 @@ public class UTF8StreamJsonParser
     }
 
     // NOTE: first character already decoded
-    protected final void _matchTrue() throws IOException
-    {
+    protected final void _matchTrue() throws IOException {
         int ptr = _inputPtr;
         if ((ptr + 3) < _inputEnd) {
             byte[] buf = _inputBuffer;
-            if ((buf[ptr++] == 'r') 
-                   && (buf[ptr++] == 'u')
-                   && (buf[ptr++] == 'e')) {
+            if ((buf[ptr++] == 'r')
+                    && (buf[ptr++] == 'u')
+                    && (buf[ptr++] == 'e')) {
                 int ch = buf[ptr] & 0xFF;
                 if (ch < INT_0 || (ch == INT_RBRACKET) || (ch == INT_RCURLY)) { // expected/allowed chars
                     _inputPtr = ptr;
@@ -3128,15 +3061,14 @@ public class UTF8StreamJsonParser
         _matchToken2("true", 1);
     }
 
-    protected final void _matchFalse() throws IOException
-    {
+    protected final void _matchFalse() throws IOException {
         int ptr = _inputPtr;
         if ((ptr + 4) < _inputEnd) {
             byte[] buf = _inputBuffer;
-            if ((buf[ptr++] == 'a') 
-                   && (buf[ptr++] == 'l')
-                   && (buf[ptr++] == 's')
-                   && (buf[ptr++] == 'e')) {
+            if ((buf[ptr++] == 'a')
+                    && (buf[ptr++] == 'l')
+                    && (buf[ptr++] == 's')
+                    && (buf[ptr++] == 'e')) {
                 int ch = buf[ptr] & 0xFF;
                 if (ch < INT_0 || (ch == INT_RBRACKET) || (ch == INT_RCURLY)) { // expected/allowed chars
                     _inputPtr = ptr;
@@ -3147,14 +3079,13 @@ public class UTF8StreamJsonParser
         _matchToken2("false", 1);
     }
 
-    protected final void _matchNull() throws IOException
-    {
+    protected final void _matchNull() throws IOException {
         int ptr = _inputPtr;
         if ((ptr + 3) < _inputEnd) {
             byte[] buf = _inputBuffer;
-            if ((buf[ptr++] == 'u') 
-                   && (buf[ptr++] == 'l')
-                   && (buf[ptr++] == 'l')) {
+            if ((buf[ptr++] == 'u')
+                    && (buf[ptr++] == 'l')
+                    && (buf[ptr++] == 'l')) {
                 int ch = buf[ptr] & 0xFF;
                 if (ch < INT_0 || (ch == INT_RBRACKET) || (ch == INT_RCURLY)) { // expected/allowed chars
                     _inputPtr = ptr;
@@ -3164,9 +3095,8 @@ public class UTF8StreamJsonParser
         }
         _matchToken2("null", 1);
     }
-    
-    protected final void _matchToken(String matchStr, int i) throws IOException
-    {
+
+    protected final void _matchToken(String matchStr, int i) throws IOException {
         final int len = matchStr.length();
         if ((_inputPtr + len) >= _inputEnd) {
             _matchToken2(matchStr, i);
@@ -3178,24 +3108,23 @@ public class UTF8StreamJsonParser
             }
             ++_inputPtr;
         } while (++i < len);
-    
+
         int ch = _inputBuffer[_inputPtr] & 0xFF;
         if (ch >= '0' && ch != ']' && ch != '}') { // expected/allowed chars
             _checkMatchEnd(matchStr, i, ch);
         }
     }
 
-    private final void _matchToken2(String matchStr, int i) throws IOException
-    {
+    private final void _matchToken2(String matchStr, int i) throws IOException {
         final int len = matchStr.length();
         do {
             if (((_inputPtr >= _inputEnd) && !_loadMore())
-                ||  (_inputBuffer[_inputPtr] != matchStr.charAt(i))) {
+                    || (_inputBuffer[_inputPtr] != matchStr.charAt(i))) {
                 _reportInvalidToken(matchStr.substring(0, i));
             }
             ++_inputPtr;
         } while (++i < len);
-    
+
         // but let's also ensure we either get EOF, or non-alphanum char...
         if (_inputPtr >= _inputEnd && !_loadMore()) {
             return;
@@ -3220,8 +3149,7 @@ public class UTF8StreamJsonParser
     /**********************************************************
      */
 
-    private final int _skipWS() throws IOException
-    {
+    private final int _skipWS() throws IOException {
         while (_inputPtr < _inputEnd) {
             int i = _inputBuffer[_inputPtr++] & 0xFF;
             if (i > INT_SPACE) {
@@ -3245,8 +3173,7 @@ public class UTF8StreamJsonParser
         return _skipWS2();
     }
 
-    private final int _skipWS2() throws IOException
-    {
+    private final int _skipWS2() throws IOException {
         while (_inputPtr < _inputEnd || _loadMore()) {
             int i = _inputBuffer[_inputPtr++] & 0xFF;
             if (i > INT_SPACE) {
@@ -3271,12 +3198,11 @@ public class UTF8StreamJsonParser
                     _throwInvalidSpace(i);
                 }
             }
-        }        
-        throw _constructError("Unexpected end-of-input within/between "+_parsingContext.typeDesc()+" entries");
+        }
+        throw _constructError("Unexpected end-of-input within/between " + _parsingContext.typeDesc() + " entries");
     }
 
-    private final int _skipWSOrEnd() throws IOException
-    {
+    private final int _skipWSOrEnd() throws IOException {
         // Let's handle first character separately since it is likely that
         // it is either non-whitespace; or we have longer run of white space
         if (_inputPtr >= _inputEnd) {
@@ -3302,7 +3228,7 @@ public class UTF8StreamJsonParser
                 _throwInvalidSpace(i);
             }
         }
-        
+
         while (_inputPtr < _inputEnd) {
             i = _inputBuffer[_inputPtr++] & 0xFF;
             if (i > INT_SPACE) {
@@ -3326,8 +3252,7 @@ public class UTF8StreamJsonParser
         return _skipWSOrEnd2();
     }
 
-    private final int _skipWSOrEnd2() throws IOException
-    {
+    private final int _skipWSOrEnd2() throws IOException {
         while ((_inputPtr < _inputEnd) || _loadMore()) {
             int i = _inputBuffer[_inputPtr++] & 0xFF;
             if (i > INT_SPACE) {
@@ -3356,8 +3281,7 @@ public class UTF8StreamJsonParser
         return _eofAsNextChar();
     }
 
-    private final int _skipColon() throws IOException
-    {
+    private final int _skipColon() throws IOException {
         if ((_inputPtr + 4) >= _inputEnd) {
             return _skipColon2(false);
         }
@@ -3378,7 +3302,7 @@ public class UTF8StreamJsonParser
                     if (i == INT_SLASH || i == INT_HASH) {
                         return _skipColon2(true);
                     }
-                    ++_inputPtr;                    
+                    ++_inputPtr;
                     return i;
                 }
             }
@@ -3411,8 +3335,7 @@ public class UTF8StreamJsonParser
         return _skipColon2(false);
     }
 
-    private final int _skipColon2(boolean gotColon) throws IOException
-    {
+    private final int _skipColon2(boolean gotColon) throws IOException {
         while (_inputPtr < _inputEnd || _loadMore()) {
             int i = _inputBuffer[_inputPtr++] & 0xFF;
 
@@ -3444,13 +3367,12 @@ public class UTF8StreamJsonParser
                 }
             }
         }
-        _reportInvalidEOF(" within/between "+_parsingContext.typeDesc()+" entries",
+        _reportInvalidEOF(" within/between " + _parsingContext.typeDesc() + " entries",
                 null);
         return -1;
     }
 
-    private final void _skipComment() throws IOException
-    {
+    private final void _skipComment() throws IOException {
         if (!isEnabled(JsonReadFeature.ALLOW_JAVA_COMMENTS)) {
             _reportUnexpectedChar('/', "maybe a (non-standard) comment? (not recognized as one since Feature 'ALLOW_COMMENTS' not enabled for parser)");
         }
@@ -3468,8 +3390,7 @@ public class UTF8StreamJsonParser
         }
     }
 
-    private final void _skipCComment() throws IOException
-    {
+    private final void _skipCComment() throws IOException {
         // Need to be UTF-8 aware here to decode content (for skipping)
         final int[] codes = CharTypes.getInputCodeComment();
 
@@ -3480,42 +3401,41 @@ public class UTF8StreamJsonParser
             int code = codes[i];
             if (code != 0) {
                 switch (code) {
-                case '*':
-                    if (_inputPtr >= _inputEnd && !_loadMore()) {
-                        break main_loop;
-                    }
-                    if (_inputBuffer[_inputPtr] == INT_SLASH) {
-                        ++_inputPtr;
-                        return;
-                    }
-                    break;
-                case INT_LF:
-                    ++_currInputRow;
-                    _currInputRowStart = _inputPtr;
-                    break;
-                case INT_CR:
-                    _skipCR();
-                    break;
-                case 2: // 2-byte UTF
-                    _skipUtf8_2();
-                    break;
-                case 3: // 3-byte UTF
-                    _skipUtf8_3();
-                    break;
-                case 4: // 4-byte UTF
-                    _skipUtf8_4(i);
-                    break;
-                default: // e.g. -1
-                    // Is this good enough error message?
-                    _reportInvalidChar(i);
+                    case '*':
+                        if (_inputPtr >= _inputEnd && !_loadMore()) {
+                            break main_loop;
+                        }
+                        if (_inputBuffer[_inputPtr] == INT_SLASH) {
+                            ++_inputPtr;
+                            return;
+                        }
+                        break;
+                    case INT_LF:
+                        ++_currInputRow;
+                        _currInputRowStart = _inputPtr;
+                        break;
+                    case INT_CR:
+                        _skipCR();
+                        break;
+                    case 2: // 2-byte UTF
+                        _skipUtf8_2();
+                        break;
+                    case 3: // 3-byte UTF
+                        _skipUtf8_3();
+                        break;
+                    case 4: // 4-byte UTF
+                        _skipUtf8_4(i);
+                        break;
+                    default: // e.g. -1
+                        // Is this good enough error message?
+                        _reportInvalidChar(i);
                 }
             }
         }
         _reportInvalidEOF(" in a comment", null);
     }
 
-    private final boolean _skipYAMLComment() throws IOException
-    {
+    private final boolean _skipYAMLComment() throws IOException {
         if (!isEnabled(JsonReadFeature.ALLOW_YAML_COMMENTS)) {
             return false;
         }
@@ -3527,8 +3447,7 @@ public class UTF8StreamJsonParser
      * Method for skipping contents of an input line; usually for CPP
      * and YAML style comments.
      */
-    private final void _skipLine() throws IOException
-    {
+    private final void _skipLine() throws IOException {
         // Ok: need to find EOF or linefeed
         final int[] codes = CharTypes.getInputCodeComment();
         while ((_inputPtr < _inputEnd) || _loadMore()) {
@@ -3536,37 +3455,36 @@ public class UTF8StreamJsonParser
             int code = codes[i];
             if (code != 0) {
                 switch (code) {
-                case INT_LF:
-                    ++_currInputRow;
-                    _currInputRowStart = _inputPtr;
-                    return;
-                case INT_CR:
-                    _skipCR();
-                    return;
-                case '*': // nop for these comments
-                    break;
-                case 2: // 2-byte UTF
-                    _skipUtf8_2();
-                    break;
-                case 3: // 3-byte UTF
-                    _skipUtf8_3();
-                    break;
-                case 4: // 4-byte UTF
-                    _skipUtf8_4(i);
-                    break;
-                default: // e.g. -1
-                    if (code < 0) {
-                        // Is this good enough error message?
-                        _reportInvalidChar(i);
-                    }
+                    case INT_LF:
+                        ++_currInputRow;
+                        _currInputRowStart = _inputPtr;
+                        return;
+                    case INT_CR:
+                        _skipCR();
+                        return;
+                    case '*': // nop for these comments
+                        break;
+                    case 2: // 2-byte UTF
+                        _skipUtf8_2();
+                        break;
+                    case 3: // 3-byte UTF
+                        _skipUtf8_3();
+                        break;
+                    case 4: // 4-byte UTF
+                        _skipUtf8_4(i);
+                        break;
+                    default: // e.g. -1
+                        if (code < 0) {
+                            // Is this good enough error message?
+                            _reportInvalidChar(i);
+                        }
                 }
             }
         }
     }
-    
+
     @Override
-    protected char _decodeEscaped() throws IOException
-    {
+    protected char _decodeEscaped() throws IOException {
         if (_inputPtr >= _inputEnd) {
             if (!_loadMore()) {
                 _reportInvalidEOF(" in character escape sequence", JsonToken.VALUE_STRING);
@@ -3576,28 +3494,28 @@ public class UTF8StreamJsonParser
 
         switch (c) {
             // First, ones that are mapped
-        case 'b':
-            return '\b';
-        case 't':
-            return '\t';
-        case 'n':
-            return '\n';
-        case 'f':
-            return '\f';
-        case 'r':
-            return '\r';
+            case 'b':
+                return '\b';
+            case 't':
+                return '\t';
+            case 'n':
+                return '\n';
+            case 'f':
+                return '\f';
+            case 'r':
+                return '\r';
 
             // And these are to be returned as they are
-        case '"':
-        case '/':
-        case '\\':
-            return (char) c;
+            case '"':
+            case '/':
+            case '\\':
+                return (char) c;
 
-        case 'u': // and finally hex-escaped
-            break;
+            case 'u': // and finally hex-escaped
+                break;
 
-        default:
-            return _handleUnrecognizedCharacterEscape((char) _decodeCharForError(c));
+            default:
+                return _handleUnrecognizedCharacterEscape((char) _decodeCharForError(c));
         }
 
         // Ok, a hex escape. Need 4 characters
@@ -3618,12 +3536,11 @@ public class UTF8StreamJsonParser
         return (char) value;
     }
 
-    protected int _decodeCharForError(int firstByte) throws IOException
-    {
+    protected int _decodeCharForError(int firstByte) throws IOException {
         int c = firstByte & 0xFF;
         if (c > 0x7F) { // if >= 0, is ascii and fine as is
             int needed;
-            
+
             // Ok; if we end here, we got multi-byte combination
             if ((c & 0xE0) == 0xC0) { // 2 bytes (0x0080 - 0x07FF)
                 c &= 0x1F;
@@ -3645,7 +3562,7 @@ public class UTF8StreamJsonParser
                 _reportInvalidOther(d & 0xFF);
             }
             c = (c << 6) | (d & 0x3F);
-            
+
             if (needed > 1) { // needed == 1 means 2 bytes total
                 d = nextByte(); // 3rd byte
                 if ((d & 0xC0) != 0x080) {
@@ -3670,8 +3587,7 @@ public class UTF8StreamJsonParser
     /**********************************************************
      */
 
-    private final int _decodeUtf8_2(int c) throws IOException
-    {
+    private final int _decodeUtf8_2(int c) throws IOException {
         if (_inputPtr >= _inputEnd) {
             _loadMoreGuaranteed();
         }
@@ -3682,8 +3598,7 @@ public class UTF8StreamJsonParser
         return ((c & 0x1F) << 6) | (d & 0x3F);
     }
 
-    private final int _decodeUtf8_3(int c1) throws IOException
-    {
+    private final int _decodeUtf8_3(int c1) throws IOException {
         if (_inputPtr >= _inputEnd) {
             _loadMoreGuaranteed();
         }
@@ -3704,8 +3619,7 @@ public class UTF8StreamJsonParser
         return c;
     }
 
-    private final int _decodeUtf8_3fast(int c1) throws IOException
-    {
+    private final int _decodeUtf8_3fast(int c1) throws IOException {
         c1 &= 0x0F;
         int d = (int) _inputBuffer[_inputPtr++];
         if ((d & 0xC0) != 0x080) {
@@ -3722,10 +3636,9 @@ public class UTF8StreamJsonParser
 
     /**
      * @return Character value <b>minus 0x10000</c>; this so that caller
-     *    can readily expand it to actual surrogates
+     * can readily expand it to actual surrogates
      */
-    private final int _decodeUtf8_4(int c) throws IOException
-    {
+    private final int _decodeUtf8_4(int c) throws IOException {
         if (_inputPtr >= _inputEnd) {
             _loadMoreGuaranteed();
         }
@@ -3757,8 +3670,7 @@ public class UTF8StreamJsonParser
         return ((c << 6) | (d & 0x3F)) - 0x10000;
     }
 
-    private final void _skipUtf8_2() throws IOException
-    {
+    private final void _skipUtf8_2() throws IOException {
         if (_inputPtr >= _inputEnd) {
             _loadMoreGuaranteed();
         }
@@ -3771,8 +3683,7 @@ public class UTF8StreamJsonParser
     /* Alas, can't heavily optimize skipping, since we still have to
      * do validity checks...
      */
-    private final void _skipUtf8_3() throws IOException
-    {
+    private final void _skipUtf8_3() throws IOException {
         if (_inputPtr >= _inputEnd) {
             _loadMoreGuaranteed();
         }
@@ -3790,8 +3701,7 @@ public class UTF8StreamJsonParser
         }
     }
 
-    private final void _skipUtf8_4(int c) throws IOException
-    {
+    private final void _skipUtf8_4(int c) throws IOException {
         if (_inputPtr >= _inputEnd) {
             _loadMoreGuaranteed();
         }
@@ -3825,8 +3735,7 @@ public class UTF8StreamJsonParser
      * We actually need to check the character value here
      * (to see if we have \n following \r).
      */
-    protected final void _skipCR() throws IOException
-    {
+    protected final void _skipCR() throws IOException {
         if (_inputPtr < _inputEnd || _loadMore()) {
             if (_inputBuffer[_inputPtr] == BYTE_LF) {
                 ++_inputPtr;
@@ -3836,8 +3745,7 @@ public class UTF8StreamJsonParser
         _currInputRowStart = _inputPtr;
     }
 
-        private int nextByte() throws IOException
-    {
+    private int nextByte() throws IOException {
         if (_inputPtr >= _inputEnd) {
             _loadMoreGuaranteed();
         }
@@ -3859,8 +3767,7 @@ public class UTF8StreamJsonParser
         _reportInvalidToken(matchedPart, "'null', 'true', 'false' or NaN");
     }
 
-    protected void _reportInvalidToken(String matchedPart, String msg) throws IOException
-    {
+    protected void _reportInvalidToken(String matchedPart, String msg) throws IOException {
         /* Let's just try to find what appears to be the token, using
          * regular Java identifier character rules. It's just a heuristic,
          * nothing fancy here (nor fast).
@@ -3883,8 +3790,7 @@ public class UTF8StreamJsonParser
         _reportError("Unrecognized token '%s': was expecting %s", sb, msg);
     }
 
-    protected void _reportInvalidChar(int c) throws JsonParseException
-    {
+    protected void _reportInvalidChar(int c) throws JsonParseException {
         // Either invalid WS or illegal UTF-8 start char
         if (c < INT_SPACE) {
             _throwInvalidSpace(c);
@@ -3893,16 +3799,15 @@ public class UTF8StreamJsonParser
     }
 
     protected void _reportInvalidInitial(int mask) throws JsonParseException {
-        _reportError("Invalid UTF-8 start byte 0x"+Integer.toHexString(mask));
+        _reportError("Invalid UTF-8 start byte 0x" + Integer.toHexString(mask));
     }
 
     protected void _reportInvalidOther(int mask) throws JsonParseException {
-        _reportError("Invalid UTF-8 middle byte 0x"+Integer.toHexString(mask));
+        _reportError("Invalid UTF-8 middle byte 0x" + Integer.toHexString(mask));
     }
 
     protected void _reportInvalidOther(int mask, int ptr)
-        throws JsonParseException
-    {
+            throws JsonParseException {
         _inputPtr = ptr;
         _reportInvalidOther(mask);
     }
@@ -3918,8 +3823,7 @@ public class UTF8StreamJsonParser
      * textual content.
      */
     @SuppressWarnings("resource")
-    protected final byte[] _decodeBase64(Base64Variant b64variant) throws IOException
-    {
+    protected final byte[] _decodeBase64(Base64Variant b64variant) throws IOException {
         ByteArrayBuilder builder = _getByteArrayBuilder();
 
         while (true) {
@@ -3942,9 +3846,9 @@ public class UTF8StreamJsonParser
                 }
             }
             int decodedData = bits;
-            
+
             // then second base64 char; can't get padding yet, nor ws
-            
+
             if (_inputPtr >= _inputEnd) {
                 _loadMoreGuaranteed();
             }
@@ -3954,7 +3858,7 @@ public class UTF8StreamJsonParser
                 bits = _decodeBase64Escape(b64variant, ch, 1);
             }
             decodedData = (decodedData << 6) | bits;
-            
+
             // third base64 char; can be padding, but not ws
             if (_inputPtr >= _inputEnd) {
                 _loadMoreGuaranteed();
@@ -3985,7 +3889,7 @@ public class UTF8StreamJsonParser
                     ch = _inputBuffer[_inputPtr++] & 0xFF;
                     if (!b64variant.usesPaddingChar(ch)) {
                         if (_decodeBase64Escape(b64variant, ch, 3) != Base64Variant.BASE64_VALUE_PADDING) {
-                            throw reportInvalidBase64Char(b64variant, ch, 3, "expected padding character '"+b64variant.getPaddingChar()+"'");
+                            throw reportInvalidBase64Char(b64variant, ch, 3, "expected padding character '" + b64variant.getPaddingChar() + "'");
                         }
                     }
                     // Got 12 bits, only need 8, need to shift
@@ -4039,37 +3943,33 @@ public class UTF8StreamJsonParser
 
     // As per [core#108], must ensure we call the right method
     @Override
-    public JsonLocation getTokenLocation()
-    {
+    public JsonLocation getTokenLocation() {
         if (_currToken == JsonToken.FIELD_NAME) {
-            long total = _currInputProcessed + (_nameStartOffset-1);
+            long total = _currInputProcessed + (_nameStartOffset - 1);
             return new JsonLocation(_getSourceReference(),
                     total, -1L, _nameStartRow, _nameStartCol);
         }
         return new JsonLocation(_getSourceReference(),
-                _tokenInputTotal-1, -1L, _tokenInputRow, _tokenInputCol);
+                _tokenInputTotal - 1, -1L, _tokenInputRow, _tokenInputCol);
     }
 
     // As per [core#108], must ensure we call the right method
     @Override
-    public JsonLocation getCurrentLocation()
-    {
+    public JsonLocation getCurrentLocation() {
         int col = _inputPtr - _currInputRowStart + 1; // 1-based
         return new JsonLocation(_getSourceReference(),
                 _currInputProcessed + _inputPtr, -1L, // bytes, chars
                 _currInputRow, col);
     }
 
-    private final void _updateLocation()
-    {
+    private final void _updateLocation() {
         _tokenInputRow = _currInputRow;
         final int ptr = _inputPtr;
         _tokenInputTotal = _currInputProcessed + ptr;
         _tokenInputCol = ptr - _currInputRowStart;
     }
 
-    private final void _updateNameLocation()
-    {
+    private final void _updateNameLocation() {
         _nameStartRow = _currInputRow;
         final int ptr = _inputPtr;
         _nameStartOffset = ptr;

--- a/src/main/java/com/fasterxml/jackson/core/json/UTF8StreamJsonParser.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/UTF8StreamJsonParser.java
@@ -1,13 +1,6 @@
 package com.fasterxml.jackson.core.json;
 
-import com.fasterxml.jackson.core.Base64Variant;
-import com.fasterxml.jackson.core.JsonLocation;
-import com.fasterxml.jackson.core.JsonParseException;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonToken;
-import com.fasterxml.jackson.core.ObjectReadContext;
-import com.fasterxml.jackson.core.SerializableString;
-import com.fasterxml.jackson.core.StreamReadFeature;
+import com.fasterxml.jackson.core.*;
 import com.fasterxml.jackson.core.io.CharTypes;
 import com.fasterxml.jackson.core.io.IOContext;
 import com.fasterxml.jackson.core.sym.ByteQuadsCanonicalizer;

--- a/src/test/java/com/fasterxml/jackson/core/read/LocationDuringReaderParsingTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/read/LocationDuringReaderParsingTest.java
@@ -1,0 +1,203 @@
+package com.fasterxml.jackson.core.read;
+
+import com.fasterxml.jackson.core.BaseTest;
+import com.fasterxml.jackson.core.JsonLocation;
+import com.fasterxml.jackson.core.JsonParser;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Set of tests that checks getCurrentLocation() and getTokenLocation() are as expected during
+ * parsing.
+ */
+public class LocationDuringReaderParsingTest extends BaseTest {
+    public void testLocationAtEndOfParse() throws Exception {
+        for (LocationTestCase test : LocationTestCase.values()) {
+            //System.out.println(test.name());
+            testLocationAtEndOfParse(test);
+        }
+    }
+
+    public void testInitialLocation() throws Exception {
+        for (LocationTestCase test : LocationTestCase.values()) {
+            //System.out.println(test.name());
+            testInitialLocation(test);
+        }
+    }
+
+    public void testTokenLocations() throws Exception {
+        for (LocationTestCase test : LocationTestCase.values()) {
+            //System.out.println(test.name());
+            testTokenLocations(test);
+        }
+    }
+
+    private void testLocationAtEndOfParse(LocationTestCase test) throws Exception {
+        JsonParser p = createParserUsingReader(test.json);
+        while (p.nextToken() != null) {
+            p.nextToken();
+        }
+        assertCurrentLocation(p, test.getFinalLocation());
+        p.close();
+    }
+
+    private void testInitialLocation(LocationTestCase test) throws Exception {
+        JsonParser p = createParserUsingReader(test.json);
+        JsonLocation loc = p.getCurrentLocation();
+        p.close();
+
+        assertLocation(loc, at(1, 1, 0));
+    }
+
+    private void testTokenLocations(LocationTestCase test) throws Exception {
+        JsonParser p = createParserUsingReader(test.json);
+        int i = 0;
+        while (p.nextToken() != null) {
+            assertTokenLocation(p, test.locations.get(i));
+            i++;
+        }
+        assertEquals(test.locations.size(), i + 1); // last LocData is end of stream
+        p.close();
+    }
+
+    private void assertCurrentLocation(JsonParser p, LocData loc) {
+        assertLocation(p.getCurrentLocation(), loc);
+    }
+
+    private void assertTokenLocation(JsonParser p, LocData loc) {
+        assertLocation(p.getTokenLocation(), loc);
+    }
+
+    private void assertLocation(JsonLocation pLoc, LocData loc) {
+        String expected = String.format("(%d, %d, %d)",
+                loc.lineNumber, loc.columnNumber, loc.offset);
+        String actual = String.format("(%d, %d, %d)", pLoc.getLineNr(), pLoc.getColumnNr(),
+                pLoc.getByteOffset() == -1 ? pLoc.getCharOffset() : pLoc.getByteOffset());
+        assertEquals(expected, actual);
+    }
+
+    private static class LocData {
+        private long lineNumber;
+        private long columnNumber;
+        private long offset;
+
+        LocData(long lineNumber, long columnNumber, long offset) {
+            this.lineNumber = lineNumber;
+            this.columnNumber = columnNumber;
+            this.offset = offset;
+        }
+    }
+
+    private static LocData at(long lineNumber, long columnNumber, long offset) {
+        return new LocData(lineNumber, columnNumber, offset);
+    }
+
+    /**
+     * Adapted liberally from https://github.com/leadpony/jsonp-test-suite, also
+     * released under the Apache License v2.
+     */
+    enum LocationTestCase {
+        SIMPLE_VALUE("42", at(1, 1, 0), at(1, 3, 2)),
+
+        SIMPLE_VALUE_WITH_PADDING("   1337  ", at(1, 4, 3), at(1, 10, 9)),
+
+        SIMPLE_VALUE_WITH_MULTIBYTE_CHARS("\"Правда\"",
+                at(1,1,0),
+                at(1,9,8)
+        ),
+
+        SIMPLE_VALUE_INCLUDING_SURROGATE_PAIR_CHARS("\"a П \uD83D\uDE01\"",
+                at(1,1,0),
+                at(1,9,8) // reader counts surrogate pairs as two chars
+        ),
+
+        ARRAY_IN_ONE_LINE("[\"hello\",42,true]",
+                at(1, 1, 0), // [
+                at(1, 2, 1), // "hello"
+                at(1, 10, 9), // 42
+                at(1, 13, 12), // true
+                at(1, 17, 16), // ]
+                at(1, 18, 17) // end of input
+        ),
+
+        ARRAY_IN_ONE_LINE_WITH_PADDING("  [ \"hello\" ,   42   ,   true   ]   ",
+                at(1, 3, 2), // [
+                at(1, 5, 4), // "hello"
+                at(1, 17, 16), // 42
+                at(1, 26, 25), // true
+                at(1, 33, 32), // ]
+                at(1, 37, 36) // end of input
+        ),
+
+        ARRAY_IN_MULTIPLE_LINES("[\n" + "    \"hello\",\n" + "    42,\n" + "    true\n" + "]",
+                at(1, 1, 0), // [
+                at(2, 5, 6), // "hello"
+                at(3, 5, 19), // 42
+                at(4, 5, 27), // true
+                at(5, 1, 32), // ]
+                at(5, 2, 33) // end of input
+        ),
+
+        ARRAY_IN_MULTIPLE_LINES_WITH_WEIRD_SPACING(" [\n" + "  \"hello\" ,  \n" + " 42   ,\n" + "      true\n" + " ]",
+                at(1, 2, 1), // [
+                at(2, 3, 5), // "hello"
+                at(3, 2, 18), // 42
+                at(4, 7, 31), // true
+                at(5, 2, 37), // ]
+                at(5, 3, 38) // end of input
+        ),
+
+        ARRAY_IN_MULTIPLE_LINES_CRLF("[\r\n" + "    \"hello\",\r\n" + "    42,\r\n" + "    true\r\n" + "]",
+                at(1, 1, 0), // [
+                at(2, 5, 7), // "hello"
+                at(3, 5, 21), // 42
+                at(4, 5, 30), // true
+                at(5, 1, 36), // ]
+                at(5, 2, 37) // end of input
+        ),
+
+        OBJECT_IN_ONE_LINE("{\"first\":\"hello\",\"second\":42}",
+                at(1, 1, 0), // {
+                at(1, 2, 1), // "first"
+                at(1, 10, 9), // "hello"
+                at(1, 18, 17), // "second"
+                at(1, 27, 26), // 42
+                at(1, 29, 28), // }
+                at(1, 30, 29) // end of input
+        ),
+
+        OBJECT_IN_MULTIPLE_LINES("{\n" + "    \"first\":\"hello\",\n" + "    \"second\":42\n" + "}",
+                at(1, 1, 0), // {
+                at(2, 5, 6), // "first"
+                at(2, 13, 14), // "hello"
+                at(3, 5, 27), // "second"
+                at(3, 14, 36), // 42
+                at(4, 1, 39), // }
+                at(4, 2, 40) // end of input
+        ),
+
+        OBJECT_IN_MULTIPLE_LINES_CRLF("{\r\n" + "    \"first\":\"hello\",\r\n" + "    \"second\":42\r\n" + "}",
+                at(1, 1, 0), // {
+                at(2, 5, 7), // "first"
+                at(2, 13, 15), // "hello"
+                at(3, 5, 29), // "second"
+                at(3, 14, 38), // 42
+                at(4, 1, 42), // }
+                at(4, 2, 43) // end of input
+        ),;
+
+        final String json;
+        final List<LocData> locations;
+
+        LocationTestCase(String json, LocData... locations) {
+            this.json = json;
+            this.locations = Arrays.asList(locations);
+        }
+
+        LocData getFinalLocation() {
+            return locations.get(locations.size() - 1);
+        }
+    }
+
+}

--- a/src/test/java/com/fasterxml/jackson/core/read/LocationDuringReaderParsingTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/read/LocationDuringReaderParsingTest.java
@@ -1,39 +1,44 @@
 package com.fasterxml.jackson.core.read;
 
+import java.util.Arrays;
+import java.util.List;
+
 import com.fasterxml.jackson.core.BaseTest;
 import com.fasterxml.jackson.core.JsonLocation;
 import com.fasterxml.jackson.core.JsonParser;
-
-import java.util.Arrays;
-import java.util.List;
 
 /**
  * Set of tests that checks getCurrentLocation() and getTokenLocation() are as expected during
  * parsing.
  */
-public class LocationDuringReaderParsingTest extends BaseTest {
-    public void testLocationAtEndOfParse() throws Exception {
+public class LocationDuringReaderParsingTest extends BaseTest
+{
+    public void testLocationAtEndOfParse() throws Exception
+    {
         for (LocationTestCase test : LocationTestCase.values()) {
             //System.out.println(test.name());
             testLocationAtEndOfParse(test);
         }
     }
 
-    public void testInitialLocation() throws Exception {
+    public void testInitialLocation() throws Exception
+    {
         for (LocationTestCase test : LocationTestCase.values()) {
             //System.out.println(test.name());
             testInitialLocation(test);
         }
     }
 
-    public void testTokenLocations() throws Exception {
+    public void testTokenLocations() throws Exception
+    {
         for (LocationTestCase test : LocationTestCase.values()) {
             //System.out.println(test.name());
             testTokenLocations(test);
         }
     }
 
-    private void testLocationAtEndOfParse(LocationTestCase test) throws Exception {
+    private void testLocationAtEndOfParse(LocationTestCase test) throws Exception
+    {
         JsonParser p = createParserUsingReader(test.json);
         while (p.nextToken() != null) {
             p.nextToken();
@@ -42,7 +47,8 @@ public class LocationDuringReaderParsingTest extends BaseTest {
         p.close();
     }
 
-    private void testInitialLocation(LocationTestCase test) throws Exception {
+    private void testInitialLocation(LocationTestCase test) throws Exception
+    {
         JsonParser p = createParserUsingReader(test.json);
         JsonLocation loc = p.getCurrentLocation();
         p.close();
@@ -50,7 +56,8 @@ public class LocationDuringReaderParsingTest extends BaseTest {
         assertLocation(loc, at(1, 1, 0));
     }
 
-    private void testTokenLocations(LocationTestCase test) throws Exception {
+    private void testTokenLocations(LocationTestCase test) throws Exception
+    {
         JsonParser p = createParserUsingReader(test.json);
         int i = 0;
         while (p.nextToken() != null) {
@@ -61,15 +68,18 @@ public class LocationDuringReaderParsingTest extends BaseTest {
         p.close();
     }
 
-    private void assertCurrentLocation(JsonParser p, LocData loc) {
+    private void assertCurrentLocation(JsonParser p, LocData loc)
+    {
         assertLocation(p.getCurrentLocation(), loc);
     }
 
-    private void assertTokenLocation(JsonParser p, LocData loc) {
+    private void assertTokenLocation(JsonParser p, LocData loc)
+    {
         assertLocation(p.getTokenLocation(), loc);
     }
 
-    private void assertLocation(JsonLocation pLoc, LocData loc) {
+    private void assertLocation(JsonLocation pLoc, LocData loc)
+    {
         String expected = String.format("(%d, %d, %d)",
                 loc.lineNumber, loc.columnNumber, loc.offset);
         String actual = String.format("(%d, %d, %d)", pLoc.getLineNr(), pLoc.getColumnNr(),
@@ -77,19 +87,22 @@ public class LocationDuringReaderParsingTest extends BaseTest {
         assertEquals(expected, actual);
     }
 
-    private static class LocData {
+    private static class LocData
+    {
         private long lineNumber;
         private long columnNumber;
         private long offset;
 
-        LocData(long lineNumber, long columnNumber, long offset) {
+        LocData(long lineNumber, long columnNumber, long offset)
+        {
             this.lineNumber = lineNumber;
             this.columnNumber = columnNumber;
             this.offset = offset;
         }
     }
 
-    private static LocData at(long lineNumber, long columnNumber, long offset) {
+    private static LocData at(long lineNumber, long columnNumber, long offset)
+    {
         return new LocData(lineNumber, columnNumber, offset);
     }
 
@@ -97,7 +110,8 @@ public class LocationDuringReaderParsingTest extends BaseTest {
      * Adapted liberally from https://github.com/leadpony/jsonp-test-suite, also
      * released under the Apache License v2.
      */
-    enum LocationTestCase {
+    enum LocationTestCase
+    {
         SIMPLE_VALUE("42", at(1, 1, 0), at(1, 3, 2)),
 
         SIMPLE_VALUE_WITH_PADDING("   1337  ", at(1, 4, 3), at(1, 10, 9)),
@@ -191,12 +205,14 @@ public class LocationDuringReaderParsingTest extends BaseTest {
         final String json;
         final List<LocData> locations;
 
-        LocationTestCase(String json, LocData... locations) {
+        LocationTestCase(String json, LocData... locations)
+        {
             this.json = json;
             this.locations = Arrays.asList(locations);
         }
 
-        LocData getFinalLocation() {
+        LocData getFinalLocation()
+        {
             return locations.get(locations.size() - 1);
         }
     }

--- a/src/test/java/com/fasterxml/jackson/core/read/LocationDuringReaderParsingTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/read/LocationDuringReaderParsingTest.java
@@ -103,13 +103,13 @@ public class LocationDuringReaderParsingTest extends BaseTest {
         SIMPLE_VALUE_WITH_PADDING("   1337  ", at(1, 4, 3), at(1, 10, 9)),
 
         SIMPLE_VALUE_WITH_MULTIBYTE_CHARS("\"Правда\"",
-                at(1,1,0),
-                at(1,9,8)
+                at(1, 1, 0),
+                at(1, 9, 8)
         ),
 
         SIMPLE_VALUE_INCLUDING_SURROGATE_PAIR_CHARS("\"a П \uD83D\uDE01\"",
-                at(1,1,0),
-                at(1,9,8) // reader counts surrogate pairs as two chars
+                at(1, 1, 0),
+                at(1, 9, 8) // reader counts surrogate pairs as two chars
         ),
 
         ARRAY_IN_ONE_LINE("[\"hello\",42,true]",
@@ -185,7 +185,8 @@ public class LocationDuringReaderParsingTest extends BaseTest {
                 at(3, 14, 38), // 42
                 at(4, 1, 42), // }
                 at(4, 2, 43) // end of input
-        ),;
+        ),
+        ;
 
         final String json;
         final List<LocData> locations;
@@ -199,5 +200,4 @@ public class LocationDuringReaderParsingTest extends BaseTest {
             return locations.get(locations.size() - 1);
         }
     }
-
 }

--- a/src/test/java/com/fasterxml/jackson/core/read/LocationDuringStreamParsingTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/read/LocationDuringStreamParsingTest.java
@@ -103,13 +103,13 @@ public class LocationDuringStreamParsingTest extends BaseTest {
         SIMPLE_VALUE_WITH_PADDING("   1337  ", at(1, 4, 3), at(1, 10, 9)),
 
         SIMPLE_VALUE_WITH_MULTIBYTE_CHARS("\"Правда\"",
-                at(1,1,0),
-                at(1,15,14) // one byte for each ", two for each Cyrillic char
+                at(1, 1, 0),
+                at(1, 15, 14) // one byte for each ", two for each Cyrillic char
         ),
 
         SIMPLE_VALUE_INCLUDING_SURROGATE_PAIR_CHARS("\"a П \uD83D\uDE01\"",
-                at(1,1,0),
-                at(1,12,11) // one byte for each ", a and space; two for П, four for smiley emoji
+                at(1, 1, 0),
+                at(1, 12, 11) // one byte for each ", a and space; two for П, four for smiley emoji
         ),
 
         ARRAY_IN_ONE_LINE("[\"hello\",42,true]",
@@ -185,7 +185,8 @@ public class LocationDuringStreamParsingTest extends BaseTest {
                 at(3, 14, 38), // 42
                 at(4, 1, 42), // }
                 at(4, 2, 43) // end of input
-        ),;
+        ),
+        ;
 
         final String json;
         final List<LocData> locations;

--- a/src/test/java/com/fasterxml/jackson/core/read/LocationDuringStreamParsingTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/read/LocationDuringStreamParsingTest.java
@@ -1,39 +1,44 @@
 package com.fasterxml.jackson.core.read;
 
+import java.util.Arrays;
+import java.util.List;
+
 import com.fasterxml.jackson.core.BaseTest;
 import com.fasterxml.jackson.core.JsonLocation;
 import com.fasterxml.jackson.core.JsonParser;
-
-import java.util.Arrays;
-import java.util.List;
 
 /**
  * Set of tests that checks getCurrentLocation() and getTokenLocation() are as expected during
  * parsing.
  */
-public class LocationDuringStreamParsingTest extends BaseTest {
-    public void testLocationAtEndOfParse() throws Exception {
+public class LocationDuringStreamParsingTest extends BaseTest
+{
+    public void testLocationAtEndOfParse() throws Exception
+    {
         for (LocationTestCase test : LocationTestCase.values()) {
             //System.out.println(test.name());
             testLocationAtEndOfParse(test);
         }
     }
 
-    public void testInitialLocation() throws Exception {
+    public void testInitialLocation() throws Exception
+    {
         for (LocationTestCase test : LocationTestCase.values()) {
             //System.out.println(test.name());
             testInitialLocation(test);
         }
     }
 
-    public void testTokenLocations() throws Exception {
+    public void testTokenLocations() throws Exception
+    {
         for (LocationTestCase test : LocationTestCase.values()) {
             //System.out.println(test.name());
             testTokenLocations(test);
         }
     }
 
-    private void testLocationAtEndOfParse(LocationTestCase test) throws Exception {
+    private void testLocationAtEndOfParse(LocationTestCase test) throws Exception
+    {
         JsonParser p = createParserUsingStream(test.json, "UTF8");
         while (p.nextToken() != null) {
             p.nextToken();
@@ -42,7 +47,8 @@ public class LocationDuringStreamParsingTest extends BaseTest {
         p.close();
     }
 
-    private void testInitialLocation(LocationTestCase test) throws Exception {
+    private void testInitialLocation(LocationTestCase test) throws Exception
+    {
         JsonParser p = createParserUsingStream(test.json, "UTF8");
         JsonLocation loc = p.getCurrentLocation();
         p.close();
@@ -50,7 +56,8 @@ public class LocationDuringStreamParsingTest extends BaseTest {
         assertLocation(loc, at(1, 1, 0));
     }
 
-    private void testTokenLocations(LocationTestCase test) throws Exception {
+    private void testTokenLocations(LocationTestCase test) throws Exception
+    {
         JsonParser p = createParserUsingStream(test.json, "UTF8");
         int i = 0;
         while (p.nextToken() != null) {
@@ -61,15 +68,18 @@ public class LocationDuringStreamParsingTest extends BaseTest {
         p.close();
     }
 
-    private void assertCurrentLocation(JsonParser p, LocData loc) {
+    private void assertCurrentLocation(JsonParser p, LocData loc)
+    {
         assertLocation(p.getCurrentLocation(), loc);
     }
 
-    private void assertTokenLocation(JsonParser p, LocData loc) {
+    private void assertTokenLocation(JsonParser p, LocData loc)
+    {
         assertLocation(p.getTokenLocation(), loc);
     }
 
-    private void assertLocation(JsonLocation pLoc, LocData loc) {
+    private void assertLocation(JsonLocation pLoc, LocData loc)
+    {
         String expected = String.format("(%d, %d, %d)",
                 loc.lineNumber, loc.columnNumber, loc.offset);
         String actual = String.format("(%d, %d, %d)", pLoc.getLineNr(), pLoc.getColumnNr(),
@@ -77,19 +87,22 @@ public class LocationDuringStreamParsingTest extends BaseTest {
         assertEquals(expected, actual);
     }
 
-    private static class LocData {
+    private static class LocData
+    {
         private long lineNumber;
         private long columnNumber;
         private long offset;
 
-        LocData(long lineNumber, long columnNumber, long offset) {
+        LocData(long lineNumber, long columnNumber, long offset)
+        {
             this.lineNumber = lineNumber;
             this.columnNumber = columnNumber;
             this.offset = offset;
         }
     }
 
-    private static LocData at(long lineNumber, long columnNumber, long offset) {
+    private static LocData at(long lineNumber, long columnNumber, long offset)
+    {
         return new LocData(lineNumber, columnNumber, offset);
     }
 
@@ -97,7 +110,8 @@ public class LocationDuringStreamParsingTest extends BaseTest {
      * Adapted liberally from https://github.com/leadpony/jsonp-test-suite, also
      * released under the Apache License v2.
      */
-    enum LocationTestCase {
+    enum LocationTestCase
+    {
         SIMPLE_VALUE("42", at(1, 1, 0), at(1, 3, 2)),
 
         SIMPLE_VALUE_WITH_PADDING("   1337  ", at(1, 4, 3), at(1, 10, 9)),
@@ -191,12 +205,14 @@ public class LocationDuringStreamParsingTest extends BaseTest {
         final String json;
         final List<LocData> locations;
 
-        LocationTestCase(String json, LocData... locations) {
+        LocationTestCase(String json, LocData... locations)
+        {
             this.json = json;
             this.locations = Arrays.asList(locations);
         }
 
-        LocData getFinalLocation() {
+        LocData getFinalLocation()
+        {
             return locations.get(locations.size() - 1);
         }
     }

--- a/src/test/java/com/fasterxml/jackson/core/read/LocationDuringStreamParsingTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/read/LocationDuringStreamParsingTest.java
@@ -1,0 +1,203 @@
+package com.fasterxml.jackson.core.read;
+
+import com.fasterxml.jackson.core.BaseTest;
+import com.fasterxml.jackson.core.JsonLocation;
+import com.fasterxml.jackson.core.JsonParser;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Set of tests that checks getCurrentLocation() and getTokenLocation() are as expected during
+ * parsing.
+ */
+public class LocationDuringStreamParsingTest extends BaseTest {
+    public void testLocationAtEndOfParse() throws Exception {
+        for (LocationTestCase test : LocationTestCase.values()) {
+            //System.out.println(test.name());
+            testLocationAtEndOfParse(test);
+        }
+    }
+
+    public void testInitialLocation() throws Exception {
+        for (LocationTestCase test : LocationTestCase.values()) {
+            //System.out.println(test.name());
+            testInitialLocation(test);
+        }
+    }
+
+    public void testTokenLocations() throws Exception {
+        for (LocationTestCase test : LocationTestCase.values()) {
+            //System.out.println(test.name());
+            testTokenLocations(test);
+        }
+    }
+
+    private void testLocationAtEndOfParse(LocationTestCase test) throws Exception {
+        JsonParser p = createParserUsingStream(test.json, "UTF8");
+        while (p.nextToken() != null) {
+            p.nextToken();
+        }
+        assertCurrentLocation(p, test.getFinalLocation());
+        p.close();
+    }
+
+    private void testInitialLocation(LocationTestCase test) throws Exception {
+        JsonParser p = createParserUsingStream(test.json, "UTF8");
+        JsonLocation loc = p.getCurrentLocation();
+        p.close();
+
+        assertLocation(loc, at(1, 1, 0));
+    }
+
+    private void testTokenLocations(LocationTestCase test) throws Exception {
+        JsonParser p = createParserUsingStream(test.json, "UTF8");
+        int i = 0;
+        while (p.nextToken() != null) {
+            assertTokenLocation(p, test.locations.get(i));
+            i++;
+        }
+        assertEquals(test.locations.size(), i + 1); // last LocData is end of stream
+        p.close();
+    }
+
+    private void assertCurrentLocation(JsonParser p, LocData loc) {
+        assertLocation(p.getCurrentLocation(), loc);
+    }
+
+    private void assertTokenLocation(JsonParser p, LocData loc) {
+        assertLocation(p.getTokenLocation(), loc);
+    }
+
+    private void assertLocation(JsonLocation pLoc, LocData loc) {
+        String expected = String.format("(%d, %d, %d)",
+                loc.lineNumber, loc.columnNumber, loc.offset);
+        String actual = String.format("(%d, %d, %d)", pLoc.getLineNr(), pLoc.getColumnNr(),
+                pLoc.getByteOffset() == -1 ? pLoc.getCharOffset() : pLoc.getByteOffset());
+        assertEquals(expected, actual);
+    }
+
+    private static class LocData {
+        private long lineNumber;
+        private long columnNumber;
+        private long offset;
+
+        LocData(long lineNumber, long columnNumber, long offset) {
+            this.lineNumber = lineNumber;
+            this.columnNumber = columnNumber;
+            this.offset = offset;
+        }
+    }
+
+    private static LocData at(long lineNumber, long columnNumber, long offset) {
+        return new LocData(lineNumber, columnNumber, offset);
+    }
+
+    /**
+     * Adapted liberally from https://github.com/leadpony/jsonp-test-suite, also
+     * released under the Apache License v2.
+     */
+    enum LocationTestCase {
+        SIMPLE_VALUE("42", at(1, 1, 0), at(1, 3, 2)),
+
+        SIMPLE_VALUE_WITH_PADDING("   1337  ", at(1, 4, 3), at(1, 10, 9)),
+
+        SIMPLE_VALUE_WITH_MULTIBYTE_CHARS("\"Правда\"",
+                at(1,1,0),
+                at(1,15,14) // one byte for each ", two for each Cyrillic char
+        ),
+
+        SIMPLE_VALUE_INCLUDING_SURROGATE_PAIR_CHARS("\"a П \uD83D\uDE01\"",
+                at(1,1,0),
+                at(1,12,11) // one byte for each ", a and space; two for П, four for smiley emoji
+        ),
+
+        ARRAY_IN_ONE_LINE("[\"hello\",42,true]",
+                at(1, 1, 0), // [
+                at(1, 2, 1), // "hello"
+                at(1, 10, 9), // 42
+                at(1, 13, 12), // true
+                at(1, 17, 16), // ]
+                at(1, 18, 17) // end of input
+        ),
+
+        ARRAY_IN_ONE_LINE_WITH_PADDING("  [ \"hello\" ,   42   ,   true   ]   ",
+                at(1, 3, 2), // [
+                at(1, 5, 4), // "hello"
+                at(1, 17, 16), // 42
+                at(1, 26, 25), // true
+                at(1, 33, 32), // ]
+                at(1, 37, 36) // end of input
+        ),
+
+        ARRAY_IN_MULTIPLE_LINES("[\n" + "    \"hello\",\n" + "    42,\n" + "    true\n" + "]",
+                at(1, 1, 0), // [
+                at(2, 5, 6), // "hello"
+                at(3, 5, 19), // 42
+                at(4, 5, 27), // true
+                at(5, 1, 32), // ]
+                at(5, 2, 33) // end of input
+        ),
+
+        ARRAY_IN_MULTIPLE_LINES_WITH_WEIRD_SPACING(" [\n" + "  \"hello\" ,  \n" + " 42   ,\n" + "      true\n" + " ]",
+                at(1, 2, 1), // [
+                at(2, 3, 5), // "hello"
+                at(3, 2, 18), // 42
+                at(4, 7, 31), // true
+                at(5, 2, 37), // ]
+                at(5, 3, 38) // end of input
+        ),
+
+        ARRAY_IN_MULTIPLE_LINES_CRLF("[\r\n" + "    \"hello\",\r\n" + "    42,\r\n" + "    true\r\n" + "]",
+                at(1, 1, 0), // [
+                at(2, 5, 7), // "hello"
+                at(3, 5, 21), // 42
+                at(4, 5, 30), // true
+                at(5, 1, 36), // ]
+                at(5, 2, 37) // end of input
+        ),
+
+        OBJECT_IN_ONE_LINE("{\"first\":\"hello\",\"second\":42}",
+                at(1, 1, 0), // {
+                at(1, 2, 1), // "first"
+                at(1, 10, 9), // "hello"
+                at(1, 18, 17), // "second"
+                at(1, 27, 26), // 42
+                at(1, 29, 28), // }
+                at(1, 30, 29) // end of input
+        ),
+
+        OBJECT_IN_MULTIPLE_LINES("{\n" + "    \"first\":\"hello\",\n" + "    \"second\":42\n" + "}",
+                at(1, 1, 0), // {
+                at(2, 5, 6), // "first"
+                at(2, 13, 14), // "hello"
+                at(3, 5, 27), // "second"
+                at(3, 14, 36), // 42
+                at(4, 1, 39), // }
+                at(4, 2, 40) // end of input
+        ),
+
+        OBJECT_IN_MULTIPLE_LINES_CRLF("{\r\n" + "    \"first\":\"hello\",\r\n" + "    \"second\":42\r\n" + "}",
+                at(1, 1, 0), // {
+                at(2, 5, 7), // "first"
+                at(2, 13, 15), // "hello"
+                at(3, 5, 29), // "second"
+                at(3, 14, 38), // 42
+                at(4, 1, 42), // }
+                at(4, 2, 43) // end of input
+        ),;
+
+        final String json;
+        final List<LocData> locations;
+
+        LocationTestCase(String json, LocData... locations) {
+            this.json = json;
+            this.locations = Arrays.asList(locations);
+        }
+
+        LocData getFinalLocation() {
+            return locations.get(locations.size() - 1);
+        }
+    }
+
+}


### PR DESCRIPTION
Fixes the getCurrentLocation() issue (#455) by moving changes to _currInputProcessed,
_currInputRowStart, and _nameStartOffset inside successful branch. Also includes
checks for getTokenLocation() that make sure correct beginning location of tokens is
reported and that getCurrentLocation() correctly reports the end of
stream when reading is finished.

Tests would be much nicer with parameterized tests from Junit5 since it's
hard to tell which test case fails if one does. That's what the commented
out print statements are for. Let me know if you'd like something different,
but I originally had them separated out and forgot to add methods when I
added to the enum.

Also, the idea for the enum and much of the test data is from
https://github.com/leadpony/jsonp-test-suite, which is also Apache 2
licensed. I had to rework the expected results because the JsonP
getLocation() works very differently. Let me know if you need a
CLA from the author of that project and I'll approach him.