### PR TITLE
Applying modification pattern in #385 to FilteringParserDelegate#_nextToken2

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/filter/FilteringParserDelegate.java
+++ b/src/main/java/com/fasterxml/jackson/core/filter/FilteringParserDelegate.java
@@ -549,8 +549,13 @@ public class FilteringParserDelegate extends JsonParserDelegate
                     }
                     _itemFilter = f;
                     if (f == TokenFilter.INCLUDE_ALL) {
-                        if (_verifyAllowedMatches() && _includePath) {
-                            return (_currToken = t);
+                        if (_verifyAllowedMatches()) {
+                            if (_includePath) {
+                                return (_currToken = t);
+                            }
+                        } else {
+                            delegate.nextToken();
+                            delegate.skipChildren();
                         }
                         continue main_loop;
                     }


### PR DESCRIPTION
In #385, `FilteringParserDelegate#nextToken` was modified, but its similar method, `_nextToken2` was not modified.
Isn't the same modification needed?