### PR TITLE
get ParserMinimalBase constructor to call super to initiate its super class

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/base/ParserMinimalBase.java
+++ b/src/main/java/com/fasterxml/jackson/core/base/ParserMinimalBase.java
@@ -156,7 +156,7 @@ public abstract class ParserMinimalBase extends JsonParser
     /**********************************************************
      */
 
-    protected ParserMinimalBase() { }
+    protected ParserMinimalBase() { super(); }
     protected ParserMinimalBase(int features) { super(features); }
 
     // NOTE: had base impl in 2.3 and before; but shouldn't


### PR DESCRIPTION
seems more correct because the other ParserMinimalBase constructor calls super(...)