### PR TITLE
Propose that JsonPointer be Serializable

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/JsonPointer.java
+++ b/src/main/java/com/fasterxml/jackson/core/JsonPointer.java
@@ -17,8 +17,9 @@ import com.fasterxml.jackson.core.io.NumberInput;
  *
  * @since 2.3
  */
-public class JsonPointer
+public class JsonPointer extends Serializable
 {
+    private static final long serialVersionUID = 1L; 
     /**
      * Character used to separate segments.
      *

--- a/src/main/java/com/fasterxml/jackson/core/JsonPointer.java
+++ b/src/main/java/com/fasterxml/jackson/core/JsonPointer.java
@@ -76,13 +76,12 @@ public class JsonPointer implements Serializable
     /* Construction
     /**********************************************************
      */
-    
+
     /**
      * Constructor used for creating "empty" instance, used to represent
-     * state that matches current node. Note that this constructor must be public for
-     * implementing {@link Externalizable}.
+     * state that matches current node.
      */
-    public JsonPointer() {
+    protected JsonPointer() {
         _nextSegment = null;
         _matchingPropertyName = "";
         _matchingElementIndex = -1;

--- a/src/test/java/com/fasterxml/jackson/core/TestJsonPointer.java
+++ b/src/test/java/com/fasterxml/jackson/core/TestJsonPointer.java
@@ -259,6 +259,7 @@ public class TestJsonPointer extends BaseTest
         final String INPUT = "/Image/15/name";
         JsonPointer original = JsonPointer.compile(INPUT);
         JsonPointer copy = unpickle(pickle(original), JsonPointer.class);
+        assertNotSame(copy, original);
         assertEquals(original, copy);
 
     }

--- a/src/test/java/com/fasterxml/jackson/core/TestJsonPointer.java
+++ b/src/test/java/com/fasterxml/jackson/core/TestJsonPointer.java
@@ -1,5 +1,12 @@
 package com.fasterxml.jackson.core;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+
 public class TestJsonPointer extends BaseTest
 {
     public void testSimplePath() throws Exception
@@ -227,5 +234,32 @@ public class TestJsonPointer extends BaseTest
         ptr = ptr.tail();
         assertTrue(ptr.matches());
         assertNull(ptr.tail());
+    }
+
+    private static <T extends Serializable> byte[] pickle(T obj)
+        throws IOException
+    {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        ObjectOutputStream oos = new ObjectOutputStream(baos);
+        oos.writeObject(obj);
+        oos.close();
+        return baos.toByteArray();
+    }
+
+    private static <T extends Serializable> T unpickle(byte[] b, Class<T> cl)
+        throws IOException, ClassNotFoundException
+    {
+        ByteArrayInputStream bais = new ByteArrayInputStream(b);
+        ObjectInputStream ois = new ObjectInputStream(bais);
+        Object o = ois.readObject();
+        return cl.cast(o);
+    }
+    public void testPointerSerialization() throws Exception {
+
+        final String INPUT = "/Image/15/name";
+        JsonPointer original = JsonPointer.compile(INPUT);
+        JsonPointer copy = unpickle(pickle(original), JsonPointer.class);
+        assertEquals(original, copy);
+
     }
 }


### PR DESCRIPTION
Noting that `Instances [of JsonPointer] are fully immutable and can be cached, shared between threads` it would be nice to be able to pass these between workers that require object serialization to pass instances around.