### PR TITLE
issue with parsing '-.125' when leading decimal points allowed

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/json/ReaderBasedJsonParser.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/ReaderBasedJsonParser.java
@@ -1328,11 +1328,17 @@ public class ReaderBasedJsonParser
     // @since 2.11, [core#611]
     protected final JsonToken _parseFloatThatStartsWithPeriod() throws IOException
     {
+        return _parseFloatThatStartsWithPeriod(false);
+    }
+
+    protected final JsonToken _parseFloatThatStartsWithPeriod(final boolean neg) throws IOException
+    {
         // [core#611]: allow optionally leading decimal point
         if (!isEnabled(JsonReadFeature.ALLOW_LEADING_DECIMAL_POINT_FOR_NUMBERS.mappedFeature())) {
             return _handleOddValue('.');
         }
-        return _parseFloat(INT_PERIOD, _inputPtr-1, _inputPtr, false, 0);
+        final int startPtr = neg ? _inputPtr-2 : _inputPtr;
+        return _parseFloat(INT_PERIOD, startPtr, _inputPtr, neg, 0);
     }
 
     /**
@@ -1491,7 +1497,7 @@ public class ReaderBasedJsonParser
         if (ch > INT_9 || ch < INT_0) {
             _inputPtr = ptr;
             if (ch == INT_PERIOD) {
-                return _parseFloatThatStartsWithPeriod();
+                return _parseFloatThatStartsWithPeriod(negative);
             }
             return _handleInvalidNumberStart(ch, negative, true);
         }

--- a/src/main/java/com/fasterxml/jackson/core/json/ReaderBasedJsonParser.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/ReaderBasedJsonParser.java
@@ -1337,8 +1337,7 @@ public class ReaderBasedJsonParser
         if (!isEnabled(JsonReadFeature.ALLOW_LEADING_DECIMAL_POINT_FOR_NUMBERS.mappedFeature())) {
             return _handleOddValue('.');
         }
-        final int startPtr = neg ? _inputPtr-2 : _inputPtr;
-        return _parseFloat(INT_PERIOD, startPtr, _inputPtr, neg, 0);
+        return _parseFloat(INT_PERIOD, _inputPtr-1, _inputPtr, neg, 0);
     }
 
     /**

--- a/src/main/java/com/fasterxml/jackson/core/json/UTF8DataInputJsonParser.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/UTF8DataInputJsonParser.java
@@ -1003,12 +1003,17 @@ public class UTF8DataInputJsonParser
     // @since 2.11, [core#611]
     protected final JsonToken _parseFloatThatStartsWithPeriod() throws IOException
     {
+        return _parseFloatThatStartsWithPeriod(false);
+    }
+
+    protected final JsonToken _parseFloatThatStartsWithPeriod(final boolean neg) throws IOException
+    {
         // [core#611]: allow optionally leading decimal point
         if (!isEnabled(JsonReadFeature.ALLOW_LEADING_DECIMAL_POINT_FOR_NUMBERS.mappedFeature())) {
             return _handleUnexpectedValue(INT_PERIOD);
         }
         char[] outBuf = _textBuffer.emptyAndGetCurrentSegment();
-        return _parseFloat(outBuf, 0, INT_PERIOD, false, 0);
+        return _parseFloat(outBuf, 0, INT_PERIOD, neg, 0);
     }
 
     /**
@@ -1107,7 +1112,7 @@ public class UTF8DataInputJsonParser
             if (c == INT_0) {
                 c = _handleLeadingZeroes();
             } else if (c == INT_PERIOD) {
-                return _parseFloatThatStartsWithPeriod();
+                return _parseFloatThatStartsWithPeriod(negative);
             } else {
                 return _handleInvalidNumberStart(c, negative, true);
             }

--- a/src/main/java/com/fasterxml/jackson/core/json/UTF8StreamJsonParser.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/UTF8StreamJsonParser.java
@@ -1433,12 +1433,17 @@ public class UTF8StreamJsonParser
     // @since 2.11, [core#611]
     protected final JsonToken _parseFloatThatStartsWithPeriod() throws IOException
     {
+        return _parseFloatThatStartsWithPeriod(false);
+    }
+
+    protected final JsonToken _parseFloatThatStartsWithPeriod(final boolean neg) throws IOException
+    {
         // [core#611]: allow optionally leading decimal point
         if (!isEnabled(JsonReadFeature.ALLOW_LEADING_DECIMAL_POINT_FOR_NUMBERS.mappedFeature())) {
             return _handleUnexpectedValue(INT_PERIOD);
         }
         return _parseFloat(_textBuffer.emptyAndGetCurrentSegment(),
-                0, INT_PERIOD, false, 0);
+                0, INT_PERIOD, neg, 0);
     }
 
     /**
@@ -1522,7 +1527,7 @@ public class UTF8StreamJsonParser
             // One special case: if first char is 0, must not be followed by a digit
             if (c != INT_0) {
                 if (c == INT_PERIOD) {
-                    return _parseFloatThatStartsWithPeriod();
+                    return _parseFloatThatStartsWithPeriod(negative);
                 }
                 return _handleInvalidNumberStart(c, negative, true);
             }

--- a/src/test/java/com/fasterxml/jackson/core/read/NonStandardNumberParsingTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/read/NonStandardNumberParsingTest.java
@@ -115,12 +115,6 @@ public class NonStandardNumberParsingTest
             assertEquals("0.125", p.getDecimalValue().toString());
             assertEquals(".125", p.getText());
         }
-        try (JsonParser p = createParser(f, mode, " -.125 ")) {
-            assertEquals(JsonToken.VALUE_NUMBER_FLOAT, p.nextToken());
-            assertEquals(-0.125, p.getValueAsDouble());
-            assertEquals("-0.125", p.getDecimalValue().toString());
-            assertEquals("-.125", p.getText());
-        }
     }
 
     private void _testLeadingPlusSignInDecimalAllowed(JsonFactory f, int mode) throws Exception

--- a/src/test/java/com/fasterxml/jackson/core/read/NonStandardNumberParsingTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/read/NonStandardNumberParsingTest.java
@@ -115,6 +115,12 @@ public class NonStandardNumberParsingTest
             assertEquals("0.125", p.getDecimalValue().toString());
             assertEquals(".125", p.getText());
         }
+        try (JsonParser p = createParser(f, mode, " -.125 ")) {
+            assertEquals(JsonToken.VALUE_NUMBER_FLOAT, p.nextToken());
+            assertEquals(-0.125, p.getValueAsDouble());
+            assertEquals("-0.125", p.getDecimalValue().toString());
+            assertEquals("-.125", p.getText());
+        }
     }
 
     private void _testLeadingPlusSignInDecimalAllowed(JsonFactory f, int mode) throws Exception

--- a/src/test/java/com/fasterxml/jackson/failing/FailingNonStandardNumberParsingTest.java
+++ b/src/test/java/com/fasterxml/jackson/failing/FailingNonStandardNumberParsingTest.java
@@ -1,0 +1,44 @@
+package com.fasterxml.jackson.failing;
+
+import com.fasterxml.jackson.core.BaseTest;
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.core.json.JsonReadFeature;
+
+public class FailingNonStandardNumberParsingTest
+    extends BaseTest
+{
+    private final JsonFactory JSON_F = JsonFactory.builder()
+            .enable(JsonReadFeature.ALLOW_LEADING_PLUS_SIGN_FOR_NUMBERS)
+            .enable(JsonReadFeature.ALLOW_LEADING_DECIMAL_POINT_FOR_NUMBERS)
+            .enable(JsonReadFeature.ALLOW_TRAILING_DECIMAL_POINT_FOR_NUMBERS)
+            .build();
+
+    protected JsonFactory jsonFactory() {
+        return JSON_F;
+    }
+
+    public void testLeadingDotInNegativeDecimalAllowedAsync() throws Exception {
+        _testLeadingDotInNegativeDecimalAllowed(jsonFactory(), MODE_DATA_INPUT);
+    }
+
+    public void testLeadingDotInNegativeDecimalAllowedBytes() throws Exception {
+        _testLeadingDotInNegativeDecimalAllowed(jsonFactory(), MODE_INPUT_STREAM);
+        _testLeadingDotInNegativeDecimalAllowed(jsonFactory(), MODE_INPUT_STREAM_THROTTLED);
+    }
+
+    public void testLeadingDotInNegativeDecimalAllowedReader() throws Exception {
+        _testLeadingDotInNegativeDecimalAllowed(jsonFactory(), MODE_READER);
+    }
+
+    private void _testLeadingDotInNegativeDecimalAllowed(JsonFactory f, int mode) throws Exception
+    {
+        try (JsonParser p = createParser(f, mode, " -.125 ")) {
+            assertEquals(JsonToken.VALUE_NUMBER_FLOAT, p.nextToken());
+            assertEquals(-0.125, p.getValueAsDouble());
+            assertEquals("-0.125", p.getDecimalValue().toString());
+            assertEquals("-.125", p.getText());
+        }
+    }
+}


### PR DESCRIPTION
It's easier to describe the issue with a broken test case. See NonStandardNumberParsingTest and the tests that call _testLeadingDotInDecimalAllowed - I've added an extra scenario for '-.125'.

All of the tests get back 0.125 instead of -0.125.

One issue is that _parseFloatThatStartsWithPeriod has hardcode when calling _parseFloat that says the result is non-negative. I have partially corrected that in this PR but the code still does not work. 

@cowtowncoder could you have a look and confirm that this is an issue before I spend more time trying to fix it?

Even after adjusting _parseFloatThatStartsWithPeriod to take a boolean param for the negative flag, the code is running into issues with the TextBuffer and the start pointer that _parseFloat sets on the TextBuffer (that essentially cause the TextBuffer to drop the sign). Messing around with the code for calculating the start pointer has so far caused more problems than it solves.