### PR TITLE
improvement: allowing more granular control of reading behaviour for base64

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/Base64Variant.java
+++ b/src/main/java/com/fasterxml/jackson/core/Base64Variant.java
@@ -90,7 +90,7 @@ public final class Base64Variant
     /**
      * Whether padding characters should be required or not while decoding
      */
-    private final transient PaddingReadBehaviour _paddingReadBehaviour;
+    private final PaddingReadBehaviour _paddingReadBehaviour;
 
     /**
      * Character used for padding, if any ({@link #PADDING_CHAR_NONE} if not).
@@ -189,18 +189,30 @@ public final class Base64Variant
         this(base, base._name, base._usesPadding, base._paddingChar, paddingReadBehaviour, base._maxLineLength);
     }
 
+    /**
+     * @since 2.12
+     */
     public Base64Variant withPaddingAllowed() {
         return new Base64Variant(this, PaddingReadBehaviour.PADDING_ALLOWED);
     }
 
+    /**
+     * @since 2.12
+     */
     public Base64Variant withPaddingRequired() {
         return new Base64Variant(this, PaddingReadBehaviour.PADDING_REQUIRED);
     }
 
+    /**
+     * @since 2.12
+     */
     public Base64Variant withPaddingForbidden() {
         return new Base64Variant(this, PaddingReadBehaviour.PADDING_FORBIDDEN);
     }
 
+    /**
+     * @since 2.12
+     */
     public Base64Variant withWritePadding(boolean writePadding) {
         return new Base64Variant(this, this._name, writePadding, this._paddingChar, this._maxLineLength);
 

--- a/src/main/java/com/fasterxml/jackson/core/Base64Variant.java
+++ b/src/main/java/com/fasterxml/jackson/core/Base64Variant.java
@@ -710,12 +710,12 @@ public final class Base64Variant
 
     /**
      * Helper method that will construct a message to use in exceptions for cases where input ends
-     * prematurely in place where padding would be expected.
+     * prematurely in place where padding is not expected.
      *
      * @since 2.12
      */
     public String unexpectedPaddingMessage() {
-        return String.format("Unexpected end of base64-encoded String: derived base64 variant '%s' expects no padding at the end while decoding. This Base64Variant might have been incorrectly configured",
+        return String.format("Unexpected end of base64-encoded String: base64 variant '%s' expects no padding at the end while decoding. This Base64Variant might have been incorrectly configured",
                 getName());
     }
 
@@ -726,7 +726,7 @@ public final class Base64Variant
      * @since 2.10
      */
     public String missingPaddingMessage() {
-        return String.format("Unexpected end of base64-encoded String: derived base64 variant '%s' expects padding (one or more '%c' characters) at the end. This Base64Variant might have been incorrectly configured",
+        return String.format("Unexpected end of base64-encoded String: base64 variant '%s' expects padding (one or more '%c' characters) at the end. This Base64Variant might have been incorrectly configured",
                 getName(), getPaddingChar());
     }
 

--- a/src/main/java/com/fasterxml/jackson/core/Base64Variant.java
+++ b/src/main/java/com/fasterxml/jackson/core/Base64Variant.java
@@ -190,6 +190,7 @@ public final class Base64Variant
     }
 
     /**
+     * @return Base64Variant which does not require padding on read
      * @since 2.12
      */
     public Base64Variant withPaddingAllowed() {
@@ -197,6 +198,7 @@ public final class Base64Variant
     }
 
     /**
+     * @return Base64Variant which requires padding on read
      * @since 2.12
      */
     public Base64Variant withPaddingRequired() {
@@ -204,6 +206,7 @@ public final class Base64Variant
     }
 
     /**
+     * @return Base64Variant which does not accept padding on read
      * @since 2.12
      */
     public Base64Variant withPaddingForbidden() {
@@ -211,6 +214,8 @@ public final class Base64Variant
     }
 
     /**
+     * @param writePadding Determines if padding is output on write
+     * @return Base64Variant which writes padding or not depending on writePadding
      * @since 2.12
      */
     public Base64Variant withWritePadding(boolean writePadding) {
@@ -218,7 +223,11 @@ public final class Base64Variant
 
     }
 
-    private enum PaddingReadBehaviour {
+    /**
+     * Defines how the Base64Variant deals with Padding while reading
+     * @since 2.12
+     */
+    public enum PaddingReadBehaviour {
         PADDING_FORBIDDEN,
         PADDING_REQUIRED,
         PADDING_ALLOWED

--- a/src/main/java/com/fasterxml/jackson/core/Base64Variants.java
+++ b/src/main/java/com/fasterxml/jackson/core/Base64Variants.java
@@ -31,6 +31,7 @@ public final class Base64Variants
      * Note that although this can be thought of as the standard variant,
      * it is <b>not</b> the default for Jackson: no-linefeeds alternative
      * is because of JSON requirement of escaping all linefeeds.
+     * writes padding on output; does not accept padding when reading (may change latter with a call to {@link Base64Variant#withWritePadding(boolean)}])
      */
     public final static Base64Variant MIME;
     static {
@@ -42,6 +43,7 @@ public final class Base64Variants
      * use linefeeds (max line length set to infinite). Useful when linefeeds
      * wouldn't work well (possibly in attributes), or for minor space savings
      * (save 1 linefeed per 76 data chars, ie. ~1.4% savings).
+     * writes padding on output; does not accept padding when reading (may change latter with a call to {@link Base64Variant#withWritePadding(boolean)}])
      */
     public final static Base64Variant MIME_NO_LINEFEEDS;
     static {
@@ -51,6 +53,7 @@ public final class Base64Variants
     /**
      * This variant is the one that predates {@link #MIME}: it is otherwise
      * identical, except that it mandates shorter line length.
+     * writes padding on output; does not accept padding when reading (may change latter with a call to {@link Base64Variant#withWritePadding(boolean)}])
      */
     public final static Base64Variant PEM = new Base64Variant(MIME, "PEM", true, '=', 64);
 
@@ -64,6 +67,7 @@ public final class Base64Variants
      * line length set to infinite). And finally, two characters (plus and
      * slash) that would need quoting in URLs are replaced with more
      * optimal alternatives (hyphen and underscore, respectively).
+     * writes padding on output; does not accept padding when reading (may change latter with a call to {@link Base64Variant#withWritePadding(boolean)}])
      */
     public final static Base64Variant MODIFIED_FOR_URL;
     static {

--- a/src/main/java/com/fasterxml/jackson/core/Base64Variants.java
+++ b/src/main/java/com/fasterxml/jackson/core/Base64Variants.java
@@ -12,7 +12,10 @@ package com.fasterxml.jackson.core;
  * <li> {@link #PEM}
  * <li> {@link #MODIFIED_FOR_URL}
  * </ul>
- * 
+ *
+ * If a Base64Variant with default configuration outputs padding it also expects it on reading.
+ * If it does not output padding it will not accept padding on read.
+ *
  * @author Tatu Saloranta
  */
 public final class Base64Variants

--- a/src/main/java/com/fasterxml/jackson/core/Base64Variants.java
+++ b/src/main/java/com/fasterxml/jackson/core/Base64Variants.java
@@ -31,7 +31,7 @@ public final class Base64Variants
      * Note that although this can be thought of as the standard variant,
      * it is <b>not</b> the default for Jackson: no-linefeeds alternative
      * is because of JSON requirement of escaping all linefeeds.
-     * writes padding on output; does not accept padding when reading (may change latter with a call to {@link Base64Variant#withWritePadding(boolean)}])
+     * writes padding on output; does not accept padding when reading (may change later with a call to {@link Base64Variant#withWritePadding(boolean)}])
      */
     public final static Base64Variant MIME;
     static {
@@ -43,7 +43,7 @@ public final class Base64Variants
      * use linefeeds (max line length set to infinite). Useful when linefeeds
      * wouldn't work well (possibly in attributes), or for minor space savings
      * (save 1 linefeed per 76 data chars, ie. ~1.4% savings).
-     * writes padding on output; does not accept padding when reading (may change latter with a call to {@link Base64Variant#withWritePadding(boolean)}])
+     * writes padding on output; does not accept padding when reading (may change later with a call to {@link Base64Variant#withWritePadding(boolean)}])
      */
     public final static Base64Variant MIME_NO_LINEFEEDS;
     static {
@@ -53,7 +53,7 @@ public final class Base64Variants
     /**
      * This variant is the one that predates {@link #MIME}: it is otherwise
      * identical, except that it mandates shorter line length.
-     * writes padding on output; does not accept padding when reading (may change latter with a call to {@link Base64Variant#withWritePadding(boolean)}])
+     * writes padding on output; does not accept padding when reading (may change later with a call to {@link Base64Variant#withWritePadding(boolean)}])
      */
     public final static Base64Variant PEM = new Base64Variant(MIME, "PEM", true, '=', 64);
 
@@ -67,7 +67,7 @@ public final class Base64Variants
      * line length set to infinite). And finally, two characters (plus and
      * slash) that would need quoting in URLs are replaced with more
      * optimal alternatives (hyphen and underscore, respectively).
-     * writes padding on output; does not accept padding when reading (may change latter with a call to {@link Base64Variant#withWritePadding(boolean)}])
+     * writes padding on output; does not accept padding when reading (may change later with a call to {@link Base64Variant#withWritePadding(boolean)}])
      */
     public final static Base64Variant MODIFIED_FOR_URL;
     static {

--- a/src/test/java/com/fasterxml/jackson/core/base64/Base64CodecTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/base64/Base64CodecTest.java
@@ -206,6 +206,7 @@ public class Base64CodecTest
         } catch (IllegalArgumentException iae) {
             verifyException(iae, "expects padding");
         }
+
         Base64Variants.MODIFIED_FOR_URL.withPaddingAllowed().decode(BASE64_HELLO_WITHOUT_PADDING);
         Base64Variants.MODIFIED_FOR_URL.withPaddingForbidden().decode(BASE64_HELLO_WITHOUT_PADDING);
 


### PR DESCRIPTION
As Discussed in #500.

Allowing configuration of read behaviour via trio methods (withPadddingForbidden, withPaddingAllowed, withPaddingRequired)
existing usage of usesPadding now changes meaning to writePadding. (maybe this should be renamed?)
also there is a method included withWritePadding(boolean) to allow configuration of whether padding should be written derived from the Base64Variants.

Existing constructors set the following read behaviour. if usesPadding is enabled, then Padding on read is required. if usesPadding is disabled then Padding on Read is forbidden
Testing and validation pending.
