### PR TITLE
Fixed NPE in writeNumber(String) method of UTF8JsonGenerator and WriterBasedJsonGenerator

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/json/UTF8JsonGenerator.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/UTF8JsonGenerator.java
@@ -1054,7 +1054,9 @@ public class UTF8JsonGenerator
     public void writeNumber(String encodedValue) throws IOException
     {
         _verifyValueWrite(WRITE_NUMBER);
-        if (_cfgNumbersAsStrings) {
+        if (encodedValue == null) {
+            _writeNull();
+        } else if (_cfgNumbersAsStrings) {
             _writeQuotedRaw(encodedValue);            
         } else {
             writeRaw(encodedValue);

--- a/src/main/java/com/fasterxml/jackson/core/json/WriterBasedJsonGenerator.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/WriterBasedJsonGenerator.java
@@ -829,7 +829,9 @@ public class WriterBasedJsonGenerator
     public void writeNumber(String encodedValue) throws IOException
     {
         _verifyValueWrite(WRITE_NUMBER);
-        if (_cfgNumbersAsStrings) {
+        if (encodedValue == null) {
+            _writeNull();
+        } else if (_cfgNumbersAsStrings) {
             _writeQuotedRaw(encodedValue);
         } else {
             writeRaw(encodedValue);

--- a/src/test/java/com/fasterxml/jackson/core/json/GeneratorFeaturesTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/json/GeneratorFeaturesTest.java
@@ -95,16 +95,16 @@ public class GeneratorFeaturesTest
     {
         JsonFactory f = new JsonFactory();
         // by default should output numbers as-is:
-        assertEquals("[1,2,3,1.25,2.25,3001,0.5,-1,12.3]", _writeNumbers(f, false));
-        assertEquals("[1,2,3,1.25,2.25,3001,0.5,-1,12.3]", _writeNumbers(f, true));
+        assertEquals("[1,2,3,1.25,2.25,3001,0.5,-1,12.3,null,null,null]", _writeNumbers(f, false));
+        assertEquals("[1,2,3,1.25,2.25,3001,0.5,-1,12.3,null,null,null]", _writeNumbers(f, true));
 
         // but if overridden, quotes as Strings
         f = JsonFactory.builder()
                 .enable(JsonWriteFeature.WRITE_NUMBERS_AS_STRINGS)
                 .build();
-        assertEquals("[\"1\",\"2\",\"3\",\"1.25\",\"2.25\",\"3001\",\"0.5\",\"-1\",\"12.3\"]",
+        assertEquals("[\"1\",\"2\",\"3\",\"1.25\",\"2.25\",\"3001\",\"0.5\",\"-1\",\"12.3\",null,null,null]",
                      _writeNumbers(f, false));
-        assertEquals("[\"1\",\"2\",\"3\",\"1.25\",\"2.25\",\"3001\",\"0.5\",\"-1\",\"12.3\"]",
+        assertEquals("[\"1\",\"2\",\"3\",\"1.25\",\"2.25\",\"3001\",\"0.5\",\"-1\",\"12.3\",null,null,null]",
                 _writeNumbers(f, true));
 
         
@@ -228,6 +228,9 @@ public class GeneratorFeaturesTest
         g.writeNumber(BigDecimal.valueOf(0.5));
         g.writeNumber("-1");
         g.writeNumber(new char[]{'1', '2', '.', '3', '-'}, 0, 4);
+        g.writeNumber((String) null);
+        g.writeNumber((BigDecimal) null);
+        g.writeNumber((BigInteger) null);
         g.writeEndArray();
         g.close();
 


### PR DESCRIPTION
I faced NPE in writeNumber(String) of UTF8JsonGenerator when trying to pass null into this method.

`gen.writeNumber(getStringValue());`
where `getStringValue()` method can return null, and this causes NPE in writeRaw(String text) method of generator. 
But it works fine for writeNumber(BigDecimal) and writeNumber(BigInteger) methods if I pass null into those methods.

Thus, I added null check for `writeNumber(String encodedValue)`  the same as it made for BigDecimal and BigInteger types. Furthermore modified some tests for this nullability check.