### PR TITLE
Fix test so it works on all OS

### DIFF
--- a/src/test/java/com/fasterxml/jackson/core/util/DefaultIndenterTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/util/DefaultIndenterTest.java
@@ -29,7 +29,7 @@ public class DefaultIndenterTest {
     DefaultIndenter defaultIndenterTwo = defaultIndenter.withIndent("9Qh/6,~n");
     DefaultIndenter defaultIndenterThree = defaultIndenterTwo.withIndent("9Qh/6,~n");
 
-    assertEquals("\n", defaultIndenterThree.getEol());
+    assertEquals(System.lineSeparator(), defaultIndenterThree.getEol());
     assertNotSame(defaultIndenterThree, defaultIndenter);
     assertSame(defaultIndenterThree, defaultIndenterTwo);
   }


### PR DESCRIPTION
Especially on Windows one test did not pass, so I used the System.lineSeparator()-method, so it works on every Operation System.