### PR TITLE
improve performance with parsing bigints with lots of digits

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/io/BigDecimalParser.java
+++ b/src/main/java/com/fasterxml/jackson/core/io/BigDecimalParser.java
@@ -37,7 +37,7 @@ public final class BigDecimalParser
             return parseBigDecimal(chars, off, len, len / 10);
 
         // 20-Aug-2022, tatu: Although "new BigDecimal(...)" only throws NumberFormatException
-        //    operatons by "parseBigDecimal()" can throw "ArithmeticException", so handle both:
+        //    operations by "parseBigDecimal()" can throw "ArithmeticException", so handle both:
         } catch (ArithmeticException | NumberFormatException e) {
             String desc = e.getMessage();
             // 05-Feb-2021, tatu: Alas, JDK mostly has null message so:

--- a/src/main/java/com/fasterxml/jackson/core/io/NumberInput.java
+++ b/src/main/java/com/fasterxml/jackson/core/io/NumberInput.java
@@ -8,6 +8,10 @@ import java.math.BigInteger;
 
 public final class NumberInput
 {
+    // numbers with more than these characters are better parsed with BigDecimalParser
+    // parsing numbers with many digits in Java is slower than O(n)
+    private final static int LARGE_INT_SIZE = 1500;
+
     /**
      * Formerly used constant for a value that was problematic on certain
      * pre-1.8 JDKs.
@@ -395,6 +399,9 @@ public final class NumberInput
      * @since v2.14
      */
     public static BigInteger parseBigInteger(String s) throws NumberFormatException {
+        if (s.length() > LARGE_INT_SIZE) {
+            return BigDecimalParser.parse(s).toBigInteger();
+        }
         return new BigInteger(s);
     }
 }

--- a/src/main/java/com/fasterxml/jackson/core/io/NumberInput.java
+++ b/src/main/java/com/fasterxml/jackson/core/io/NumberInput.java
@@ -10,7 +10,7 @@ public final class NumberInput
 {
     // numbers with more than these characters are better parsed with BigDecimalParser
     // parsing numbers with many digits in Java is slower than O(n)
-    private final static int LARGE_INT_SIZE = 1500;
+    private final static int LARGE_INT_SIZE = 1250;
 
     /**
      * Formerly used constant for a value that was problematic on certain

--- a/src/test/java/com/fasterxml/jackson/core/io/TestNumberInput.java
+++ b/src/test/java/com/fasterxml/jackson/core/io/TestNumberInput.java
@@ -1,5 +1,7 @@
 package com.fasterxml.jackson.core.io;
 
+import java.math.BigInteger;
+
 public class TestNumberInput
     extends com.fasterxml.jackson.core.BaseTest
 {
@@ -23,6 +25,21 @@ public class TestNumberInput
         final String exampleFloat2 = "7.006492321624086e-46";
         assertEquals("1.4E-45", Float.toString(NumberInput.parseFloat(exampleFloat2)));
         assertEquals("1.4E-45", Float.toString(NumberInput.parseFloat(exampleFloat2, true)));
+    }
+
+    public void testParseLongBigInteger()
+    {
+        StringBuilder stringBuilder = new StringBuilder();
+        for (int i = 0; i < 1000; i++) {
+            stringBuilder.append(7);
+        }
+        String test1000 = stringBuilder.toString();
+        assertEquals(new BigInteger(test1000), NumberInput.parseBigInteger(test1000));
+        for (int i = 0; i < 1000; i++) {
+            stringBuilder.append(7);
+        }
+        String test2000 = stringBuilder.toString();
+        assertEquals(new BigInteger(test2000), NumberInput.parseBigInteger(test2000));
     }
 }
 


### PR DESCRIPTION
Parsing numbers in Java has poor performance characteristics. Parse time increases exponentially as the number of digits increases.
Using BigDecimalParser to parse BigIntegers has better performance when there are a lot of digits. It is slower for more usual numbers. From benchmarking, BigDecimalParser is more performant when you have approx 1250 digits and as you head to 10k, 100k digits, it is much faster. BigDecimalParser is not O(n) but it is better than `new BigInteger(string)`. 

Relates to #814
