### PR TITLE
Allow TokenFilter to preserve empty

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/filter/FilteringParserDelegate.java
+++ b/src/main/java/com/fasterxml/jackson/core/filter/FilteringParserDelegate.java
@@ -273,9 +273,11 @@ public class FilteringParserDelegate extends JsonParserDelegate
                     _exposedContext = null;
                     if (ctxt.inArray()) {
                         t = delegate.getCurrentToken();
-// Is this guaranteed to work without further checks?
-//                        if (t != JsonToken.START_ARRAY) {
                         _currToken = t;
+                        if (_currToken == JsonToken.END_ARRAY) {
+                            _headContext = _headContext.getParent();
+                            _itemFilter = _headContext.getFilter();
+                        }
                         return t;
                     }
 
@@ -283,6 +285,10 @@ public class FilteringParserDelegate extends JsonParserDelegate
                     // Almost! Most likely still have the current token;
                     // with the sole exception of FIELD_NAME
                     t = delegate.currentToken();
+                    if (t == JsonToken.END_OBJECT) {
+                        _headContext = _headContext.getParent();
+                        _itemFilter = _headContext.getFilter();
+                    }
                     if (t != JsonToken.FIELD_NAME) {
                         _currToken = t;
                         return t;
@@ -562,13 +568,33 @@ public class FilteringParserDelegate extends JsonParserDelegate
                 continue main_loop;
 
             case ID_END_ARRAY:
+                {
+                    boolean returnEnd = _headContext.isStartHandled();
+                    f = _headContext.getFilter();
+                    if ((f != null) && (f != TokenFilter.INCLUDE_ALL)) {
+                        boolean includeEmpty = f.includeEmptyArray(_headContext.hasCurrentIndex());
+                        f.filterFinishArray();
+                        if (includeEmpty) {
+                            return _nextBuffered(_headContext);
+                        }
+                    }
+                    _headContext = _headContext.getParent();
+                    _itemFilter = _headContext.getFilter();
+                    if (returnEnd) {
+                        return (_currToken = t);
+                    }
+                }
+                continue main_loop;
             case ID_END_OBJECT:
                 {
                     boolean returnEnd = _headContext.isStartHandled();
                     f = _headContext.getFilter();
                     if ((f != null) && (f != TokenFilter.INCLUDE_ALL)) {
-                        f.filterFinishArray();
-                    }
+                        boolean includeEmpty = f.includeEmptyArray(_headContext.hasCurrentName());
+                        f.filterFinishObject();
+                        if (includeEmpty) {
+                            return _nextBuffered(_headContext);
+                        }                    }
                     _headContext = _headContext.getParent();
                     _itemFilter = _headContext.getFilter();
                     if (returnEnd) {
@@ -708,13 +734,16 @@ public class FilteringParserDelegate extends JsonParserDelegate
                 continue main_loop;
 
             case ID_END_ARRAY:
-            case ID_END_OBJECT:
                 {
                     // Unlike with other loops, here we know that content was NOT
                     // included (won't get this far otherwise)
                     f = _headContext.getFilter();
                     if ((f != null) && (f != TokenFilter.INCLUDE_ALL)) {
+                        boolean includeEmpty = f.includeEmptyArray(_headContext.hasCurrentIndex());
                         f.filterFinishArray();
+                        if (includeEmpty) {
+                            return _nextBuffered(buffRoot);
+                        }
                     }
                     boolean gotEnd = (_headContext == buffRoot);
                     boolean returnEnd = gotEnd && _headContext.isStartHandled();
@@ -727,6 +756,33 @@ public class FilteringParserDelegate extends JsonParserDelegate
                     }
                 }
                 continue main_loop;
+            case ID_END_OBJECT:
+            {
+                // Unlike with other loops, here we know that content was NOT
+                // included (won't get this far otherwise)
+                f = _headContext.getFilter();
+                if ((f != null) && (f != TokenFilter.INCLUDE_ALL)) {
+                    boolean includeEmpty = f.includeEmptyObject(_headContext.hasCurrentName());
+                    f.filterFinishObject();
+                    if (includeEmpty) {
+                        _headContext._currentName = _headContext._parent == null
+                                ? null
+                                : _headContext._parent._currentName;
+                        _headContext._needToHandleName = false;
+                        return _nextBuffered(buffRoot);
+                    }
+                }
+                boolean gotEnd = (_headContext == buffRoot);
+                boolean returnEnd = gotEnd && _headContext.isStartHandled();
+
+                _headContext = _headContext.getParent();
+                _itemFilter = _headContext.getFilter();
+
+                if (returnEnd) {
+                    return t;
+                }
+            }
+            continue main_loop;
 
             case ID_FIELD_NAME:
                 {

--- a/src/main/java/com/fasterxml/jackson/core/filter/TokenFilter.java
+++ b/src/main/java/com/fasterxml/jackson/core/filter/TokenFilter.java
@@ -432,6 +432,14 @@ public class TokenFilter
         return _includeScalar();
     }
 
+    public boolean includeEmptyArray(boolean contentsFiltered) {
+        return false;
+    }
+
+    public boolean includeEmptyObject(boolean contentsFiltered) {
+        return false;
+    }
+
     /*
     /**********************************************************
     /* Overrides

--- a/src/main/java/com/fasterxml/jackson/core/filter/TokenFilterContext.java
+++ b/src/main/java/com/fasterxml/jackson/core/filter/TokenFilterContext.java
@@ -233,6 +233,16 @@ public class TokenFilterContext extends JsonStreamContext
     {
         if (_startHandled) {
             gen.writeEndArray();
+        } else {
+            if ((_filter != null) && (_filter != TokenFilter.INCLUDE_ALL)) {
+                if (_filter.includeEmptyArray(hasCurrentIndex())) {
+                    if (_parent != null) {
+                        _parent._writePath(gen);
+                    }
+                    gen.writeStartArray();
+                    gen.writeEndArray();
+                }
+            }
         }
         if ((_filter != null) && (_filter != TokenFilter.INCLUDE_ALL)) {
             _filter.filterFinishArray();
@@ -244,6 +254,16 @@ public class TokenFilterContext extends JsonStreamContext
     {
         if (_startHandled) {
             gen.writeEndObject();
+        } else {
+            if ((_filter != null) && (_filter != TokenFilter.INCLUDE_ALL)) {
+                if (_filter.includeEmptyObject(hasCurrentName())) {
+                    if (_parent != null) {
+                        _parent._writePath(gen);
+                    }
+                    gen.writeStartObject();
+                    gen.writeEndObject();
+                }
+            }
         }
         if ((_filter != null) && (_filter != TokenFilter.INCLUDE_ALL)) {
             _filter.filterFinishObject();

--- a/src/test/java/com/fasterxml/jackson/core/BaseTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/BaseTest.java
@@ -451,11 +451,15 @@ public abstract class BaseTest
         g.disable(JsonGenerator.Feature.AUTO_CLOSE_JSON_CONTENT);
         try {
             while (p.nextToken() != null) {
+                System.err.println(p.currentToken() + "  " + p.currentName() + "  " + p.currentValue());
                 g.copyCurrentEvent(p);
             }
         } catch (IOException e) {
             g.flush();
-            fail("Unexpected problem during `readAndWrite`. Output so far: '"+sw+"'; problem: "+e);
+            throw new AssertionError(
+                    "Unexpected problem during `readAndWrite`. Output so far: '" +
+                            sw + "'; problem: " + e.getMessage(),
+                    e);
         }
         p.close();
         g.close();

--- a/src/test/java/com/fasterxml/jackson/core/filter/BasicGeneratorFilteringTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/filter/BasicGeneratorFilteringTest.java
@@ -614,6 +614,262 @@ public class BasicGeneratorFilteringTest extends BaseTest
         assertEquals(aposToQuotes("{'f1':1,'f2':12.3,'f3':3}"), w.toString());
     }
 
+    static final TokenFilter INCLUDE_EMPTY_IF_NOT_FILTERED = new TokenFilter() {
+        @Override
+        public boolean includeEmptyArray(boolean contentsFiltered) {
+            return !contentsFiltered;
+        }
+
+        @Override
+        public boolean includeEmptyObject(boolean contentsFiltered) {
+            return !contentsFiltered;
+        }
+
+        @Override
+        public boolean _includeScalar() {
+            return false;
+        }
+    };
+
+    static final TokenFilter INCLUDE_EMPTY = new TokenFilter() {
+        @Override
+        public boolean includeEmptyArray(boolean contentsFiltered) {
+            return true;
+        }
+
+        @Override
+        public boolean includeEmptyObject(boolean contentsFiltered) {
+            return true;
+        }
+
+        @Override
+        public boolean _includeScalar() {
+            return false;
+        }
+    };
+
+    public void testIncludeEmptyArrayIfNotFiltered() throws Exception
+    {
+        StringWriter w = new StringWriter();
+        JsonGenerator gen = new FilteringGeneratorDelegate(
+                _createGenerator(w),
+                INCLUDE_EMPTY_IF_NOT_FILTERED,
+                Inclusion.INCLUDE_ALL_AND_PATH,
+                true);
+
+        gen.writeStartObject();
+        gen.writeArrayFieldStart("empty_array");
+        gen.writeEndArray();
+        gen.writeArrayFieldStart("filtered_array");
+        gen.writeNumber(6);
+        gen.writeEndArray();
+        gen.writeEndObject();
+
+        gen.close();
+        assertEquals(aposToQuotes("{'empty_array':[]}"), w.toString());
+    }
+
+    public void testIncludeEmptyArray() throws Exception
+    {
+        StringWriter w = new StringWriter();
+        JsonGenerator gen = new FilteringGeneratorDelegate(
+                _createGenerator(w),
+                INCLUDE_EMPTY,
+                Inclusion.INCLUDE_ALL_AND_PATH,
+                true);
+
+        gen.writeStartObject();
+        gen.writeArrayFieldStart("empty_array");
+        gen.writeEndArray();
+        gen.writeArrayFieldStart("filtered_array");
+        gen.writeNumber(6);
+        gen.writeEndArray();
+        gen.writeEndObject();
+
+        gen.close();
+        assertEquals(aposToQuotes("{'empty_array':[],'filtered_array':[]}"), w.toString());
+    }
+
+    public void testIncludeEmptyObjectIfNotFiltered() throws Exception
+    {
+        StringWriter w = new StringWriter();
+        JsonGenerator gen = new FilteringGeneratorDelegate(
+                _createGenerator(w),
+                INCLUDE_EMPTY_IF_NOT_FILTERED,
+                Inclusion.INCLUDE_ALL_AND_PATH,
+                true);
+
+        gen.writeStartObject();
+        gen.writeFieldName("empty_object");
+        gen.writeStartObject();
+        gen.writeEndObject();
+        gen.writeFieldName("filtered_object");
+        gen.writeStartObject();
+        gen.writeNumberField("foo", 6);
+        gen.writeEndObject();
+        gen.writeEndObject();
+
+        gen.close();
+        assertEquals(aposToQuotes("{'empty_object':{}}"), w.toString());
+    }
+
+    public void testIncludeEmptyObject() throws Exception
+    {
+        StringWriter w = new StringWriter();
+        JsonGenerator gen = new FilteringGeneratorDelegate(
+                _createGenerator(w),
+                INCLUDE_EMPTY,
+                Inclusion.INCLUDE_ALL_AND_PATH,
+                true);
+
+        gen.writeStartObject();
+        gen.writeObjectFieldStart("empty_object");
+        gen.writeEndObject();
+        gen.writeObjectFieldStart("filtered_object");
+        gen.writeNumberField("foo", 6);
+        gen.writeEndObject();
+        gen.writeEndObject();
+
+        gen.close();
+        assertEquals(aposToQuotes("{'empty_object':{},'filtered_object':{}}"), w.toString());
+    }
+
+    public void testIncludeEmptyArrayInObjectIfNotFiltered() throws Exception
+    {
+        StringWriter w = new StringWriter();
+        JsonGenerator gen = new FilteringGeneratorDelegate(
+                _createGenerator(w),
+                INCLUDE_EMPTY_IF_NOT_FILTERED,
+                Inclusion.INCLUDE_ALL_AND_PATH,
+                true);
+
+        gen.writeStartObject();
+        gen.writeObjectFieldStart("object_with_empty_array");
+        gen.writeArrayFieldStart("foo");
+        gen.writeEndArray();
+        gen.writeEndObject();
+        gen.writeObjectFieldStart("object_with_filtered_array");
+        gen.writeArrayFieldStart("foo");
+        gen.writeNumber(5);
+        gen.writeEndArray();
+        gen.writeEndObject();
+        gen.writeEndObject();
+
+        gen.close();
+        assertEquals(aposToQuotes("{'object_with_empty_array':{'foo':[]}}"), w.toString());
+    }
+
+    public void testIncludeEmptyArrayInObject() throws Exception
+    {
+        StringWriter w = new StringWriter();
+        JsonGenerator gen = new FilteringGeneratorDelegate(
+                _createGenerator(w),
+                INCLUDE_EMPTY,
+                Inclusion.INCLUDE_ALL_AND_PATH,
+                true);
+
+        gen.writeStartObject();
+        gen.writeObjectFieldStart("object_with_empty_array");
+        gen.writeArrayFieldStart("foo");
+        gen.writeEndArray();
+        gen.writeEndObject();
+        gen.writeObjectFieldStart("object_with_filtered_array");
+        gen.writeArrayFieldStart("foo");
+        gen.writeNumber(5);
+        gen.writeEndArray();
+        gen.writeEndObject();
+        gen.writeEndObject();
+
+        gen.close();
+        assertEquals(aposToQuotes("{'object_with_empty_array':{'foo':[]},'object_with_filtered_array':{'foo':[]}}"), w.toString());
+    }
+
+
+    public void testIncludeEmptyObjectInArrayIfNotFiltered() throws Exception
+    {
+        StringWriter w = new StringWriter();
+        JsonGenerator gen = new FilteringGeneratorDelegate(
+                _createGenerator(w),
+                INCLUDE_EMPTY_IF_NOT_FILTERED,
+                Inclusion.INCLUDE_ALL_AND_PATH,
+                true);
+
+        gen.writeStartObject();
+        gen.writeArrayFieldStart("array_with_empty_object");
+        gen.writeStartObject();
+        gen.writeEndObject();
+        gen.writeEndArray();
+        gen.writeArrayFieldStart("array_with_filtered_object");
+        gen.writeStartObject();
+        gen.writeNumberField("foo", 5);
+        gen.writeEndObject();
+        gen.writeEndArray();
+        gen.writeEndObject();
+
+        gen.close();
+        assertEquals(aposToQuotes("{'array_with_empty_object':[{}]}"), w.toString());
+    }
+
+    public void testIncludeEmptyObjectInArray() throws Exception
+    {
+        StringWriter w = new StringWriter();
+        JsonGenerator gen = new FilteringGeneratorDelegate(
+                _createGenerator(w),
+                INCLUDE_EMPTY,
+                Inclusion.INCLUDE_ALL_AND_PATH,
+                true);
+
+        gen.writeStartObject();
+        gen.writeArrayFieldStart("array_with_empty_object");
+        gen.writeStartObject();
+        gen.writeEndObject();
+        gen.writeEndArray();
+        gen.writeArrayFieldStart("array_with_filtered_object");
+        gen.writeStartObject();
+        gen.writeNumberField("foo", 5);
+        gen.writeEndObject();
+        gen.writeEndArray();
+        gen.writeEndObject();
+
+        gen.close();
+        assertEquals(
+                aposToQuotes("{'array_with_empty_object':[{}],'array_with_filtered_object':[{}]}"),
+                w.toString());
+    }
+
+
+    public void testIncludeEmptyTopLevelObject() throws Exception
+    {
+        StringWriter w = new StringWriter();
+        JsonGenerator gen = new FilteringGeneratorDelegate(
+                _createGenerator(w),
+                INCLUDE_EMPTY_IF_NOT_FILTERED,
+                Inclusion.INCLUDE_ALL_AND_PATH,
+                true);
+
+        gen.writeStartObject();
+        gen.writeEndObject();
+
+        gen.close();
+        assertEquals(aposToQuotes("{}"), w.toString());
+    }
+
+    public void testIncludeEmptyTopLevelArray() throws Exception
+    {
+        StringWriter w = new StringWriter();
+        JsonGenerator gen = new FilteringGeneratorDelegate(
+                _createGenerator(w),
+                INCLUDE_EMPTY_IF_NOT_FILTERED,
+                Inclusion.INCLUDE_ALL_AND_PATH,
+                true);
+
+        gen.writeStartArray();
+        gen.writeEndArray();
+
+        gen.close();
+        assertEquals(aposToQuotes("[]"), w.toString());
+    }
+
     private JsonGenerator _createGenerator(Writer w) throws IOException {
         return JSON_F.createGenerator(w);
     }

--- a/src/test/java/com/fasterxml/jackson/core/filter/BasicParserFilteringTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/filter/BasicParserFilteringTest.java
@@ -6,6 +6,8 @@ import java.util.*;
 import com.fasterxml.jackson.core.*;
 import com.fasterxml.jackson.core.filter.TokenFilter.Inclusion;
 
+import static com.fasterxml.jackson.core.filter.BasicGeneratorFilteringTest.*;
+
 @SuppressWarnings("resource")
 public class BasicParserFilteringTest extends BaseTest
 {
@@ -559,5 +561,108 @@ public class BasicParserFilteringTest extends BaseTest
         p.skipChildren();
         assertEquals(JsonToken.END_OBJECT, p.getCurrentToken());
         assertNull(p.nextToken());
+    }
+
+    public void testIncludeEmptyArrayIfNotFiltered() throws Exception {
+        JsonParser p0 = JSON_F.createParser(aposToQuotes(
+                "{'empty_array':[],'filtered_array':[5]}"));
+        JsonParser p = new FilteringParserDelegate(p0,
+                INCLUDE_EMPTY_IF_NOT_FILTERED,
+                Inclusion.INCLUDE_ALL_AND_PATH,
+                false // multipleMatches
+        );
+        assertEquals(aposToQuotes("{'empty_array':[]}"), readAndWrite(JSON_F, p));
+    }
+
+    public void testIncludeEmptyArray() throws Exception {
+        JsonParser p0 = JSON_F.createParser(aposToQuotes(
+                "{'empty_array':[],'filtered_array':[5]}"));
+        JsonParser p = new FilteringParserDelegate(p0,
+                INCLUDE_EMPTY,
+                Inclusion.INCLUDE_ALL_AND_PATH,
+                false // multipleMatches
+        );
+        assertEquals(aposToQuotes("{'empty_array':[],'filtered_array':[]}"), readAndWrite(JSON_F, p));
+    }
+
+    public void testIncludeEmptyObjectIfNotFiltered() throws Exception {
+        JsonParser p0 = JSON_F.createParser(aposToQuotes(
+                "{'empty_object':{},'filtered_object':{'foo':5}}"));
+        JsonParser p = new FilteringParserDelegate(p0,
+                INCLUDE_EMPTY_IF_NOT_FILTERED,
+                Inclusion.INCLUDE_ALL_AND_PATH,
+                false // multipleMatches
+        );
+        assertEquals(aposToQuotes("{'empty_object':{}}"), readAndWrite(JSON_F, p));
+    }
+
+    public void testIncludeEmptyObject() throws Exception {
+        JsonParser p0 = JSON_F.createParser(aposToQuotes(
+                "{'empty_object':{},'filtered_object':{'foo':5}}"));
+        JsonParser p = new FilteringParserDelegate(p0,
+                INCLUDE_EMPTY,
+                Inclusion.INCLUDE_ALL_AND_PATH,
+                false // multipleMatches
+        );
+        assertEquals(aposToQuotes("{'empty_object':{},'filtered_object':{}}"), readAndWrite(JSON_F, p));
+    }
+
+    public void testIncludeEmptyArrayInObjectIfNotFiltered() throws Exception {
+        JsonParser p0 = JSON_F.createParser(aposToQuotes(
+                "{'object_with_empty_array':{'foo':[]},'object_with_filtered_array':{'foo':[5]}}"));
+        JsonParser p = new FilteringParserDelegate(p0,
+                INCLUDE_EMPTY_IF_NOT_FILTERED,
+                Inclusion.INCLUDE_ALL_AND_PATH,
+                false // multipleMatches
+        );
+        assertEquals(aposToQuotes("{'object_with_empty_array':{'foo':[]}}"), readAndWrite(JSON_F, p));
+    }
+
+    public void testIncludeEmptyArrayInObject() throws Exception {
+        JsonParser p0 = JSON_F.createParser(aposToQuotes(
+                "{'object_with_empty_array':{'foo':[]},'object_with_filtered_array':{'foo':[5]}}"));
+        JsonParser p = new FilteringParserDelegate(p0,
+                INCLUDE_EMPTY,
+                Inclusion.INCLUDE_ALL_AND_PATH,
+                false // multipleMatches
+        );
+        assertEquals(
+                aposToQuotes("{'object_with_empty_array':{'foo':[]},'object_with_filtered_array':{'foo':[]}}"),
+                readAndWrite(JSON_F, p));
+    }
+
+    public void testIncludeEmptyObjectInArrayIfNotFiltered() throws Exception {
+        JsonParser p0 = JSON_F.createParser(aposToQuotes(
+                "{'array_with_empty_object':[{}],'array_with_filtered_object':[{'foo':5}]}"));
+        JsonParser p = new FilteringParserDelegate(p0,
+                INCLUDE_EMPTY_IF_NOT_FILTERED,
+                Inclusion.INCLUDE_ALL_AND_PATH,
+                false // multipleMatches
+        );
+        assertEquals(aposToQuotes("{'array_with_empty_object':[{}]}"), readAndWrite(JSON_F, p));
+    }
+
+    public void testIncludeEmptyObjectInArray() throws Exception {
+        JsonParser p0 = JSON_F.createParser(aposToQuotes(
+                "{'array_with_empty_object':[{}],'array_with_filtered_object':[{'foo':5}]}"));
+        JsonParser p = new FilteringParserDelegate(p0,
+                INCLUDE_EMPTY,
+                Inclusion.INCLUDE_ALL_AND_PATH,
+                false // multipleMatches
+        );
+        assertEquals(
+                aposToQuotes("{'array_with_empty_object':[{}],'array_with_filtered_object':[{}]}"),
+                readAndWrite(JSON_F, p));
+    }
+
+    public void testIncludeEmptyArrayIfNotFilteredAfterFiltered() throws Exception {
+        JsonParser p0 = JSON_F.createParser(aposToQuotes(
+                "[5, {'empty_array':[],'filtered_array':[5]}]"));
+        JsonParser p = new FilteringParserDelegate(p0,
+                INCLUDE_EMPTY_IF_NOT_FILTERED,
+                Inclusion.INCLUDE_ALL_AND_PATH,
+                false // multipleMatches
+        );
+        assertEquals(aposToQuotes("[{'empty_array':[]}]"), readAndWrite(JSON_F, p));
     }
 }


### PR DESCRIPTION
This creates two new method on `TokenFilter` which you can override to
decide if empty arrays and objects should be included or excluded. An
override like this, for example, will include all arrays and objects
that were sent empty but strip any arrays or objects that were
*filtered* to be empty:
```
        @Override
        public boolean includeEmptyArray(boolean contentsFiltered) {
            return !contentsFiltered;
        }

        @Override
        public boolean includeEmptyObject(boolean contentsFiltered) {
            return !contentsFiltered;
        }
```

The default to preserve backwards compatibility is to always *exclude*
empty objects.

Closes #715