### PR TITLE
Fix typo when calling the "@code" tag.

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/JsonParser.java
+++ b/src/main/java/com/fasterxml/jackson/core/JsonParser.java
@@ -215,7 +215,7 @@ public abstract class JsonParser
      * Access mode is determined by earlier calls via {@link JsonFactory};
      * it may not be changed after construction.
      *<p>
-     * If non-blocking decoding is (@code true}, it is possible to call
+     * If non-blocking decoding is {@code true}, it is possible to call
      * {@link #getNonBlockingInputFeeder()} to obtain object to use
      * for feeding input; otherwise (<code>false</code> returned)
      * input is read by blocking 


### PR DESCRIPTION
I just noted a small typo while reading the Javadoc, so I decided to offer a quick fix.