### PR TITLE
Async pos sign

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/io/NumberInput.java
+++ b/src/main/java/com/fasterxml/jackson/core/io/NumberInput.java
@@ -40,6 +40,11 @@ public final class NumberInput
      */
     public static int parseInt(char[] ch, int off, int len)
     {
+        if (len > 0 && ch[off] == '+') {
+            off++;
+            len--;
+        }
+
         int num = ch[off + len - 1] - '0';
         
         switch(len) {

--- a/src/main/java/com/fasterxml/jackson/core/json/async/NonBlockingJsonParser.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/async/NonBlockingJsonParser.java
@@ -1744,12 +1744,12 @@ public class NonBlockingJsonParser
                     _fractLength = fractLen;
                     return JsonToken.NOT_AVAILABLE;
                 }
+                ch = _inputBuffer[_inputPtr++];
             } else if (ch == 'f' || ch == 'd' || ch == 'F' || ch == 'D') {
                 reportUnexpectedNumberChar(ch, "JSON does not support parsing numbers that have trailing 'f' or 'd' markers");
             } else {
                 loop = false;
             }
-            ch = _inputBuffer[_inputPtr++];
         }
         
         // Ok, fraction done; what have we got next?

--- a/src/main/java/com/fasterxml/jackson/core/json/async/NonBlockingJsonParser.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/async/NonBlockingJsonParser.java
@@ -1581,7 +1581,7 @@ public class NonBlockingJsonParser
             reportUnexpectedNumberChar(ch, "expected digit (0-9) for valid numeric value");
         } else if (ch > INT_9) {
             if (ch == 'I') {
-                return _finishNonStdToken(NON_STD_TOKEN_MINUS_INFINITY, 2);
+                return _finishNonStdToken(NON_STD_TOKEN_PLUS_INFINITY, 2);
             }
             reportUnexpectedNumberChar(ch, "expected digit (0-9) for valid numeric value");
         }

--- a/src/main/java/com/fasterxml/jackson/core/json/async/NonBlockingJsonParser.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/async/NonBlockingJsonParser.java
@@ -1746,7 +1746,9 @@ public class NonBlockingJsonParser
                 }
                 ch = _inputBuffer[_inputPtr++];
             } else if (ch == 'f' || ch == 'd' || ch == 'F' || ch == 'D') {
-                reportUnexpectedNumberChar(ch, "JSON does not support parsing numbers that have trailing 'f' or 'd' markers");
+                reportUnexpectedNumberChar(ch, "JSON does not support parsing numbers that have 'f' or 'd' suffixes");
+            } else if (ch == INT_PERIOD) {
+                reportUnexpectedNumberChar(ch, "Cannot parse number with more than one decimal point");
             } else {
                 loop = false;
             }

--- a/src/main/java/com/fasterxml/jackson/core/json/async/NonBlockingJsonParser.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/async/NonBlockingJsonParser.java
@@ -1576,6 +1576,9 @@ public class NonBlockingJsonParser
     {
         if (ch <= INT_0) {
             if (ch == INT_0) {
+                if (!isEnabled(JsonReadFeature.ALLOW_LEADING_PLUS_SIGN_FOR_NUMBERS.mappedFeature())) {
+                    reportUnexpectedNumberChar('+', "JSON spec does not allow numbers to have plus signs: enable `JsonReadFeature.ALLOW_LEADING_PLUS_SIGN_FOR_NUMBERS` to allow");
+                }
                 return _finishNumberLeadingPosZeroes();
             }
             reportUnexpectedNumberChar(ch, "expected digit (0-9) for valid numeric value");
@@ -1651,9 +1654,6 @@ public class NonBlockingJsonParser
     }
 
     protected JsonToken _finishNumberLeadingPosZeroes() throws IOException {
-        if (!isEnabled(JsonReadFeature.ALLOW_LEADING_PLUS_SIGN_FOR_NUMBERS.mappedFeature())) {
-            reportUnexpectedNumberChar('+', "JSON spec does not allow numbers to have plus signs: enable `JsonReadFeature.ALLOW_LEADING_PLUS_SIGN_FOR_NUMBERS` to allow");
-        }
         return _finishNumberLeadingPosNegZeroes(false);
     }
 

--- a/src/main/java/com/fasterxml/jackson/core/json/async/NonBlockingJsonParser.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/async/NonBlockingJsonParser.java
@@ -729,7 +729,7 @@ public class NonBlockingJsonParser
         case '#':
             return _finishHashComment(MINOR_VALUE_WS_AFTER_COMMA);
         case '+':
-            return _startNegativeNumber();
+            return _startPositiveNumber();
         case '-':
             return _startNegativeNumber();
         case '/':

--- a/src/main/java/com/fasterxml/jackson/core/json/async/NonBlockingJsonParser.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/async/NonBlockingJsonParser.java
@@ -1440,6 +1440,9 @@ public class NonBlockingJsonParser
         _numberNegative = false;
         if (_inputPtr >= _inputEnd) {
             _minorState = MINOR_NUMBER_PLUS;
+            if (!isEnabled(JsonReadFeature.ALLOW_LEADING_PLUS_SIGN_FOR_NUMBERS.mappedFeature())) {
+                reportUnexpectedNumberChar('+', "JSON spec does not allow numbers to have plus signs: enable `JsonReadFeature.ALLOW_LEADING_PLUS_SIGN_FOR_NUMBERS` to allow");
+            }
             return (_currToken = JsonToken.NOT_AVAILABLE);
         }
         int ch = _inputBuffer[_inputPtr++] & 0xFF;

--- a/src/main/java/com/fasterxml/jackson/core/json/async/NonBlockingJsonParser.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/async/NonBlockingJsonParser.java
@@ -1573,7 +1573,7 @@ public class NonBlockingJsonParser
     {
         if (ch <= INT_0) {
             if (ch == INT_0) {
-                return _finishNumberLeadingNegZeroes();
+                return _finishNumberLeadingPosZeroes();
             }
             reportUnexpectedNumberChar(ch, "expected digit (0-9) for valid numeric value");
         } else if (ch > INT_9) {

--- a/src/main/java/com/fasterxml/jackson/core/json/async/NonBlockingJsonParser.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/async/NonBlockingJsonParser.java
@@ -1437,9 +1437,6 @@ public class NonBlockingJsonParser
 
     protected JsonToken _startPositiveNumber() throws IOException
     {
-        if (!isEnabled(JsonReadFeature.ALLOW_LEADING_PLUS_SIGN_FOR_NUMBERS.mappedFeature())) {
-            reportUnexpectedNumberChar('+', "JSON spec does not allow numbers to have plus signs: enable `JsonReadFeature.ALLOW_LEADING_PLUS_SIGN_FOR_NUMBERS` to allow");
-        }
         _numberNegative = false;
         if (_inputPtr >= _inputEnd) {
             _minorState = MINOR_NUMBER_PLUS;
@@ -1448,15 +1445,21 @@ public class NonBlockingJsonParser
         int ch = _inputBuffer[_inputPtr++] & 0xFF;
         if (ch <= INT_0) {
             if (ch == INT_0) {
+                if (!isEnabled(JsonReadFeature.ALLOW_LEADING_PLUS_SIGN_FOR_NUMBERS.mappedFeature())) {
+                    reportUnexpectedNumberChar('+', "JSON spec does not allow numbers to have plus signs: enable `JsonReadFeature.ALLOW_LEADING_PLUS_SIGN_FOR_NUMBERS` to allow");
+                }
                 return _finishNumberLeadingPosZeroes();
             }
             // One special case: if first char is 0, must not be followed by a digit
             reportUnexpectedNumberChar(ch, "expected digit (0-9) to follow plus sign, for valid numeric value");
         } else if (ch > INT_9) {
             if (ch == 'I') {
-                return _finishNonStdToken(NON_STD_TOKEN_MINUS_INFINITY, 2);
+                return _finishNonStdToken(NON_STD_TOKEN_PLUS_INFINITY, 2);
             }
             reportUnexpectedNumberChar(ch, "expected digit (0-9) to follow plus sign, for valid numeric value");
+        }
+        if (!isEnabled(JsonReadFeature.ALLOW_LEADING_PLUS_SIGN_FOR_NUMBERS.mappedFeature())) {
+            reportUnexpectedNumberChar('+', "JSON spec does not allow numbers to have plus signs: enable `JsonReadFeature.ALLOW_LEADING_PLUS_SIGN_FOR_NUMBERS` to allow");
         }
         char[] outBuf = _textBuffer.emptyAndGetCurrentSegment();
         outBuf[0] = '+';

--- a/src/main/java/com/fasterxml/jackson/core/json/async/NonBlockingJsonParser.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/async/NonBlockingJsonParser.java
@@ -1440,9 +1440,6 @@ public class NonBlockingJsonParser
         _numberNegative = false;
         if (_inputPtr >= _inputEnd) {
             _minorState = MINOR_NUMBER_PLUS;
-            if (!isEnabled(JsonReadFeature.ALLOW_LEADING_PLUS_SIGN_FOR_NUMBERS.mappedFeature())) {
-                reportUnexpectedNumberChar('+', "JSON spec does not allow numbers to have plus signs: enable `JsonReadFeature.ALLOW_LEADING_PLUS_SIGN_FOR_NUMBERS` to allow");
-            }
             return (_currToken = JsonToken.NOT_AVAILABLE);
         }
         int ch = _inputBuffer[_inputPtr++] & 0xFF;
@@ -1588,6 +1585,9 @@ public class NonBlockingJsonParser
             }
             reportUnexpectedNumberChar(ch, "expected digit (0-9) for valid numeric value");
         }
+        if (!isEnabled(JsonReadFeature.ALLOW_LEADING_PLUS_SIGN_FOR_NUMBERS.mappedFeature())) {
+            reportUnexpectedNumberChar('+', "JSON spec does not allow numbers to have plus signs: enable `JsonReadFeature.ALLOW_LEADING_PLUS_SIGN_FOR_NUMBERS` to allow");
+        }
         char[] outBuf = _textBuffer.emptyAndGetCurrentSegment();
         outBuf[0] = '+';
         outBuf[1] = (char) ch;
@@ -1702,6 +1702,9 @@ public class NonBlockingJsonParser
 
     protected JsonToken _finishNumberLeadingPosZeroes() throws IOException
     {
+        if (!isEnabled(JsonReadFeature.ALLOW_LEADING_PLUS_SIGN_FOR_NUMBERS.mappedFeature())) {
+            reportUnexpectedNumberChar('+', "JSON spec does not allow numbers to have plus signs: enable `JsonReadFeature.ALLOW_LEADING_PLUS_SIGN_FOR_NUMBERS` to allow");
+        }
         // In general, skip further zeroes (if allowed), look for legal follow-up
         // numeric characters; likely legal separators, or, known illegal (letters).
         while (true) {

--- a/src/main/java/com/fasterxml/jackson/core/json/async/NonBlockingJsonParserBase.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/async/NonBlockingJsonParserBase.java
@@ -99,6 +99,8 @@ public abstract class NonBlockingJsonParserBase
 
     protected final static int MINOR_VALUE_TOKEN_NON_STD = 19;
 
+    protected final static int MINOR_NUMBER_PLUS = 230;
+
     protected final static int MINOR_NUMBER_MINUS = 23;
     protected final static int MINOR_NUMBER_ZERO = 24; // zero as first, possibly trimming multiple
     protected final static int MINOR_NUMBER_MINUSZERO = 25; // "-0" (and possibly more zeroes) receive

--- a/src/main/java/com/fasterxml/jackson/core/json/async/NonBlockingJsonParserBase.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/async/NonBlockingJsonParserBase.java
@@ -99,7 +99,7 @@ public abstract class NonBlockingJsonParserBase
 
     protected final static int MINOR_VALUE_TOKEN_NON_STD = 19;
 
-    protected final static int MINOR_NUMBER_PLUS = 230;
+    protected final static int MINOR_NUMBER_PLUS = 22;
 
     protected final static int MINOR_NUMBER_MINUS = 23;
     protected final static int MINOR_NUMBER_ZERO = 24; // zero as first, possibly trimming multiple

--- a/src/test/java/com/fasterxml/jackson/core/json/async/AsyncNonStandardNumberParsingTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/json/async/AsyncNonStandardNumberParsingTest.java
@@ -96,6 +96,22 @@ public class AsyncNonStandardNumberParsingTest extends AsyncTestBase
         }
     }
 
+    public void test2DecimalPoints() throws Exception {
+        final String JSON = "[ -0.123.456 ]";
+
+        // without enabling, should get an exception
+        AsyncReaderWrapper p = createParser(DEFAULT_F, JSON, 1);
+        assertToken(JsonToken.START_ARRAY, p.nextToken());
+        try {
+            p.nextToken();
+            fail("Expected exception");
+        } catch (Exception e) {
+            verifyException(e, "Unexpected character ('.'");
+        } finally {
+            p.close();
+        }
+    }
+
     /**
      * The format ".NNN" (as opposed to "0.NNN") is not valid JSON, so this should fail
      */

--- a/src/test/java/com/fasterxml/jackson/core/json/async/AsyncNonStandardNumberParsingTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/json/async/AsyncNonStandardNumberParsingTest.java
@@ -3,6 +3,7 @@ package com.fasterxml.jackson.core.json.async;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.core.async.AsyncTestBase;
+import com.fasterxml.jackson.core.exc.StreamReadException;
 import com.fasterxml.jackson.core.json.JsonReadFeature;
 import com.fasterxml.jackson.core.testsupport.AsyncReaderWrapper;
 
@@ -22,7 +23,7 @@ public class AsyncNonStandardNumberParsingTest extends AsyncTestBase
         try {
             p.nextToken();
             fail("Expected exception");
-        } catch (Exception e) {
+        } catch (StreamReadException e) {
             verifyException(e, "Unexpected character ('x'");
         } finally {
             p.close();
@@ -39,7 +40,7 @@ public class AsyncNonStandardNumberParsingTest extends AsyncTestBase
         try {
             p.nextToken();
             fail("Expected exception");
-        } catch (Exception e) {
+        } catch (StreamReadException e) {
             verifyException(e, "Unexpected character ('X'");
         } finally {
             p.close();
@@ -56,7 +57,7 @@ public class AsyncNonStandardNumberParsingTest extends AsyncTestBase
         try {
             p.nextToken();
             fail("Expected exception");
-        } catch (Exception e) {
+        } catch (StreamReadException e) {
             verifyException(e, "Unexpected character ('x'");
         } finally {
             p.close();
@@ -73,7 +74,7 @@ public class AsyncNonStandardNumberParsingTest extends AsyncTestBase
         try {
             p.nextToken();
             fail("Expected exception");
-        } catch (Exception e) {
+        } catch (StreamReadException e) {
             verifyException(e, "Unexpected character ('f'");
         } finally {
             p.close();
@@ -90,7 +91,7 @@ public class AsyncNonStandardNumberParsingTest extends AsyncTestBase
         try {
             p.nextToken();
             fail("Expected exception");
-        } catch (Exception e) {
+        } catch (StreamReadException e) {
             verifyException(e, "Unexpected character ('d'");
         } finally {
             p.close();
@@ -106,7 +107,7 @@ public class AsyncNonStandardNumberParsingTest extends AsyncTestBase
         try {
             p.nextToken();
             fail("Expected exception");
-        } catch (Exception e) {
+        } catch (StreamReadException e) {
             verifyException(e, "Unexpected character ('.'");
         } finally {
             p.close();
@@ -125,7 +126,7 @@ public class AsyncNonStandardNumberParsingTest extends AsyncTestBase
         try {
             p.nextToken();
             fail("Expected exception");
-        } catch (Exception e) {
+        } catch (StreamReadException e) {
             verifyException(e, "Unexpected character ('.'");
         } finally {
             p.close();
@@ -144,7 +145,7 @@ public class AsyncNonStandardNumberParsingTest extends AsyncTestBase
         try {
             p.nextToken();
             fail("Expected exception");
-        } catch (Exception e) {
+        } catch (StreamReadException e) {
             verifyException(e, "Unexpected character ('+'");
         } finally {
             p.close();
@@ -160,7 +161,7 @@ public class AsyncNonStandardNumberParsingTest extends AsyncTestBase
         try {
             p.nextToken();
             fail("Expected exception");
-        } catch (Exception e) {
+        } catch (StreamReadException e) {
             verifyException(e, "Unexpected character ('+'");
         } finally {
             p.close();
@@ -213,7 +214,7 @@ public class AsyncNonStandardNumberParsingTest extends AsyncTestBase
         try {
             p.nextToken();
             fail("Expected exception");
-        } catch (Exception e) {
+        } catch (StreamReadException e) {
             //the message does not match non-async parsers
             verifyException(e, "Unexpected character (' '");
         } finally {

--- a/src/test/java/com/fasterxml/jackson/core/json/async/AsyncNonStandardNumberParsingTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/json/async/AsyncNonStandardNumberParsingTest.java
@@ -195,7 +195,7 @@ public class AsyncNonStandardNumberParsingTest extends AsyncTestBase
             assertEquals(JsonToken.VALUE_NUMBER_FLOAT, p.nextToken());
             assertEquals(0.123, p.getDoubleValue());
             assertEquals("0.123", p.getDecimalValue().toString());
-            assertEquals("+0.123", p.currentText());
+            assertEquals("0.123", p.currentText());
         } finally {
             p.close();
         }

--- a/src/test/java/com/fasterxml/jackson/core/json/async/AsyncNonStandardNumberParsingTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/json/async/AsyncNonStandardNumberParsingTest.java
@@ -3,6 +3,7 @@ package com.fasterxml.jackson.core.json.async;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.core.async.AsyncTestBase;
+import com.fasterxml.jackson.core.json.JsonReadFeature;
 import com.fasterxml.jackson.core.testsupport.AsyncReaderWrapper;
 
 import java.io.IOException;
@@ -144,8 +145,57 @@ public class AsyncNonStandardNumberParsingTest extends AsyncTestBase
             p.nextToken();
             fail("Expected exception");
         } catch (Exception e) {
-            //the message does not match non-async parsers
-            verifyException(e, "Unrecognized token '+123'");
+            verifyException(e, "Unexpected character ('+'");
+        } finally {
+            p.close();
+        }
+    }
+
+    public void testLeadingPlusSignInDecimalDefaultFail2() throws Exception {
+        final String JSON = "[ +0.123 ]";
+
+        // without enabling, should get an exception
+        AsyncReaderWrapper p = createParser(DEFAULT_F, JSON, 1);
+        assertToken(JsonToken.START_ARRAY, p.nextToken());
+        try {
+            p.nextToken();
+            fail("Expected exception");
+        } catch (Exception e) {
+            verifyException(e, "Unexpected character ('+'");
+        } finally {
+            p.close();
+        }
+    }
+
+    public void testLeadingPlusSignInDecimalEnabled() throws Exception {
+        final String JSON = "[ +123 ]";
+
+        JsonFactory jsonFactory =
+                JsonFactory.builder().enable(JsonReadFeature.ALLOW_LEADING_PLUS_SIGN_FOR_NUMBERS).build();
+        AsyncReaderWrapper p = createParser(jsonFactory, JSON, 1);
+        assertToken(JsonToken.START_ARRAY, p.nextToken());
+        try {
+            assertEquals(JsonToken.VALUE_NUMBER_INT, p.nextToken());
+            assertEquals(123.0, p.getDoubleValue());
+            assertEquals("123", p.getDecimalValue().toString());
+            assertEquals("+123", p.currentText());
+        } finally {
+            p.close();
+        }
+    }
+
+    public void testLeadingPlusSignInDecimalEnabled2() throws Exception {
+        final String JSON = "[ +0.123 ]";
+
+        JsonFactory jsonFactory =
+                JsonFactory.builder().enable(JsonReadFeature.ALLOW_LEADING_PLUS_SIGN_FOR_NUMBERS).build();
+        AsyncReaderWrapper p = createParser(jsonFactory, JSON, 1);
+        assertToken(JsonToken.START_ARRAY, p.nextToken());
+        try {
+            assertEquals(JsonToken.VALUE_NUMBER_FLOAT, p.nextToken());
+            assertEquals(0.123, p.getDoubleValue());
+            assertEquals("0.123", p.getDecimalValue().toString());
+            assertEquals("+0.123", p.currentText());
         } finally {
             p.close();
         }

--- a/src/test/java/com/fasterxml/jackson/core/json/async/AsyncNonStandardNumberParsingTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/json/async/AsyncNonStandardNumberParsingTest.java
@@ -62,8 +62,6 @@ public class AsyncNonStandardNumberParsingTest extends AsyncTestBase
         }
     }
 
-    //next 2 tests do not work as expected
-    /*
     public void testFloatMarker() throws Exception
     {
         final String JSON = "[ -0.123f ]";
@@ -97,7 +95,6 @@ public class AsyncNonStandardNumberParsingTest extends AsyncTestBase
             p.close();
         }
     }
-    */
 
     /**
      * The format ".NNN" (as opposed to "0.NNN") is not valid JSON, so this should fail
@@ -152,7 +149,7 @@ public class AsyncNonStandardNumberParsingTest extends AsyncTestBase
             fail("Expected exception");
         } catch (Exception e) {
             //the message does not match non-async parsers
-            verifyException(e, "Unexpected character (' '");
+            verifyException(e, "Unexpected character ((CTRL-CHAR, code 0))");
         } finally {
             p.close();
         }

--- a/src/test/java/com/fasterxml/jackson/core/json/async/AsyncNonStandardNumberParsingTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/json/async/AsyncNonStandardNumberParsingTest.java
@@ -149,7 +149,7 @@ public class AsyncNonStandardNumberParsingTest extends AsyncTestBase
             fail("Expected exception");
         } catch (Exception e) {
             //the message does not match non-async parsers
-            verifyException(e, "Unexpected character ((CTRL-CHAR, code 0))");
+            verifyException(e, "Unexpected character (' '");
         } finally {
             p.close();
         }

--- a/src/test/java/com/fasterxml/jackson/core/json/async/AsyncNonStandardNumberParsingTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/json/async/AsyncNonStandardNumberParsingTest.java
@@ -99,6 +99,65 @@ public class AsyncNonStandardNumberParsingTest extends AsyncTestBase
     }
     */
 
+    /**
+     * The format ".NNN" (as opposed to "0.NNN") is not valid JSON, so this should fail
+     */
+    public void testLeadingDotInDecimal() throws Exception {
+        final String JSON = "[ .123 ]";
+
+        // without enabling, should get an exception
+        AsyncReaderWrapper p = createParser(DEFAULT_F, JSON, 1);
+        assertToken(JsonToken.START_ARRAY, p.nextToken());
+        try {
+            p.nextToken();
+            fail("Expected exception");
+        } catch (Exception e) {
+            verifyException(e, "Unexpected character ('.'");
+        } finally {
+            p.close();
+        }
+    }
+
+    /*
+     * The format "+NNN" (as opposed to "NNN") is not valid JSON, so this should fail
+     */
+    public void testLeadingPlusSignInDecimalDefaultFail() throws Exception {
+        final String JSON = "[ +123 ]";
+
+        // without enabling, should get an exception
+        AsyncReaderWrapper p = createParser(DEFAULT_F, JSON, 1);
+        assertToken(JsonToken.START_ARRAY, p.nextToken());
+        try {
+            p.nextToken();
+            fail("Expected exception");
+        } catch (Exception e) {
+            //the message does not match non-async parsers
+            verifyException(e, "Unrecognized token '+123'");
+        } finally {
+            p.close();
+        }
+    }
+
+    /**
+     * The format "NNN." (as opposed to "NNN") is not valid JSON, so this should fail
+     */
+    public void testTrailingDotInDecimal() throws Exception {
+        final String JSON = "[ 123. ]";
+
+        // without enabling, should get an exception
+        AsyncReaderWrapper p = createParser(DEFAULT_F, JSON, 1);
+        assertToken(JsonToken.START_ARRAY, p.nextToken());
+        try {
+            p.nextToken();
+            fail("Expected exception");
+        } catch (Exception e) {
+            //the message does not match non-async parsers
+            verifyException(e, "Unexpected character (' '");
+        } finally {
+            p.close();
+        }
+    }
+
     private AsyncReaderWrapper createParser(JsonFactory f, String doc, int readBytes) throws IOException
     {
         return asyncForBytes(f, readBytes, _jsonDoc(doc), 1);

--- a/src/test/java/com/fasterxml/jackson/core/read/NonStandardNumberParsingTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/read/NonStandardNumberParsingTest.java
@@ -80,6 +80,17 @@ public class NonStandardNumberParsingTest
         }
     }
 
+    public void test2DecimalPoints() throws Exception {
+        for (int mode : ALL_MODES) {
+            try (JsonParser p = createParser(mode, " -0.123.456 ")) {
+                p.nextToken();
+                fail("Should not pass");
+            } catch (JsonParseException e) {
+                verifyException(e, "Unexpected character ('.'");
+            }
+        }
+    }
+
     /**
      * The format ".NNN" (as opposed to "0.NNN") is not valid JSON, so this should fail
      */


### PR DESCRIPTION
The feature for allowing leading plus signs in numbers does not work with async JSON parser. This is my attempt at a fix. 