### PR TITLE
Add SLSA provenance to release workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,20 +2,20 @@ name: Build and Deploy Snapshot
 on:
   push:
     branches:
-      - master
-      - "3.0"
-      - "2.14"
+    - master
+    - "3.0"
+    - "2.14"
     paths-ignore:
-      - "README.md"
-      - "release-notes/*"
+    - "README.md"
+    - "release-notes/*"
   pull_request:
     branches:
-      - master
-      - "3.0"
-      - "2.14"
+    - master
+    - "3.0"
+    - "2.14"
     paths-ignore:
-      - "README.md"
-      - "release-notes/*"
+    - "README.md"
+    - "release-notes/*"
 permissions:
   contents: read
 
@@ -35,65 +35,65 @@ jobs:
       artifact_name: ${{ steps.hash.outputs.artifact_name }}
       project_version: ${{ steps.projectVersion.outputs.version }}
     steps:
-      - uses: actions/checkout@v3
-      - name: Set up JDK
-        uses: actions/setup-java@v3
-        with:
-          distribution: "temurin"
-          java-version: ${{ matrix.java_version }}
-          cache: "maven"
-          server-id: sonatype-nexus-snapshots
-          server-username: CI_DEPLOY_USERNAME
-          server-password: CI_DEPLOY_PASSWORD
-          # See https://github.com/actions/setup-java/blob/v2/docs/advanced-usage.md#Publishing-using-Apache-Maven
-          # gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }} # Value of the GPG private key to import
-          # gpg-passphrase: MAVEN_GPG_PASSPHRASE # env variable for GPG private key passphrase
-      - name: Build
-        run: ./mvnw -B -q -ff -ntp verify
-      - name: Extract project Maven version
-        id: projectVersion
-        run: echo "version=$(./mvnw org.apache.maven.plugins:maven-help-plugin:3.3.0:evaluate -DforceStdout -Dexpression=project.version -q)" >>$GITHUB_OUTPUT
-      - name: Verify Android SDK Compatibility
-        if: matrix.java_version == '8'
-        run: ./mvnw -B -q -ff -ntp -DskipTests animal-sniffer:check
-      - name: Deploy snapshot
-        if: github.event_name != 'pull_request' && matrix.java_version == '8' && endsWith(steps.projectVersion.outputs.version, '-SNAPSHOT')
-        env:
-          CI_DEPLOY_USERNAME: ${{ secrets.CI_DEPLOY_USERNAME }}
-          CI_DEPLOY_PASSWORD: ${{ secrets.CI_DEPLOY_PASSWORD }}
-          # MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
-        run: ./mvnw -B -q -ff -DskipTests -ntp source:jar deploy
-      # Until generator_generic_slsa3@v1.2.3, calculate hashes from ./target
-      # https://github.com/slsa-framework/slsa-github-generator/issues/1225
-      - name: Generate hash
-        id: hash
-        if: |
-          github.event_name != 'pull_request' &&
-          matrix.java_version == '8' &&
-          endsWith(steps.projectVersion.outputs.version, '-SNAPSHOT')
-        run: |
-          ARTIFACT_NAME="$( \
-            ./mvnw help:evaluate \
-              -Dexpression=project.artifactId -q -DforceStdout)-$( \
-            ./mvnw help:evaluate \
-              -Dexpression=project.version -q -DforceStdout)"
-          echo "artifact_name=$ARTIFACT_NAME" >> "$GITHUB_OUTPUT"
+    - uses: actions/checkout@v3
+    - name: Set up JDK
+      uses: actions/setup-java@v3
+      with:
+        distribution: "temurin"
+        java-version: ${{ matrix.java_version }}
+        cache: "maven"
+        server-id: sonatype-nexus-snapshots
+        server-username: CI_DEPLOY_USERNAME
+        server-password: CI_DEPLOY_PASSWORD
+        # See https://github.com/actions/setup-java/blob/v2/docs/advanced-usage.md#Publishing-using-Apache-Maven
+        # gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }} # Value of the GPG private key to import
+        # gpg-passphrase: MAVEN_GPG_PASSPHRASE # env variable for GPG private key passphrase
+    - name: Build
+      run: ./mvnw -B -q -ff -ntp verify
+    - name: Extract project Maven version
+      id: projectVersion
+      run: echo "version=$(./mvnw org.apache.maven.plugins:maven-help-plugin:3.3.0:evaluate -DforceStdout -Dexpression=project.version -q)" >>$GITHUB_OUTPUT
+    - name: Verify Android SDK Compatibility
+      if: matrix.java_version == '8'
+      run: ./mvnw -B -q -ff -ntp -DskipTests animal-sniffer:check
+    - name: Deploy snapshot
+      if: github.event_name != 'pull_request' && matrix.java_version == '8' && endsWith(steps.projectVersion.outputs.version, '-SNAPSHOT')
+      env:
+        CI_DEPLOY_USERNAME: ${{ secrets.CI_DEPLOY_USERNAME }}
+        CI_DEPLOY_PASSWORD: ${{ secrets.CI_DEPLOY_PASSWORD }}
+        # MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
+      run: ./mvnw -B -q -ff -DskipTests -ntp source:jar deploy
+    # Until generator_generic_slsa3@v1.2.3, calculate hashes from ./target
+    # https://github.com/slsa-framework/slsa-github-generator/issues/1225
+    - name: Generate hash
+      id: hash
+      if: |
+        github.event_name != 'pull_request' &&
+        matrix.java_version == '8' &&
+        endsWith(steps.projectVersion.outputs.version, '-SNAPSHOT')
+      run: |
+        ARTIFACT_NAME="$( \
+          ./mvnw help:evaluate \
+            -Dexpression=project.artifactId -q -DforceStdout)-$( \
+          ./mvnw help:evaluate \
+            -Dexpression=project.version -q -DforceStdout)"
+        echo "artifact_name=$ARTIFACT_NAME" >> "$GITHUB_OUTPUT"
 
-          cd ./target
-          echo "hashes=$( \
-            sha256sum $ARTIFACT_NAME*.jar | \
-            base64 -w0 \
-          )" >> "$GITHUB_OUTPUT"
-      - name: Generate code coverage
-        if: github.event_name != 'pull_request' && matrix.java_version == '8'
-        run: ./mvnw -B -q -ff -ntp test
-      - name: Publish code coverage
-        if: github.event_name != 'pull_request' && matrix.java_version == '8'
-        uses: codecov/codecov-action@v3
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          file: ./target/site/jacoco/jacoco.xml
-          flags: unittests
+        cd ./target
+        echo "hashes=$( \
+          sha256sum $ARTIFACT_NAME*.jar | \
+          base64 -w0 \
+        )" >> "$GITHUB_OUTPUT"
+    - name: Generate code coverage
+      if: github.event_name != 'pull_request' && matrix.java_version == '8'
+      run: ./mvnw -B -q -ff -ntp test
+    - name: Publish code coverage
+      if: github.event_name != 'pull_request' && matrix.java_version == '8'
+      uses: codecov/codecov-action@v3
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        file: ./target/site/jacoco/jacoco.xml
+        flags: unittests
 
   provenance:
     needs: [build]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,7 +72,7 @@ jobs:
             ./mvnw help:evaluate \
               -Dexpression=project.artifactId -q -DforceStdout)-$( \
             ./mvnw help:evaluate \
-              -Dexpression=project.version -q -DforceStdout)*.jar"
+              -Dexpression=project.version -q -DforceStdout)"
           echo "artifact_name=$ARTIFACT_NAME" >> "$GITHUB_OUTPUT"
 
           cd ./target
@@ -80,6 +80,12 @@ jobs:
             sha256sum $ARTIFACT_NAME*.jar | \
             base64 -w0 \
           )" >> "$GITHUB_OUTPUT"
+      - name: Upload package
+        uses: actions/upload-artifact@v3
+        with:
+          path: ./target/*.jar
+          name: package
+          if-no-files-found: warn
       - name: Generate code coverage
         if: github.event_name != 'pull_request' && matrix.java_version == '8'
         run: ./mvnw -B -q -ff -ntp test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,6 +33,7 @@ jobs:
     outputs:
       hashes: ${{ steps.hash.outputs.hashes }}
       artifact_name: ${{ steps.hash.outputs.artifact_name }}
+      project_version: ${{ steps.projectVersion.outputs.version }}
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK
@@ -66,7 +67,10 @@ jobs:
       # https://github.com/slsa-framework/slsa-github-generator/issues/1225
       - name: Generate hash
         id: hash
-        if: github.event_name != 'pull_request' && matrix.java_version == '8'
+        if: |
+          github.event_name != 'pull_request' &&
+          matrix.java_version == '8' &&
+          endsWith(steps.projectVersion.outputs.version, '-SNAPSHOT')
         run: |
           ARTIFACT_NAME="$( \
             ./mvnw help:evaluate \
@@ -97,6 +101,9 @@ jobs:
       actions: read # To read the workflow path.
       id-token: write # To sign the provenance.
       contents: write # To add assets to a release.
+    if: |
+      github.event_name != 'pull_request' &&
+      endsWith(needs.build.outputs.project_version, '-SNAPSHOT')
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.2.2
     with:
       base64-subjects: "${{ needs.build.outputs.hashes }}"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,20 +2,20 @@ name: Build and Deploy Snapshot
 on:
   push:
     branches:
-    - master
-    - "3.0"
-    - "2.14"
+      - master
+      - "3.0"
+      - "2.14"
     paths-ignore:
-    - "README.md"
-    - "release-notes/*"
+      - "README.md"
+      - "release-notes/*"
   pull_request:
     branches:
-    - master
-    - "3.0"
-    - "2.14"
+      - master
+      - "3.0"
+      - "2.14"
     paths-ignore:
-    - "README.md"
-    - "release-notes/*"
+      - "README.md"
+      - "release-notes/*"
 permissions:
   contents: read
 
@@ -26,46 +26,46 @@ jobs:
       fail-fast: false
       matrix:
         # As of Jackson 2.14 got Java 8 baseline so can build on later JDKs too
-        java_version: ['8', '11', '17']
-        os: ['ubuntu-20.04']
+        java_version: ["8", "11", "17"]
+        os: ["ubuntu-20.04"]
     env:
       JAVA_OPTS: "-XX:+TieredCompilation -XX:TieredStopAtLevel=1"
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up JDK
-      uses: actions/setup-java@v3
-      with:
-        distribution: 'temurin'
-        java-version: ${{ matrix.java_version }}
-        cache: 'maven'
-        server-id: sonatype-nexus-snapshots
-        server-username: CI_DEPLOY_USERNAME
-        server-password: CI_DEPLOY_PASSWORD
-        # See https://github.com/actions/setup-java/blob/v2/docs/advanced-usage.md#Publishing-using-Apache-Maven
-        # gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }} # Value of the GPG private key to import
-        # gpg-passphrase: MAVEN_GPG_PASSPHRASE # env variable for GPG private key passphrase
-    - name: Build
-      run: ./mvnw -B -q -ff -ntp verify
-    - name: Extract project Maven version
-      id: projectVersion
-      run: echo "version=$(./mvnw org.apache.maven.plugins:maven-help-plugin:3.3.0:evaluate -DforceStdout -Dexpression=project.version -q)" >>$GITHUB_OUTPUT
-    - name: Verify Android SDK Compatibility
-      if: matrix.java_version == '8'
-      run: ./mvnw -B -q -ff -ntp -DskipTests animal-sniffer:check
-    - name: Deploy snapshot
-      if: github.event_name != 'pull_request' && matrix.java_version == '8' && endsWith(steps.projectVersion.outputs.version, '-SNAPSHOT')
-      env:
-        CI_DEPLOY_USERNAME: ${{ secrets.CI_DEPLOY_USERNAME }}
-        CI_DEPLOY_PASSWORD: ${{ secrets.CI_DEPLOY_PASSWORD }}
-        # MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
-      run: ./mvnw -B -q -ff -DskipTests -ntp source:jar deploy
-    - name: Generate code coverage
-      if: github.event_name != 'pull_request' && matrix.java_version == '8'
-      run: ./mvnw -B -q -ff -ntp test
-    - name: Publish code coverage
-      if: github.event_name != 'pull_request' && matrix.java_version == '8'
-      uses: codecov/codecov-action@v3
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-        file: ./target/site/jacoco/jacoco.xml
-        flags: unittests
+      - uses: actions/checkout@v3
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: "temurin"
+          java-version: ${{ matrix.java_version }}
+          cache: "maven"
+          server-id: sonatype-nexus-snapshots
+          server-username: CI_DEPLOY_USERNAME
+          server-password: CI_DEPLOY_PASSWORD
+          # See https://github.com/actions/setup-java/blob/v2/docs/advanced-usage.md#Publishing-using-Apache-Maven
+          # gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }} # Value of the GPG private key to import
+          # gpg-passphrase: MAVEN_GPG_PASSPHRASE # env variable for GPG private key passphrase
+      - name: Build
+        run: ./mvnw -B -q -ff -ntp verify
+      - name: Extract project Maven version
+        id: projectVersion
+        run: echo "version=$(./mvnw org.apache.maven.plugins:maven-help-plugin:3.3.0:evaluate -DforceStdout -Dexpression=project.version -q)" >>$GITHUB_OUTPUT
+      - name: Verify Android SDK Compatibility
+        if: matrix.java_version == '8'
+        run: ./mvnw -B -q -ff -ntp -DskipTests animal-sniffer:check
+      - name: Deploy snapshot
+        if: github.event_name != 'pull_request' && matrix.java_version == '8' && endsWith(steps.projectVersion.outputs.version, '-SNAPSHOT')
+        env:
+          CI_DEPLOY_USERNAME: ${{ secrets.CI_DEPLOY_USERNAME }}
+          CI_DEPLOY_PASSWORD: ${{ secrets.CI_DEPLOY_PASSWORD }}
+          # MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
+        run: ./mvnw -B -q -ff -DskipTests -ntp source:jar install
+      - name: Generate code coverage
+        if: github.event_name != 'pull_request' && matrix.java_version == '8'
+        run: ./mvnw -B -q -ff -ntp test
+      - name: Publish code coverage
+        if: github.event_name != 'pull_request' && matrix.java_version == '8'
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          file: ./target/site/jacoco/jacoco.xml
+          flags: unittests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,6 +30,9 @@ jobs:
         os: ["ubuntu-20.04"]
     env:
       JAVA_OPTS: "-XX:+TieredCompilation -XX:TieredStopAtLevel=1"
+    outputs:
+      hashes: ${{ steps.hash.outputs.hashes }}
+      artifact_name: ${{ steps.hash.outputs.artifact_name }}
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK
@@ -59,6 +62,24 @@ jobs:
           CI_DEPLOY_PASSWORD: ${{ secrets.CI_DEPLOY_PASSWORD }}
           # MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
         run: ./mvnw -B -q -ff -DskipTests -ntp source:jar install
+      # Until generator_generic_slsa3@v1.2.3, calculate hashes from ./target
+      # https://github.com/slsa-framework/slsa-github-generator/issues/1225
+      - name: Generate hash
+        id: hash
+        if: github.event_name != 'pull_request' && matrix.java_version == '8'
+        run: |
+          ARTIFACT_NAME="$( \
+            ./mvnw help:evaluate \
+              -Dexpression=project.artifactId -q -DforceStdout)-$( \
+            ./mvnw help:evaluate \
+              -Dexpression=project.version -q -DforceStdout)*.jar"
+          echo "artifact_name=$ARTIFACT_NAME" >> "$GITHUB_OUTPUT"
+
+          cd ./target
+          echo "hashes=$( \
+            sha256sum $ARTIFACT_NAME*.jar | \
+            base64 -w0 \
+          )" >> "$GITHUB_OUTPUT"
       - name: Generate code coverage
         if: github.event_name != 'pull_request' && matrix.java_version == '8'
         run: ./mvnw -B -q -ff -ntp test
@@ -69,3 +90,15 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./target/site/jacoco/jacoco.xml
           flags: unittests
+
+  provenance:
+    needs: [build]
+    permissions:
+      actions: read # To read the workflow path.
+      id-token: write # To sign the provenance.
+      contents: write # To add assets to a release.
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.2.2
+    with:
+      base64-subjects: "${{ needs.build.outputs.hashes }}"
+      provenance-name: "${{ needs.build.outputs.artifact_name }}.intoto.jsonl"
+      upload-assets: true # Optional: Upload to a new release

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,7 +61,7 @@ jobs:
           CI_DEPLOY_USERNAME: ${{ secrets.CI_DEPLOY_USERNAME }}
           CI_DEPLOY_PASSWORD: ${{ secrets.CI_DEPLOY_PASSWORD }}
           # MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
-        run: ./mvnw -B -q -ff -DskipTests -ntp source:jar install
+        run: ./mvnw -B -q -ff -DskipTests -ntp source:jar deploy
       # Until generator_generic_slsa3@v1.2.3, calculate hashes from ./target
       # https://github.com/slsa-framework/slsa-github-generator/issues/1225
       - name: Generate hash
@@ -80,12 +80,6 @@ jobs:
             sha256sum $ARTIFACT_NAME*.jar | \
             base64 -w0 \
           )" >> "$GITHUB_OUTPUT"
-      - name: Upload package
-        uses: actions/upload-artifact@v3
-        with:
-          path: ./target/*.jar
-          name: package
-          if-no-files-found: warn
       - name: Generate code coverage
         if: github.event_name != 'pull_request' && matrix.java_version == '8'
         run: ./mvnw -B -q -ff -ntp test


### PR DESCRIPTION
Closes #844.

As per the linked issue, this PR adds automatic SLSA provenance generation to the release workflow (main.yml). SLSA provenance allows maintainers and consumers to guarantee that the jars came from the expected, trusted source. See the linked issue for more information.

Currently the provenance attestation is only "attached" to the workflow (or added to GitHub releases, if the project used them). Given that Maven allows for arbitrary files in their releases, it would be best if the attestation could also be added to the release. However, I must admit my ignorance as to how precisely to do that via GitHub Actions.

You'll notice the provenance is created in a separate job from the rest of the workflow. This is for security purposes, to ensure the provenance generation is isolated and secure against external interference. If there's interest, I could submit another PR to split the build job into build, deploy, and codecov jobs. This would ensure that things such as credentials cannot leak to other steps (see [GitHub's docs on risks of compromised runners](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#accessing-secrets)).