### PR TITLE
removed unused param on _parseFloatThatStartsWithPeriod

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/json/ReaderBasedJsonParser.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/ReaderBasedJsonParser.java
@@ -787,7 +787,7 @@ public class ReaderBasedJsonParser
             }
             break;
         case '.': // [core#61]]
-            t = _parseFloatThatStartsWithPeriod(false, false);
+            t = _parseFloatThatStartsWithPeriod(false);
             break;
         case '0':
         case '1':
@@ -990,7 +990,7 @@ public class ReaderBasedJsonParser
             }
             break;
         case '.': // [core#61]]
-            t = _parseFloatThatStartsWithPeriod(false, false);
+            t = _parseFloatThatStartsWithPeriod(false);
             break;
         case '0':
         case '1':
@@ -1069,7 +1069,7 @@ public class ReaderBasedJsonParser
             }
             return;
         case '.': // [core#61]]
-            _nextToken = _parseFloatThatStartsWithPeriod(false, false);
+            _nextToken = _parseFloatThatStartsWithPeriod(false);
             return;
         case '0':
         case '1':
@@ -1114,7 +1114,7 @@ public class ReaderBasedJsonParser
             }
             break;
         case '.': // [core#61]
-            t = _parseFloatThatStartsWithPeriod(false, false);
+            t = _parseFloatThatStartsWithPeriod(false);
             break;
         case '0':
         case '1':
@@ -1183,7 +1183,7 @@ public class ReaderBasedJsonParser
              * and could be indicated by a more specific error message.
              */
         case '.': // [core#61]]
-            return (_currToken = _parseFloatThatStartsWithPeriod(false, false));
+            return (_currToken = _parseFloatThatStartsWithPeriod(false));
         case '0':
         case '1':
         case '2':
@@ -1327,11 +1327,10 @@ public class ReaderBasedJsonParser
 
     @Deprecated // since 2.14
     protected final JsonToken _parseFloatThatStartsWithPeriod() throws IOException {
-        return _parseFloatThatStartsWithPeriod(false, false);
+        return _parseFloatThatStartsWithPeriod(false);
     }
 
-    protected final JsonToken _parseFloatThatStartsWithPeriod(final boolean neg,
-            final boolean hasSign)
+    protected final JsonToken _parseFloatThatStartsWithPeriod(final boolean neg)
         throws IOException
     {
         // [core#611]: allow optionally leading decimal point
@@ -1509,7 +1508,7 @@ public class ReaderBasedJsonParser
         if (ch > INT_9 || ch < INT_0) {
             _inputPtr = ptr;
             if (ch == INT_PERIOD) {
-                return _parseFloatThatStartsWithPeriod(negative, true);
+                return _parseFloatThatStartsWithPeriod(negative);
             }
             return _handleInvalidNumberStart(ch, negative, true);
         }


### PR DESCRIPTION
This version of the _parseFloatThatStartsWithPeriod method on ReaderBasedJsonParser was only introduced in 2.14 branch recently. Seems safe to remove the unused param from the method signature.