### PR TITLE
Support option to enable non-standard trailing decimal point

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/JsonParser.java
+++ b/src/main/java/com/fasterxml/jackson/core/JsonParser.java
@@ -189,6 +189,12 @@ public abstract class JsonParser
         ALLOW_LEADING_DECIMAL_POINT_FOR_NUMBERS(false),
 
         /**
+         * @deprecated Use {@link com.fasterxml.jackson.core.json.JsonReadFeature#ALLOW_TRAILING_DECIMAL_POINT_FOR_NUMBERS} instead
+         */
+        @Deprecated
+        ALLOW_TRAILING_DECIMAL_POINT_FOR_NUMBERS(false),
+
+        /**
          * Feature that allows parser to recognize set of
          * "Not-a-Number" (NaN) tokens as legal floating number
          * values (similar to how many other data formats and

--- a/src/main/java/com/fasterxml/jackson/core/json/JsonReadFeature.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/JsonReadFeature.java
@@ -113,13 +113,27 @@ public enum JsonReadFeature
      * (like: .123). If enabled, no exception is thrown, and the number
      * is parsed as though a leading 0 had been present.
      *<p>
-     * Since JSON specification does not allow leading decimal,
+     * Since JSON specification does not allow leading decimal points,
      * this is a non-standard feature, and as such disabled by default.
      *
      * @since 2.11
      */
     @SuppressWarnings("deprecation")
     ALLOW_LEADING_DECIMAL_POINT_FOR_NUMBERS(false, JsonParser.Feature.ALLOW_LEADING_DECIMAL_POINT_FOR_NUMBERS),
+
+    /**
+     * Feature that determines whether parser will allow
+     * JSON decimal numbers to end with a decimal point
+     * (like: 123.). If enabled, no exception is thrown, and the number
+     * is parsed as though the trailing decimal point had not been present.
+     *<p>
+     * Since JSON specification does not allow trailing decimal points,
+     * this is a non-standard feature, and as such disabled by default.
+     *
+     * @since 2.11
+     */
+    @SuppressWarnings("deprecation")
+    ALLOW_TRAILING_DECIMAL_POINT_FOR_NUMBERS(false, JsonParser.Feature.ALLOW_TRAILING_DECIMAL_POINT_FOR_NUMBERS),
 
     /**
      * Feature that allows parser to recognize set of

--- a/src/main/java/com/fasterxml/jackson/core/json/ReaderBasedJsonParser.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/ReaderBasedJsonParser.java
@@ -1408,7 +1408,9 @@ public class ReaderBasedJsonParser
             }
             // must be followed by sequence of ints, one minimum
             if (fractLen == 0) {
-                reportUnexpectedNumberChar(ch, "Decimal point not followed by a digit");
+                if (!isEnabled(Feature.ALLOW_TRAILING_DECIMAL_POINT_FOR_NUMBERS)) {
+                    reportUnexpectedNumberChar(ch, "Decimal point not followed by a digit");
+                }
             }
         }
         int expLen = 0;
@@ -1585,7 +1587,9 @@ public class ReaderBasedJsonParser
             }
             // must be followed by sequence of ints, one minimum
             if (fractLen == 0) {
-                reportUnexpectedNumberChar(c, "Decimal point not followed by a digit");
+                if (!isEnabled(Feature.ALLOW_TRAILING_DECIMAL_POINT_FOR_NUMBERS)) {
+                    reportUnexpectedNumberChar(c, "Decimal point not followed by a digit");
+                }
             }
         }
 

--- a/src/main/java/com/fasterxml/jackson/core/json/ReaderBasedJsonParser.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/ReaderBasedJsonParser.java
@@ -1408,7 +1408,7 @@ public class ReaderBasedJsonParser
             }
             // must be followed by sequence of ints, one minimum
             if (fractLen == 0) {
-                if (!isEnabled(Feature.ALLOW_TRAILING_DECIMAL_POINT_FOR_NUMBERS)) {
+                if (!isEnabled(JsonReadFeature.ALLOW_TRAILING_DECIMAL_POINT_FOR_NUMBERS.mappedFeature())) {
                     reportUnexpectedNumberChar(ch, "Decimal point not followed by a digit");
                 }
             }
@@ -1587,7 +1587,7 @@ public class ReaderBasedJsonParser
             }
             // must be followed by sequence of ints, one minimum
             if (fractLen == 0) {
-                if (!isEnabled(Feature.ALLOW_TRAILING_DECIMAL_POINT_FOR_NUMBERS)) {
+                if (!isEnabled(JsonReadFeature.ALLOW_TRAILING_DECIMAL_POINT_FOR_NUMBERS.mappedFeature())) {
                     reportUnexpectedNumberChar(c, "Decimal point not followed by a digit");
                 }
             }

--- a/src/main/java/com/fasterxml/jackson/core/json/UTF8DataInputJsonParser.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/UTF8DataInputJsonParser.java
@@ -1165,7 +1165,7 @@ public class UTF8DataInputJsonParser
             }
             // must be followed by sequence of ints, one minimum
             if (fractLen == 0) {
-                if (!isEnabled(Feature.ALLOW_TRAILING_DECIMAL_POINT_FOR_NUMBERS)) {
+                if (!isEnabled(JsonReadFeature.ALLOW_TRAILING_DECIMAL_POINT_FOR_NUMBERS.mappedFeature())) {
                     reportUnexpectedNumberChar(c, "Decimal point not followed by a digit");
                 }
             }

--- a/src/main/java/com/fasterxml/jackson/core/json/UTF8DataInputJsonParser.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/UTF8DataInputJsonParser.java
@@ -1165,7 +1165,9 @@ public class UTF8DataInputJsonParser
             }
             // must be followed by sequence of ints, one minimum
             if (fractLen == 0) {
-                reportUnexpectedNumberChar(c, "Decimal point not followed by a digit");
+                if (!isEnabled(Feature.ALLOW_TRAILING_DECIMAL_POINT_FOR_NUMBERS)) {
+                    reportUnexpectedNumberChar(c, "Decimal point not followed by a digit");
+                }
             }
         }
 

--- a/src/main/java/com/fasterxml/jackson/core/json/UTF8StreamJsonParser.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/UTF8StreamJsonParser.java
@@ -1638,7 +1638,9 @@ public class UTF8StreamJsonParser
             }
             // must be followed by sequence of ints, one minimum
             if (fractLen == 0) {
-                reportUnexpectedNumberChar(c, "Decimal point not followed by a digit");
+                if (!isEnabled(Feature.ALLOW_TRAILING_DECIMAL_POINT_FOR_NUMBERS)) {
+                    reportUnexpectedNumberChar(c, "Decimal point not followed by a digit");
+                }
             }
         }
 

--- a/src/main/java/com/fasterxml/jackson/core/json/UTF8StreamJsonParser.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/UTF8StreamJsonParser.java
@@ -1638,7 +1638,7 @@ public class UTF8StreamJsonParser
             }
             // must be followed by sequence of ints, one minimum
             if (fractLen == 0) {
-                if (!isEnabled(Feature.ALLOW_TRAILING_DECIMAL_POINT_FOR_NUMBERS)) {
+                if (!isEnabled(JsonReadFeature.ALLOW_TRAILING_DECIMAL_POINT_FOR_NUMBERS.mappedFeature())) {
                     reportUnexpectedNumberChar(c, "Decimal point not followed by a digit");
                 }
             }

--- a/src/main/java/com/fasterxml/jackson/core/json/async/NonBlockingJsonParser.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/async/NonBlockingJsonParser.java
@@ -1655,7 +1655,7 @@ public class NonBlockingJsonParser
                     ch &= 0xFF; // but here we'll want to mask it to unsigned 8-bit
                     // must be followed by sequence of ints, one minimum
                     if (fractLen == 0) {
-                        if (!isEnabled(Feature.ALLOW_TRAILING_DECIMAL_POINT_FOR_NUMBERS)) {
+                        if (!isEnabled(JsonReadFeature.ALLOW_TRAILING_DECIMAL_POINT_FOR_NUMBERS.mappedFeature())) {
                             reportUnexpectedNumberChar(ch, "Decimal point not followed by a digit");
                         }
                     }
@@ -1747,7 +1747,7 @@ public class NonBlockingJsonParser
         // Ok, fraction done; what have we got next?
         // must be followed by sequence of ints, one minimum
         if (fractLen == 0) {
-            if (!isEnabled(Feature.ALLOW_TRAILING_DECIMAL_POINT_FOR_NUMBERS)) {
+            if (!isEnabled(JsonReadFeature.ALLOW_TRAILING_DECIMAL_POINT_FOR_NUMBERS.mappedFeature())) {
                 reportUnexpectedNumberChar(ch, "Decimal point not followed by a digit");
             }
         }

--- a/src/main/java/com/fasterxml/jackson/core/json/async/NonBlockingJsonParser.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/async/NonBlockingJsonParser.java
@@ -1655,7 +1655,9 @@ public class NonBlockingJsonParser
                     ch &= 0xFF; // but here we'll want to mask it to unsigned 8-bit
                     // must be followed by sequence of ints, one minimum
                     if (fractLen == 0) {
-                        reportUnexpectedNumberChar(ch, "Decimal point not followed by a digit");
+                        if (!isEnabled(Feature.ALLOW_TRAILING_DECIMAL_POINT_FOR_NUMBERS)) {
+                            reportUnexpectedNumberChar(ch, "Decimal point not followed by a digit");
+                        }
                     }
                     break;
                 }
@@ -1745,7 +1747,9 @@ public class NonBlockingJsonParser
         // Ok, fraction done; what have we got next?
         // must be followed by sequence of ints, one minimum
         if (fractLen == 0) {
-            reportUnexpectedNumberChar(ch, "Decimal point not followed by a digit");
+            if (!isEnabled(Feature.ALLOW_TRAILING_DECIMAL_POINT_FOR_NUMBERS)) {
+                reportUnexpectedNumberChar(ch, "Decimal point not followed by a digit");
+            }
         }
         _fractLength = fractLen;
         _textBuffer.setCurrentLength(outPtr);

--- a/src/test/java/com/fasterxml/jackson/core/read/FastParserNonStandardNumberParsingTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/read/FastParserNonStandardNumberParsingTest.java
@@ -10,6 +10,7 @@ public class FastParserNonStandardNumberParsingTest
     private final JsonFactory fastFactory =
             JsonFactory.builder()
                     .enable(JsonReadFeature.ALLOW_LEADING_DECIMAL_POINT_FOR_NUMBERS)
+                    .enable(JsonReadFeature.ALLOW_TRAILING_DECIMAL_POINT_FOR_NUMBERS)
                     .enable(StreamReadFeature.USE_FAST_DOUBLE_PARSER)
                     .build();
 

--- a/src/test/java/com/fasterxml/jackson/core/read/NonStandardNumberParsingTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/read/NonStandardNumberParsingTest.java
@@ -8,6 +8,7 @@ public class NonStandardNumberParsingTest
 {
     private final JsonFactory JSON_F = JsonFactory.builder()
             .enable(JsonReadFeature.ALLOW_LEADING_DECIMAL_POINT_FOR_NUMBERS)
+            .enable(JsonReadFeature.ALLOW_TRAILING_DECIMAL_POINT_FOR_NUMBERS)
             .build();
 
     protected JsonFactory jsonFactory() {
@@ -30,6 +31,22 @@ public class NonStandardNumberParsingTest
         }
     }
 
+    /**
+     * The format "NNN." (as opposed to "NNN") is not valid JSON, so this should fail
+     */
+    public void testTrailingDotInDecimal() throws Exception {
+        for (int mode : ALL_MODES) {
+            JsonParser p = createParser(mode, " 123. ");
+            try {
+                p.nextToken();
+                fail("Should not pass");
+            } catch (JsonParseException e) {
+                verifyException(e, "Decimal point not followed by a digit");
+            }
+            p.close();
+        }
+    }
+
     public void testLeadingDotInDecimalAllowedAsync() throws Exception {
         _testLeadingDotInDecimalAllowed(jsonFactory(), MODE_DATA_INPUT);
     }
@@ -43,6 +60,19 @@ public class NonStandardNumberParsingTest
         _testLeadingDotInDecimalAllowed(jsonFactory(), MODE_READER);
     }
 
+    public void testTrailingDotInDecimalAllowedAsync() throws Exception {
+        _testTrailingDotInDecimalAllowed(jsonFactory(), MODE_DATA_INPUT);
+    }
+
+    public void testTrailingDotInDecimalAllowedBytes() throws Exception {
+        _testTrailingDotInDecimalAllowed(jsonFactory(), MODE_INPUT_STREAM);
+        _testTrailingDotInDecimalAllowed(jsonFactory(), MODE_INPUT_STREAM_THROTTLED);
+    }
+
+    public void testTrailingDotInDecimalAllowedReader() throws Exception {
+        _testTrailingDotInDecimalAllowed(jsonFactory(), MODE_READER);
+    }
+
     private void _testLeadingDotInDecimalAllowed(JsonFactory f, int mode) throws Exception
     {
         JsonParser p = createParser(f, mode, " .125 ");
@@ -50,6 +80,16 @@ public class NonStandardNumberParsingTest
         assertEquals(0.125, p.getValueAsDouble());
         assertEquals("0.125", p.getDecimalValue().toString());
         assertEquals(".125", p.getText());
+        p.close();
+    }
+
+    private void _testTrailingDotInDecimalAllowed(JsonFactory f, int mode) throws Exception
+    {
+        JsonParser p = createParser(f, mode, " 125. ");
+        assertEquals(JsonToken.VALUE_NUMBER_FLOAT, p.nextToken());
+        assertEquals(125.0, p.getValueAsDouble());
+        assertEquals("125", p.getDecimalValue().toString());
+        assertEquals("125.", p.getText());
         p.close();
     }
 }


### PR DESCRIPTION
One of the 'missing' features mentioned in #707