### PR TITLE
Fix the (non-developer) connection in the POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 
   <url>https://github.com/FasterXML/jackson-core</url>
   <scm>
-    <connection>scm:git:git@github.com:FasterXML/jackson-core.git</connection>
+    <connection>scm:git:https://github.com/FasterXML/jackson-core.git</connection>
     <developerConnection>scm:git:git@github.com:FasterXML/jackson-core.git</developerConnection>
     <url>http://github.com/FasterXML/jackson-core</url>    
     <tag>HEAD</tag>


### PR DESCRIPTION
The "connection" is for anonymous read-only access [1]. As such do not
use authenticated SSH, but anonymous HTTPS as the protocol.

[1] http://maven.apache.org/pom.html#SCM