### PR TITLE
Handle case when system property access is restricted

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/util/BufferRecyclers.java
+++ b/src/main/java/com/fasterxml/jackson/core/util/BufferRecyclers.java
@@ -5,7 +5,7 @@ import java.lang.ref.SoftReference;
 /**
  * Helper entity used to control access to simple buffer recyling scheme used for
  * some encoding, decoding tasks.
- * 
+ *
  * @see BufferRecycler
  *
  * @since 2.9.2
@@ -33,10 +33,13 @@ public class BufferRecyclers
      */
     private final static ThreadLocalBufferManager _bufferRecyclerTracker;
     static {
-        _bufferRecyclerTracker = "true".equals(System.getProperty(SYSTEM_PROPERTY_TRACK_REUSABLE_BUFFERS))
-                ? ThreadLocalBufferManager.instance()
-                : null;
-    }    
+        boolean trackReusableBuffers = false;
+        try {
+            trackReusableBuffers = "true".equals(System.getProperty(SYSTEM_PROPERTY_TRACK_REUSABLE_BUFFERS));
+        } catch (SecurityException e) { }
+
+        _bufferRecyclerTracker = trackReusableBuffers ? ThreadLocalBufferManager.instance() : null;
+    }
 
     /*
     /**********************************************************


### PR DESCRIPTION
I own a system that limits access to system properties. Requiring access to this property to determine if `trackReusableBuffers` should be enabled prevents my users from using Jackson.