### PR TITLE
Fix failing tests

### DIFF
--- a/src/test/java/com/fasterxml/jackson/core/filter/BasicGeneratorFilteringTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/filter/BasicGeneratorFilteringTest.java
@@ -227,7 +227,7 @@ public class BasicGeneratorFilteringTest extends BaseTest
         FilteringGeneratorDelegate gen = new FilteringGeneratorDelegate(_createGenerator(w),
                 tf,
                 Inclusion.INCLUDE_ALL_AND_PATH,
-                false // multipleMatches
+                true // multipleMatches
                 );
         //final String JSON = "{'a':123,'array':[1,2],'ob':{'value0':2,'value':[3],'value2':'foo'},'b':true}";
 

--- a/src/test/java/com/fasterxml/jackson/core/filter/BasicParserFilteringTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/filter/BasicParserFilteringTest.java
@@ -80,14 +80,6 @@ public class BasicParserFilteringTest extends BaseTest
         protected boolean _includeScalar() { return false; }
     }
 
-    static class NoArraysFilter extends TokenFilter
-    {
-        @Override
-        public TokenFilter filterStartArray() {
-            return null;
-        }
-    }
-
     static class NoObjectsFilter extends TokenFilter
     {
         @Override
@@ -420,21 +412,6 @@ public class BasicParserFilteringTest extends BaseTest
         );
         String result = readAndWrite(JSON_F, p);
         assertEquals(aposToQuotes("[[{}],[{}],[{}]]"), result);
-        assertEquals(0, p.getMatchCount());
-    }
-
-    // https://github.com/FasterXML/jackson-core/issues/649
-    public void failing_testValueOmitsFieldName1() throws Exception
-    {
-        String jsonString = aposToQuotes("{'a':123,'array':[1,2]}");
-        JsonParser p0 = JSON_F.createParser(jsonString);
-        FilteringParserDelegate p = new FilteringParserDelegate(p0,
-            new NoArraysFilter(),
-            Inclusion.INCLUDE_NON_NULL,
-            true // multipleMatches
-        );
-        String result = readAndWrite(JSON_F, p);
-        assertEquals(aposToQuotes("{'a':123}"), result);
         assertEquals(0, p.getMatchCount());
     }
 

--- a/src/test/java/com/fasterxml/jackson/core/filter/BasicParserFilteringTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/filter/BasicParserFilteringTest.java
@@ -423,7 +423,8 @@ public class BasicParserFilteringTest extends BaseTest
         assertEquals(0, p.getMatchCount());
     }
 
-    public void testValueOmitsFieldName1() throws Exception
+    // https://github.com/FasterXML/jackson-core/issues/649
+    public void failing_testValueOmitsFieldName1() throws Exception
     {
         String jsonString = aposToQuotes("{'a':123,'array':[1,2]}");
         JsonParser p0 = JSON_F.createParser(jsonString);
@@ -439,7 +440,7 @@ public class BasicParserFilteringTest extends BaseTest
 
     public void testValueOmitsFieldName2() throws Exception
     {
-        String jsonString = aposToQuotes("['a',{'value0':3,'b':{'value':4}}]");
+        String jsonString = aposToQuotes("['a',{'value0':3,'b':{'value':4}},123]");
         JsonParser p0 = JSON_F.createParser(jsonString);
         FilteringParserDelegate p = new FilteringParserDelegate(p0,
             new NoObjectsFilter(),
@@ -447,8 +448,8 @@ public class BasicParserFilteringTest extends BaseTest
             true // multipleMatches
         );
         String result = readAndWrite(JSON_F, p);
-        assertEquals(aposToQuotes("['a']"), result);
-        assertEquals(1, p.getMatchCount());
+        assertEquals(aposToQuotes("['a',123]"), result);
+        assertEquals(2, p.getMatchCount());
     }
 
     public void testIndexMatchWithPath1() throws Exception

--- a/src/test/java/com/fasterxml/jackson/failing/filter/BasicParserFilteringTest.java
+++ b/src/test/java/com/fasterxml/jackson/failing/filter/BasicParserFilteringTest.java
@@ -1,0 +1,36 @@
+package com.fasterxml.jackson.failing.filter;
+
+import com.fasterxml.jackson.core.BaseTest;
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.filter.FilteringParserDelegate;
+import com.fasterxml.jackson.core.filter.TokenFilter;
+import com.fasterxml.jackson.core.filter.TokenFilter.Inclusion;
+
+public class BasicParserFilteringTest extends BaseTest {
+
+  private final JsonFactory JSON_F = new JsonFactory();
+
+  static class NoArraysFilter extends TokenFilter
+  {
+    @Override
+    public TokenFilter filterStartArray() {
+      return null;
+    }
+  }
+
+  // for [core#649]
+  public void testValueOmitsFieldName1() throws Exception
+  {
+    String jsonString = aposToQuotes("{'a':123,'array':[1,2]}");
+    JsonParser p0 = JSON_F.createParser(jsonString);
+    FilteringParserDelegate p = new FilteringParserDelegate(p0,
+        new NoArraysFilter(),
+        Inclusion.INCLUDE_NON_NULL,
+        true // multipleMatches
+    );
+    String result = readAndWrite(JSON_F, p);
+    assertEquals(aposToQuotes("{'a':123}"), result);
+    assertEquals(0, p.getMatchCount());
+  }
+}


### PR DESCRIPTION
Follow-up to #573 to fix 2 failing tests. 

The failing `BasicGeneratorFilteringTest` was just because `multipleMatches` needs to be set to true (and was accidentally flipped to false in #573). The test was updated in 6318aeea3368f8d065535ad9d032de7ca79130be in a way that requires this flag to be true.

The failing `BasicParserFilteringTest` is the issue I described [here](https://github.com/FasterXML/jackson-core/pull/573#issuecomment-546601957) (which appears to have existed since the filtering functionality was introduced). I filed #649 and ignored the test for now.

While I was in there, I also extended `BasicParserFilteringTest#testValueOmitsFieldName2` slightly to make the input more complex