### PR TITLE
Use the default float/double parser as fallback

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/io/NumberInput.java
+++ b/src/main/java/com/fasterxml/jackson/core/io/NumberInput.java
@@ -345,7 +345,14 @@ public final class NumberInput
      * @since v2.14
      */
     public static double parseDouble(final String s, final boolean useFastParser) throws NumberFormatException {
-        return useFastParser ? FastDoubleParser.parseDouble(s) : Double.parseDouble(s);
+        if (useFastParser) {
+            try {
+                return FastDoubleParser.parseDouble(s);
+            } catch (NumberFormatException ignore) {
+                return Double.parseDouble(s);
+            }
+        }
+        return Double.parseDouble(s);
     }
 
     /**
@@ -367,7 +374,14 @@ public final class NumberInput
      * @since v2.14
      */
     public static float parseFloat(final String s, final boolean useFastParser) throws NumberFormatException {
-        return useFastParser ? FastFloatParser.parseFloat(s) : Float.parseFloat(s);
+        if (useFastParser) {
+            try {
+                return FastFloatParser.parseFloat(s);
+            } catch (NumberFormatException ignore) {
+                return Float.parseFloat(s);
+            }
+        }
+        return Float.parseFloat(s);
     }
 
     public static BigDecimal parseBigDecimal(String s) throws NumberFormatException {

--- a/src/test/java/com/fasterxml/jackson/core/io/TestNumberInput.java
+++ b/src/test/java/com/fasterxml/jackson/core/io/TestNumberInput.java
@@ -24,5 +24,14 @@ public class TestNumberInput
         assertEquals("1.4E-45", Float.toString(NumberInput.parseFloat(exampleFloat2)));
         assertEquals("1.4E-45", Float.toString(NumberInput.parseFloat(exampleFloat2, true)));
     }
+
+    public void testNastyAcceptedDoubleValues() {
+        final String[] nastyAcceptedDoubleValues = new String[]{"1.1e-23f", "0x.003p12f", "0x1.17742db862a4P-1d"};
+
+        for (String nastyAcceptedDouble : nastyAcceptedDoubleValues) {
+            assertEquals(Double.parseDouble(nastyAcceptedDouble), NumberInput.parseDouble(nastyAcceptedDouble));
+            assertEquals(Double.parseDouble(nastyAcceptedDouble), NumberInput.parseDouble(nastyAcceptedDouble, true));
+        }
+    }
 }
 


### PR DESCRIPTION
The FastDoubleParser introduced via https://github.com/FasterXML/jackson-core/pull/747 and https://github.com/FasterXML/jackson-core/pull/766 will fail on parsing certain esoteric OpenJDK Double/Float supported inputs.

This PR tries to remedy this by introducing a try/catch around the FastDoubleParser and then using the Java default Double/Float parsers as a fall-back. 

Relates to #778 and https://github.com/wrandelshofer/FastDoubleParser/issues/19