### PR TITLE
Fix NPE in DataFormatMatcher#getMatchedFormatName when no match exists

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/format/DataFormatMatcher.java
+++ b/src/main/java/com/fasterxml/jackson/core/format/DataFormatMatcher.java
@@ -91,7 +91,7 @@ public class DataFormatMatcher
      *</pre>
      */
     public String getMatchedFormatName() {
-        return _match.getFormatName();
+        return hasMatch() ? getMatch().getFormatName() : null;
     }
     
     /*

--- a/src/test/java/com/fasterxml/jackson/core/format/DataFormatMatcherTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/format/DataFormatMatcherTest.java
@@ -35,4 +35,24 @@ public class DataFormatMatcherTest extends com.fasterxml.jackson.core.BaseTest
         verifyException(e, "Illegal start/length");
     }
   }
+
+  public void testGetMatchedFormatNameReturnsNameWhenMatches() {
+    DataFormatMatcher dataFormatMatcher = new DataFormatMatcher(null,
+            new byte[2],
+            1,
+            0,
+            new JsonFactory(),
+            MatchStrength.SOLID_MATCH);
+    assertEquals(JsonFactory.FORMAT_NAME_JSON, dataFormatMatcher.getMatchedFormatName());
+  }
+
+  public void testGetMatchedFormatNameReturnsNullWhenNoMatch() {
+    DataFormatMatcher dataFormatMatcher = new DataFormatMatcher(null,
+            new byte[2],
+            1,
+            0,
+            null,
+            MatchStrength.NO_MATCH);
+    assertNull(dataFormatMatcher.getMatchedFormatName());
+  }
 }


### PR DESCRIPTION
* Change DataFormatMatcher#getMatchedFormatName so it does what
  the Javadoc says, because otherwise it throws a NullPointerException
  when there is no match (and the _match field is null)
* Added tests for when there is a match, and when there isn't