### PR TITLE
Add test to show hexadecimal not supported - but fix issue in UTF8DataInputJsonParser

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/json/UTF8DataInputJsonParser.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/UTF8DataInputJsonParser.java
@@ -1051,11 +1051,13 @@ public class UTF8DataInputJsonParser
         int outPtr;
         
         // One special case: if first char is 0, must not be followed by a digit.
-        // Gets bit tricky as we only want to retain 0 if it's the full value
+        // Gets a bit tricky as we only want to retain 0 if it's the full value
         if (c == INT_0) {
             c = _handleLeadingZeroes();
             if (c <= INT_9 && c >= INT_0) { // skip if followed by digit
                 outPtr = 0;
+            } else if (c == 'x') {
+                return _handleInvalidNumberStart('x', false);
             } else {
                 outBuf[0] = '0';
                 outPtr = 1;

--- a/src/main/java/com/fasterxml/jackson/core/json/UTF8DataInputJsonParser.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/UTF8DataInputJsonParser.java
@@ -1056,8 +1056,8 @@ public class UTF8DataInputJsonParser
             c = _handleLeadingZeroes();
             if (c <= INT_9 && c >= INT_0) { // skip if followed by digit
                 outPtr = 0;
-            } else if (c == 'x') {
-                return _handleInvalidNumberStart('x', false);
+            } else if (c == 'x' || c == 'X') {
+                return _handleInvalidNumberStart(c, false);
             } else {
                 outBuf[0] = '0';
                 outPtr = 1;

--- a/src/test/java/com/fasterxml/jackson/core/read/NonStandardNumberParsingTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/read/NonStandardNumberParsingTest.java
@@ -56,6 +56,30 @@ public class NonStandardNumberParsingTest
         }
     }
 
+    //JSON does not allow numbers to have f or d suffixes
+    public void testFloatMarker() throws Exception {
+        for (int mode : ALL_MODES) {
+            try (JsonParser p = createParser(mode, " -0.123f ")) {
+                p.nextToken();
+                fail("Should not pass");
+            } catch (JsonParseException e) {
+                verifyException(e, "Unexpected character ('f'");
+            }
+        }
+    }
+
+    //JSON does not allow numbers to have f or d suffixes
+    public void testDoubleMarker() throws Exception {
+        for (int mode : ALL_MODES) {
+            try (JsonParser p = createParser(mode, " -0.123d ")) {
+                p.nextToken();
+                fail("Should not pass");
+            } catch (JsonParseException e) {
+                verifyException(e, "Unexpected character ('d'");
+            }
+        }
+    }
+
     /**
      * The format ".NNN" (as opposed to "0.NNN") is not valid JSON, so this should fail
      */

--- a/src/test/java/com/fasterxml/jackson/core/read/NonStandardNumberParsingTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/read/NonStandardNumberParsingTest.java
@@ -45,6 +45,17 @@ public class NonStandardNumberParsingTest
         }
     }
 
+    public void testNegativeHexadecimal() throws Exception {
+        for (int mode : ALL_MODES) {
+            try (JsonParser p = createParser(mode, " -0xc0ffee ")) {
+                p.nextToken();
+                fail("Should not pass");
+            } catch (JsonParseException e) {
+                verifyException(e, "Unexpected character ('x'");
+            }
+        }
+    }
+
     /**
      * The format ".NNN" (as opposed to "0.NNN") is not valid JSON, so this should fail
      */

--- a/src/test/java/com/fasterxml/jackson/core/read/NonStandardNumberParsingTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/read/NonStandardNumberParsingTest.java
@@ -21,18 +21,30 @@ public class NonStandardNumberParsingTest
     }
 
     /**
+     * The format "0xC0FFEE" is not valid JSON, so this should fail
+     */
+    public void testHexadecimal() throws Exception {
+        for (int mode : ALL_MODES) {
+            try (JsonParser p = createParser(mode, " 0xC0FFEE ")) {
+                p.nextToken();
+                fail("Should not pass");
+            } catch (JsonParseException e) {
+                verifyException(e, "Unexpected character ('x'");
+            }
+        }
+    }
+
+    /**
      * The format ".NNN" (as opposed to "0.NNN") is not valid JSON, so this should fail
      */
     public void testLeadingDotInDecimal() throws Exception {
         for (int mode : ALL_MODES) {
-            JsonParser p = createParser(mode, " .123 ");
-            try {
+            try (JsonParser p = createParser(mode, " .123 ")) {
                 p.nextToken();
                 fail("Should not pass");
             } catch (JsonParseException e) {
                 verifyException(e, "Unexpected character ('.'");
             }
-            p.close();
         }
     }
 

--- a/src/test/java/com/fasterxml/jackson/core/read/NonStandardNumberParsingTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/read/NonStandardNumberParsingTest.java
@@ -21,11 +21,22 @@ public class NonStandardNumberParsingTest
     }
 
     /**
-     * The format "0xC0FFEE" is not valid JSON, so this should fail
+     * The format "0xc0ffee" is not valid JSON, so this should fail
      */
     public void testHexadecimal() throws Exception {
         for (int mode : ALL_MODES) {
-            try (JsonParser p = createParser(mode, " 0xC0FFEE ")) {
+            try (JsonParser p = createParser(mode, " 0xc0ffee ")) {
+                p.nextToken();
+                fail("Should not pass");
+            } catch (JsonParseException e) {
+                verifyException(e, "Unexpected character ('x'");
+            }
+        }
+    }
+
+    public void testHexadecimalBigX() throws Exception {
+        for (int mode : ALL_MODES) {
+            try (JsonParser p = createParser(mode, " 0XC0FFEE ")) {
                 p.nextToken();
                 fail("Should not pass");
             } catch (JsonParseException e) {


### PR DESCRIPTION
UTF8DataInputJsonParser did not behave like the other json parsers - added a change to make it give the same result as the others