### PR TITLE
Add minimal OSGi metadata as per #768

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,6 @@
        still use Moditect to get JDK9+ module info support; need newer bundle plugin as well
        (can just defaults from `jackson-parent`)
       -->
-
     <osgi.export>com.fasterxml.jackson.core;version=${project.version},
 com.fasterxml.jackson.core.*;version=${project.version}
     </osgi.export>
@@ -46,6 +45,9 @@ com.fasterxml.jackson.core.*;version=${project.version}
     <!-- Generate PackageVersion.java into this directory. -->
     <packageVersion.dir>com/fasterxml/jackson/core/json</packageVersion.dir>
     <packageVersion.package>${project.groupId}.json</packageVersion.package>
+
+      <!-- Bnd annotations for generating extra OSGi metadata. -->
+      <version.bnd.annotation>6.3.1</version.bnd.annotation>
   </properties>
 
   <!-- Alas, need to include snapshot reference since otherwise can not find
@@ -142,6 +144,16 @@ com.fasterxml.jackson.core.*;version=${project.version}
   </build>
 
   <dependencies>
+    <!--  31-Jul-2022, tatu: [core#768] OSGi metadata -->
+    <dependency>
+      <groupId>biz.aQute.bnd</groupId>
+      <artifactId>biz.aQute.bnd.annotation</artifactId>
+      <version>${version.bnd.annotation}</version>
+      <optional>true</optional>
+      <scope>provided</scope>
+    </dependency>
+
+    <!--  plus test dependencies -->
     <dependency>
       <groupId>org.junit.vintage</groupId>
       <artifactId>junit-vintage-engine</artifactId>

--- a/src/main/java/com/fasterxml/jackson/core/JsonFactory.java
+++ b/src/main/java/com/fasterxml/jackson/core/JsonFactory.java
@@ -8,6 +8,8 @@ import java.io.*;
 import java.lang.ref.SoftReference;
 import java.net.URL;
 
+import aQute.bnd.annotation.spi.ServiceProvider;
+
 import com.fasterxml.jackson.core.format.InputAccessor;
 import com.fasterxml.jackson.core.format.MatchStrength;
 import com.fasterxml.jackson.core.io.*;
@@ -42,6 +44,7 @@ import com.fasterxml.jackson.core.util.JacksonFeature;
  * @author Tatu Saloranta
  */
 @SuppressWarnings("resource")
+@ServiceProvider(JsonFactory.class) // will be `TokenStreamFactory` in 3.x
 public class JsonFactory
     extends TokenStreamFactory
     implements Versioned,


### PR DESCRIPTION
So, as per #768 we may want to add minimal OSGi metadata here, and eventually across all format backends plus probably `jackson-databind`. But starting with basics.

Also note that if this works, 3.0 (`master`) uses bit different bindings (`TokenStreamFactory` that `JsonFactory` implements) -- but for 2.x we'll stick to `JsonFactory` as being the base class every format backend implements.
