### PR TITLE
Optionally allow leading decimal in float tokens

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/json/JsonReadFeature.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/JsonReadFeature.java
@@ -103,7 +103,18 @@ public enum JsonReadFeature
      * this is a non-standard feature, and as such disabled by default.
      */
     ALLOW_LEADING_ZEROS_FOR_NUMBERS(false),
-    
+
+    /**
+     * Feature that determines whether parser will allow
+     * JSON decimal numbers to start with a deciaml point
+     * (like: .123). If enabled, no exception is thrown, and the number
+     * is parsed as though a leading 0 had been present.
+     *<p>
+     * Since JSON specification does not allow leading decimal,
+     * this is a non-standard feature, and as such disabled by default.
+     */
+    ALLOW_LEADING_DECIMAL_POINT_FOR_NUMBERS(false),
+
     /**
      * Feature that allows parser to recognize set of
      * "Not-a-Number" (NaN) tokens as legal floating number

--- a/src/main/java/com/fasterxml/jackson/core/json/ReaderBasedJsonParser.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/ReaderBasedJsonParser.java
@@ -726,6 +726,7 @@ public class ReaderBasedJsonParser
         case '7':
         case '8':
         case '9':
+        case '.':
             t = _parsePosNumber(i);
             break;
         default:
@@ -919,6 +920,7 @@ public class ReaderBasedJsonParser
         case '7':
         case '8':
         case '9':
+        case '.':
             t = _parsePosNumber(i);
             break;
         case 'f':
@@ -988,6 +990,7 @@ public class ReaderBasedJsonParser
         case '7':
         case '8':
         case '9':
+        case '.':
             _nextToken = _parsePosNumber(i);
             return;
         }
@@ -1023,6 +1026,7 @@ public class ReaderBasedJsonParser
         case '7':
         case '8':
         case '9':
+        case '.':
             t = _parsePosNumber(i);
             break;
         case 'f':
@@ -1089,6 +1093,7 @@ public class ReaderBasedJsonParser
         case '7':
         case '8':
         case '9':
+        case '.':
             return (_currToken = _parsePosNumber(i));
         /*
          * This check proceeds only if the Feature.ALLOW_MISSING_VALUES is enabled
@@ -1217,6 +1222,7 @@ public class ReaderBasedJsonParser
     /**********************************************************
      */
 
+
     /**
      * Initial parsing method for number values. It needs to be able
      * to parse enough input to be able to determine whether the
@@ -1234,6 +1240,18 @@ public class ReaderBasedJsonParser
      */
     protected final JsonToken _parsePosNumber(int ch) throws IOException
     {
+        if (ch == '.') {
+            if (isEnabled(JsonReadFeature.ALLOW_LEADING_DECIMAL_POINT_FOR_NUMBERS)) {
+                return (_currToken = _parsePosNumber(ch, true));
+            } else {
+                return _handleOddValue(ch);
+            }
+        }
+        return _parsePosNumber(ch, false);
+    }
+
+    protected final JsonToken _parsePosNumber(int ch, boolean numberHasLeadingDecimal) throws IOException
+    {
         /* Although we will always be complete with respect to textual
          * representation (that is, all characters will be parsed),
          * actual conversion to a number is deferred. Thus, need to
@@ -1241,6 +1259,7 @@ public class ReaderBasedJsonParser
          */
         int ptr = _inputPtr;
         int startPtr = ptr-1; // to include digit already read
+
         final int inputLen = _inputEnd;
 
         // One special case, leading zero(es):
@@ -1269,7 +1288,7 @@ public class ReaderBasedJsonParser
             }
             ++intLen;
         }
-        if (ch == INT_PERIOD || ch == INT_e || ch == INT_E) {
+        if (ch == INT_PERIOD || ch == INT_e || ch == INT_E || numberHasLeadingDecimal) {
             _inputPtr = ptr;
             return _parseFloat(ch, startPtr, ptr, false, intLen);
         }

--- a/src/main/java/com/fasterxml/jackson/core/json/UTF8DataInputJsonParser.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/UTF8DataInputJsonParser.java
@@ -625,6 +625,7 @@ public class UTF8DataInputJsonParser
         case '7':
         case '8':
         case '9':
+        case '.':
             t = _parsePosNumber(i);
             break;
         case 'f':
@@ -690,6 +691,7 @@ public class UTF8DataInputJsonParser
         case '7':
         case '8':
         case '9':
+        case '.':
             return (_currToken = _parsePosNumber(i));
         }
         return (_currToken = _handleUnexpectedValue(i));
@@ -795,6 +797,7 @@ public class UTF8DataInputJsonParser
         case '7':
         case '8':
         case '9':
+        case '.':
             t = _parsePosNumber(i);
             break;
         case 'f':
@@ -949,6 +952,16 @@ public class UTF8DataInputJsonParser
      */
     protected JsonToken _parsePosNumber(int c) throws IOException
     {
+
+        boolean forceFloat = false;
+        if (c == '.') {
+            if (isEnabled(JsonReadFeature.ALLOW_LEADING_DECIMAL_POINT_FOR_NUMBERS)) {
+                forceFloat = true;
+            } else {
+                return _handleUnexpectedValue(c);
+            }
+        }
+
         char[] outBuf = _textBuffer.emptyAndGetCurrentSegment();
         int outPtr;
 
@@ -979,7 +992,7 @@ public class UTF8DataInputJsonParser
             outBuf[outPtr++] = (char) c;
             c = _inputData.readUnsignedByte();
         }
-        if (c == '.' || c == 'e' || c == 'E') {
+        if (c == '.' || c == 'e' || c == 'E' || forceFloat) {
             return _parseFloat(outBuf, outPtr, c, false, intLen);
         }
         _textBuffer.setCurrentLength(outPtr);

--- a/src/test/java/com/fasterxml/jackson/core/read/NumberParsingTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/read/NumberParsingTest.java
@@ -765,6 +765,35 @@ public class NumberParsingTest
         }
     }
 
+    /**
+     * The format ".NNN" (as opposed to "0.NNN") is not valid JSON, so this should fail
+     */
+    public void testLeadingDotInDecimal() throws Exception {
+        for (int mode : ALL_MODES) {
+            JsonParser p = createParser(mode, " .123 ");
+            try {
+                p.nextToken();
+                fail("Should not pass");
+            } catch (JsonParseException e) {
+                verifyException(e, "Unexpected character ('.'");
+            }
+            p.close();
+        }
+    }
+
+    public void testLeadingDotInDecimalAllowed() throws Exception {
+        for (int mode : ALL_MODES) {
+            final JsonFactory f = JsonFactory.builder()
+                    .enable(JsonReadFeature.ALLOW_LEADING_DECIMAL_POINT_FOR_NUMBERS)
+                    .build();
+            JsonParser p = createParser(f, mode, " .123 ");
+            assertEquals(JsonToken.VALUE_NUMBER_FLOAT, p.nextToken());
+            assertEquals(0.123, p.getValueAsDouble());
+            assertEquals("0.123", p.getDecimalValue().toString());
+            p.close();
+        }
+    }
+
     /*
     /**********************************************************
     /* Helper methods


### PR DESCRIPTION
JSON doesn't allow a leading decimal in a float (e.g. `{ "someval": .123 }` ) and Jackson rightly errors out when you try to parse this.

I have a need however (mostly caused by a previous Gson implementation now replaced with Jackson in [HAPI FHIR](https://hapifhir.io) silently accepting this syntax) to parse JSON containing this invalid format.

The attached pull request adds a read feature enabling the parsing of these leading decimal points.