### PR TITLE
Add failing test: PointerFromContextTest for NonBlockingJsonParser

### DIFF
--- a/src/test/java/com/fasterxml/jackson/core/PointerFromContextTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/PointerFromContextTest.java
@@ -1,8 +1,10 @@
 package com.fasterxml.jackson.core;
 
 import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
 
 import com.fasterxml.jackson.core.json.JsonFactory;
+import com.fasterxml.jackson.core.json.async.NonBlockingJsonParser;
 
 public class PointerFromContextTest extends BaseTest
 {
@@ -19,7 +21,20 @@ public class PointerFromContextTest extends BaseTest
         final String SIMPLE = aposToQuotes("{'a':123,'array':[1,2,[3],5,{'obInArray':4}],"
                 +"'ob':{'first':[false,true],'second':{'sub':37}},'b':true}");
         JsonParser p = JSON_F.createParser(ObjectReadContext.empty(), SIMPLE);
+        testParser(p);
+    }
 
+    public void testViaNonBlockingParser() throws Exception
+    {
+        JsonParser p = JSON_F.createNonBlockingByteArrayParser(ObjectReadContext.empty());
+        final String SIMPLE = aposToQuotes("{'a':123,'array':[1,2,[3],5,{'obInArray':4}],"
+                +"'ob':{'first':[false,true],'second':{'sub':37}},'b':true}");
+        byte[] SIMPLE_BYTES = SIMPLE.getBytes(StandardCharsets.UTF_8);
+        ((NonBlockingJsonParser) p).feedInput(SIMPLE_BYTES, 0, SIMPLE_BYTES.length);
+        testParser(p);
+    }
+
+    private void testParser(JsonParser p) throws Exception {
         // by default should just get "empty"
         assertSame(JsonPointer.EMPTY, p.getParsingContext().pathAsPointer());
 


### PR DESCRIPTION
`pathAsPointer()` doesn't return expected `JsonPointer` values in the `NonBlockingJsonParser`. It seems to track descent object keys just fine, but fails to track the array indices. They either appear as `/0` for all indices or come back empty.

I discovered this against 2.9.9, although it seems to be reproducible in master as well.

I'm currently using the `NonBlockingJsonParser` with akka-stream and uPickle. Would be nice to lean on the parser for correct `JsonPointer`s to wrap around downstream visitor exceptions (rather than tracking the path myself in user space).

I haven't started looking into what it'd take to fix this since I'm unfamiliar with the parser internals, although let me know if you'd like for me to take a crack at it.