### PR TITLE
fuzzing: run fuzzers in CI

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -1,0 +1,26 @@
+name: CIFuzz
+on: [pull_request]
+jobs:
+  Fuzzing:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Build Fuzzers
+      id: build
+      uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
+      with:
+        oss-fuzz-project-name: 'jackson-core'
+        dry-run: false
+        language: jvm
+    - name: Run Fuzzers
+      uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
+      with:
+        oss-fuzz-project-name: 'jackson-core'
+        fuzz-seconds: 1200
+        dry-run: false
+        language: jvm
+    - name: Upload Crash
+      uses: actions/upload-artifact@v1
+      if: failure() && steps.build.outcome == 'success'
+      with:
+        name: artifacts
+        path: ./out/artifacts


### PR DESCRIPTION
This sets up CiFuzz for Jackson-core which will run the fuzzers in the CI for 20 minutes when a pull request is made. The ammount of time can be modified if need be.

Signed-off-by: AdamKorcz <adam@adalogics.com>