### PR TITLE
Array index out of bounds in hex lookup

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/io/CharTypes.java
+++ b/src/main/java/com/fasterxml/jackson/core/io/CharTypes.java
@@ -219,7 +219,7 @@ public final class CharTypes
 
     public static int charToHex(int ch)
     {
-        return (ch > 127) ? -1 : sHexValues[ch];
+        return (ch < 0 || ch > 127) ? -1 : sHexValues[ch];
     }
 
     public static void appendQuoted(StringBuilder sb, String content)

--- a/src/test/java/com/fasterxml/jackson/core/io/TestCharTypes.java
+++ b/src/test/java/com/fasterxml/jackson/core/io/TestCharTypes.java
@@ -20,4 +20,12 @@ public class TestCharTypes
             assertEquals(expected, actual);
         }
     }
+
+    public void testHexOutOfRange()
+    {
+        final int[] inputs = {0, -1, 1, 129, -129};
+        for (int input : inputs) {
+            assertEquals(-1, CharTypes.charToHex(input));
+        }
+    }
 }


### PR DESCRIPTION
Fixing an index out of bounds if a negative number manages to get here. Found two paths that were able to trigger this by fuzzing.