### PR TITLE
Negative number issue (2.13 branch - tests only)

### DIFF
--- a/src/test/java/com/fasterxml/jackson/core/read/NumberParsingTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/read/NumberParsingTest.java
@@ -177,6 +177,7 @@ public class NumberParsingTest
     public void testIntParsingWithStrings() throws Exception
     {
         assertEquals(3, NumberInput.parseInt("3"));
+        assertEquals(3, NumberInput.parseInt("+3"));
         assertEquals(0, NumberInput.parseInt("0"));
         assertEquals(-3, NumberInput.parseInt("-3"));
         assertEquals(27, NumberInput.parseInt("27"));
@@ -187,6 +188,24 @@ public class NumberParsingTest
         assertEquals(-9999, NumberInput.parseInt("-9999"));
         assertEquals(Integer.MIN_VALUE, NumberInput.parseInt(""+Integer.MIN_VALUE));
         assertEquals(Integer.MAX_VALUE, NumberInput.parseInt(""+Integer.MAX_VALUE));
+    }
+
+    public void testLongParsingWithStrings() throws Exception
+    {
+        assertEquals(3, NumberInput.parseLong("3"));
+        assertEquals(3, NumberInput.parseLong("+3"));
+        assertEquals(0, NumberInput.parseLong("0"));
+        assertEquals(-3, NumberInput.parseLong("-3"));
+        assertEquals(27, NumberInput.parseLong("27"));
+        assertEquals(-31, NumberInput.parseLong("-31"));
+        assertEquals(271, NumberInput.parseLong("271"));
+        assertEquals(-131, NumberInput.parseLong("-131"));
+        assertEquals(2709, NumberInput.parseLong("2709"));
+        assertEquals(-9999, NumberInput.parseLong("-9999"));
+        assertEquals(Long.MIN_VALUE, NumberInput.parseLong(""+Long.MIN_VALUE));
+        assertEquals(Integer.MIN_VALUE-1, NumberInput.parseLong(""+(Integer.MIN_VALUE-1)));
+        assertEquals(Long.MAX_VALUE, NumberInput.parseLong(""+Long.MAX_VALUE));
+        assertEquals(Integer.MAX_VALUE+1, NumberInput.parseLong(""+(Integer.MAX_VALUE+1)));
     }
 
     /*

--- a/src/test/java/com/fasterxml/jackson/failing/FailingNonStandardNumberParsingTest.java
+++ b/src/test/java/com/fasterxml/jackson/failing/FailingNonStandardNumberParsingTest.java
@@ -10,9 +10,7 @@ public class FailingNonStandardNumberParsingTest
     extends BaseTest
 {
     private final JsonFactory JSON_F = JsonFactory.builder()
-            .enable(JsonReadFeature.ALLOW_LEADING_PLUS_SIGN_FOR_NUMBERS)
             .enable(JsonReadFeature.ALLOW_LEADING_DECIMAL_POINT_FOR_NUMBERS)
-            .enable(JsonReadFeature.ALLOW_TRAILING_DECIMAL_POINT_FOR_NUMBERS)
             .build();
 
     protected JsonFactory jsonFactory() {
@@ -34,11 +32,14 @@ public class FailingNonStandardNumberParsingTest
 
     private void _testLeadingDotInNegativeDecimalAllowed(JsonFactory f, int mode) throws Exception
     {
-        try (JsonParser p = createParser(f, mode, " -.125 ")) {
+        JsonParser p = createParser(f, mode, " -.125 ");
+        try {
             assertEquals(JsonToken.VALUE_NUMBER_FLOAT, p.nextToken());
             assertEquals(-0.125, p.getValueAsDouble());
             assertEquals("-0.125", p.getDecimalValue().toString());
             assertEquals("-.125", p.getText());
+        } finally {
+            p.close();
         }
     }
 }

--- a/src/test/java/com/fasterxml/jackson/failing/FailingNonStandardNumberParsingTest.java
+++ b/src/test/java/com/fasterxml/jackson/failing/FailingNonStandardNumberParsingTest.java
@@ -1,0 +1,44 @@
+package com.fasterxml.jackson.failing;
+
+import com.fasterxml.jackson.core.BaseTest;
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.core.json.JsonReadFeature;
+
+public class FailingNonStandardNumberParsingTest
+    extends BaseTest
+{
+    private final JsonFactory JSON_F = JsonFactory.builder()
+            .enable(JsonReadFeature.ALLOW_LEADING_PLUS_SIGN_FOR_NUMBERS)
+            .enable(JsonReadFeature.ALLOW_LEADING_DECIMAL_POINT_FOR_NUMBERS)
+            .enable(JsonReadFeature.ALLOW_TRAILING_DECIMAL_POINT_FOR_NUMBERS)
+            .build();
+
+    protected JsonFactory jsonFactory() {
+        return JSON_F;
+    }
+
+    public void testLeadingDotInNegativeDecimalAllowedAsync() throws Exception {
+        _testLeadingDotInNegativeDecimalAllowed(jsonFactory(), MODE_DATA_INPUT);
+    }
+
+    public void testLeadingDotInNegativeDecimalAllowedBytes() throws Exception {
+        _testLeadingDotInNegativeDecimalAllowed(jsonFactory(), MODE_INPUT_STREAM);
+        _testLeadingDotInNegativeDecimalAllowed(jsonFactory(), MODE_INPUT_STREAM_THROTTLED);
+    }
+
+    public void testLeadingDotInNegativeDecimalAllowedReader() throws Exception {
+        _testLeadingDotInNegativeDecimalAllowed(jsonFactory(), MODE_READER);
+    }
+
+    private void _testLeadingDotInNegativeDecimalAllowed(JsonFactory f, int mode) throws Exception
+    {
+        try (JsonParser p = createParser(f, mode, " -.125 ")) {
+            assertEquals(JsonToken.VALUE_NUMBER_FLOAT, p.nextToken());
+            assertEquals(-0.125, p.getValueAsDouble());
+            assertEquals("-0.125", p.getDecimalValue().toString());
+            assertEquals("-.125", p.getText());
+        }
+    }
+}


### PR DESCRIPTION
Relates to #777 - these tests also fail in 2.13 branch but with a different issue.

```
com.fasterxml.jackson.core.JsonParseException: Unexpected character ('.' (code 46)) in numeric value: expected digit (0-9) to follow minus sign, for valid numeric value
 at [Source: (StringReader); line: 1, column: 4]

	at com.fasterxml.jackson.core.JsonParser._constructError(JsonParser.java:2391)
	at com.fasterxml.jackson.core.base.ParserMinimalBase._reportError(ParserMinimalBase.java:735)
	at com.fasterxml.jackson.core.base.ParserMinimalBase.reportUnexpectedNumberChar(ParserMinimalBase.java:557)
	at com.fasterxml.jackson.core.json.ReaderBasedJsonParser._handleInvalidNumberStart(ReaderBasedJsonParser.java:1718)
	at com.fasterxml.jackson.core.json.ReaderBasedJsonParser._parseNegNumber(ReaderBasedJsonParser.java:1467)
	at com.fasterxml.jackson.core.json.ReaderBasedJsonParser.nextToken(ReaderBasedJsonParser.java:784)
	at com.fasterxml.jackson.failing.FailingNonStandardNumberParsingTest._testLeadingDotInNegativeDecimalAllowed(FailingNonStandardNumberParsingTest.java:37)
	at com.fasterxml.jackson.failing.FailingNonStandardNumberParsingTest.testLeadingDotInNegativeDecimalAllowedReader(FailingNonStandardNumberParsingTest.java:30)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at junit.framework.TestCase.runTest(TestCase.java:177)
	at junit.framework.TestCase.runBare(TestCase.java:142)
	at junit.framework.TestResult$1.protect(TestResult.java:122)
	at junit.framework.TestResult.runProtected(TestResult.java:142)
	at junit.framework.TestResult.run(TestResult.java:125)
	at junit.framework.TestCase.run(TestCase.java:130)
	at junit.framework.TestSuite.runTest(TestSuite.java:241)
	at junit.framework.TestSuite.run(TestSuite.java:236)
```

