### PR TITLE
Add failing test for JSON roundtrip precision loss

### DIFF
--- a/src/test/java/com/fasterxml/jackson/core/json/JsonParserGeneratorTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/json/JsonParserGeneratorTest.java
@@ -1,0 +1,27 @@
+package com.fasterxml.jackson.core.json;
+
+import com.fasterxml.jackson.core.BaseTest;
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+
+import java.io.ByteArrayOutputStream;
+import java.io.StringWriter;
+
+public class JsonParserGeneratorTest
+    extends BaseTest {
+    final JsonFactory JSON_F = newStreamFactory();
+
+    public void testRoundtripBigDecimal() throws Exception {
+        String input = "1e999";
+        JsonParser parser = JSON_F.createParser(input);
+        parser.nextToken();
+        StringWriter stringWriter = new StringWriter();
+        JsonGenerator generator = JSON_F.createGenerator(stringWriter);
+        generator.copyCurrentEvent(parser);
+        parser.close();
+        generator.close();
+        String actual = stringWriter.toString(); // "Infinity"
+        assertEquals(input, actual);
+    }
+}


### PR DESCRIPTION
https://github.com/FasterXML/jackson-core/issues/730