### PR TITLE
update number length validation

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/base/ParserBase.java
+++ b/src/main/java/com/fasterxml/jackson/core/base/ParserBase.java
@@ -952,6 +952,7 @@ public abstract class ParserBase extends ParserMinimalBase
                     _reportTooLongIntegral(expType, numStr);
                 }
                 if ((expType == NR_DOUBLE) || (expType == NR_FLOAT)) {
+                    streamReadConstraints().validateFPLength(numStr.length());
                     _numberDouble = NumberInput.parseDouble(numStr, isEnabled(Feature.USE_FAST_DOUBLE_PARSER));
                     _numTypesValid = NR_DOUBLE;
                 } else {

--- a/src/main/java/com/fasterxml/jackson/core/base/ParserBase.java
+++ b/src/main/java/com/fasterxml/jackson/core/base/ParserBase.java
@@ -913,6 +913,7 @@ public abstract class ParserBase extends ParserMinimalBase
             if (expType == NR_BIGDECIMAL) {
                 _numberBigDecimal = null;
                 _numberString = _textBuffer.contentsAsString();
+                streamReadConstraints().validateFPLength(_numberString.length());
                 _numTypesValid = NR_BIGDECIMAL;
             } else if (expType == NR_FLOAT) {
                 _numberFloat = _textBuffer.contentsAsFloat(streamReadConstraints(),
@@ -951,7 +952,6 @@ public abstract class ParserBase extends ParserMinimalBase
                     _reportTooLongIntegral(expType, numStr);
                 }
                 if ((expType == NR_DOUBLE) || (expType == NR_FLOAT)) {
-                    streamReadConstraints().validateFPLength(numStr.length());
                     _numberDouble = NumberInput.parseDouble(numStr, isEnabled(Feature.USE_FAST_DOUBLE_PARSER));
                     _numTypesValid = NR_DOUBLE;
                 } else {

--- a/src/test/java/com/fasterxml/jackson/core/read/NumberParsingTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/read/NumberParsingTest.java
@@ -40,7 +40,7 @@ public class NumberParsingTest
 
     private void _testSimpleBoolean(int mode) throws Exception
     {
-        JsonParser p = createParser(mode, "[ true ]");
+        JsonParser p = createParser(jsonFactory(), mode, "[ true ]");
         assertToken(JsonToken.START_ARRAY, p.nextToken());
         assertToken(JsonToken.VALUE_TRUE, p.nextToken());
         assertEquals(true, p.getBooleanValue());
@@ -67,7 +67,7 @@ public class NumberParsingTest
     private void _testSimpleInt(int EXP_I, int mode) throws Exception
     {
         String DOC = "[ "+EXP_I+" ]";
-        JsonParser p = createParser(mode, DOC);
+        JsonParser p = createParser(jsonFactory(), mode, DOC);
         assertToken(JsonToken.START_ARRAY, p.nextToken());
         assertToken(JsonToken.VALUE_NUMBER_INT, p.nextToken());
         assertEquals(JsonParser.NumberType.INT, p.getNumberType());
@@ -109,7 +109,7 @@ public class NumberParsingTest
         p.close();
 
         DOC = String.valueOf(EXP_I);
-        p = createParser(mode, DOC + " "); // DataInput requires separator
+        p = createParser(jsonFactory(), mode, DOC + " "); // DataInput requires separator
         assertToken(JsonToken.VALUE_NUMBER_INT, p.nextToken());
         assertTrue(p.isExpectedNumberIntToken());
         assertEquals(DOC, p.getText());
@@ -124,13 +124,13 @@ public class NumberParsingTest
 
         // and finally, coercion from double to int; couple of variants
         DOC = String.valueOf(EXP_I)+".0";
-        p = createParser(mode, DOC + " ");
+        p = createParser(jsonFactory(), mode, DOC + " ");
         assertToken(JsonToken.VALUE_NUMBER_FLOAT, p.nextToken());
         assertFalse(p.isExpectedNumberIntToken());
         assertEquals(EXP_I, p.getValueAsInt());
         p.close();
 
-        p = createParser(mode, DOC + " ");
+        p = createParser(jsonFactory(), mode, DOC + " ");
         assertToken(JsonToken.VALUE_NUMBER_FLOAT, p.nextToken());
         assertEquals(EXP_I, p.getValueAsInt(0));
         p.close();
@@ -141,7 +141,7 @@ public class NumberParsingTest
         // let's test with readers and streams, separate code paths:
         for (int mode : ALL_MODES) {
             String DOC = "[ "+Integer.MAX_VALUE+","+Integer.MIN_VALUE+" ]";
-            JsonParser p = createParser(mode, DOC);
+            JsonParser p = createParser(jsonFactory(), mode, DOC);
             assertToken(JsonToken.START_ARRAY, p.nextToken());
             assertToken(JsonToken.VALUE_NUMBER_INT, p.nextToken());
             assertEquals(JsonParser.NumberType.INT, p.getNumberType());
@@ -252,7 +252,7 @@ public class NumberParsingTest
     {
         long EXP_L = 12345678907L;
         
-        JsonParser p = createParser(mode, "[ "+EXP_L+" ]");
+        JsonParser p = createParser(jsonFactory(), mode, "[ "+EXP_L+" ]");
         assertToken(JsonToken.START_ARRAY, p.nextToken());
         assertToken(JsonToken.VALUE_NUMBER_INT, p.nextToken());
         // beyond int, should be long
@@ -279,7 +279,7 @@ public class NumberParsingTest
             long belowMinInt = -1L + Integer.MIN_VALUE;
             long aboveMaxInt = 1L + Integer.MAX_VALUE;
             String input = "[ "+Long.MAX_VALUE+","+Long.MIN_VALUE+","+aboveMaxInt+", "+belowMinInt+" ]";
-            JsonParser p = createParser(mode, input);
+            JsonParser p = createParser(jsonFactory(), mode, input);
             assertToken(JsonToken.START_ARRAY, p.nextToken());
             assertToken(JsonToken.VALUE_NUMBER_INT, p.nextToken());
             assertEquals(JsonParser.NumberType.LONG, p.getNumberType());
@@ -361,7 +361,7 @@ public class NumberParsingTest
             BigInteger big = new BigDecimal(Long.MAX_VALUE).toBigInteger();
             big = big.add(BigInteger.ONE);
             String input = "[ "+small+"  ,  "+big+"]";
-            JsonParser p = createParser(mode, input);
+            JsonParser p = createParser(jsonFactory(), mode, input);
             assertToken(JsonToken.START_ARRAY, p.nextToken());
             assertToken(JsonToken.VALUE_NUMBER_INT, p.nextToken());
             assertEquals(JsonParser.NumberType.BIG_INTEGER, p.getNumberType());
@@ -385,7 +385,7 @@ public class NumberParsingTest
         BigInteger biggie = new BigInteger(NUMBER_STR);
 
         for (int mode : ALL_MODES) {
-            JsonParser p = createParser(mode, NUMBER_STR +" ");
+            JsonParser p = createParser(jsonFactory(), mode, NUMBER_STR +" ");
             assertToken(JsonToken.VALUE_NUMBER_INT, p.nextToken());
             assertEquals(JsonParser.NumberType.BIG_INTEGER, p.getNumberType());
             assertEquals(NUMBER_STR, p.getText());
@@ -416,7 +416,7 @@ public class NumberParsingTest
                 double EXP_D = Double.parseDouble(STR);
                 String DOC = "["+STR+"]";
 
-                JsonParser p = createParser(mode, DOC+" ");
+                JsonParser p = createParser(jsonFactory(), mode, DOC+" ");
                 assertToken(JsonToken.START_ARRAY, p.nextToken());
 
                 assertToken(JsonToken.VALUE_NUMBER_FLOAT, p.nextToken());
@@ -429,7 +429,7 @@ public class NumberParsingTest
                 p.close();
 
                 // then outside
-                p = createParser(mode, STR + " ");
+                p = createParser(jsonFactory(), mode, STR + " ");
                 JsonToken t = null;
 
                 try {
@@ -540,7 +540,10 @@ public class NumberParsingTest
         }) {
             final String DOC = "[ "+asText+" ]";
 
-            JsonParser p = createParser(mode, DOC);
+            JsonFactory jsonFactory = jsonFactory().rebuild()
+                    .streamReadConstraints(StreamReadConstraints.builder().maxNumberLength(Integer.MAX_VALUE).build())
+                    .build();
+            JsonParser p = createParser(jsonFactory, mode, DOC);
             assertToken(JsonToken.START_ARRAY, p.nextToken());
             assertToken(JsonToken.VALUE_NUMBER_FLOAT, p.nextToken());
             final BigDecimal exp = new BigDecimal(asText);
@@ -567,7 +570,7 @@ public class NumberParsingTest
     {
         final String DOC = "[ -13, 8100200300, 13.5, 0.00010, -2.033 ]";
 
-        JsonParser p = createParser(mode, DOC);
+        JsonParser p = createParser(jsonFactory(), mode, DOC);
 
         assertToken(JsonToken.START_ARRAY, p.nextToken());
         
@@ -655,7 +658,7 @@ public class NumberParsingTest
             JsonParser p;
 
             if (input == 0) {
-                p = createParserUsingStream(DOC, "UTF-8");
+                p = createParserUsingStream(jsonFactory(), DOC, "UTF-8");
             } else {
                 p = jsonFactory().createParser(DOC);
             }
@@ -796,7 +799,7 @@ public class NumberParsingTest
 
     private void _testInvalidBooleanAccess(int mode) throws Exception
     {
-        JsonParser p = createParser(mode, "[ \"abc\" ]");
+        JsonParser p = createParser(jsonFactory(), mode, "[ \"abc\" ]");
         assertToken(JsonToken.START_ARRAY, p.nextToken());
         assertToken(JsonToken.VALUE_STRING, p.nextToken());
         try {
@@ -817,7 +820,7 @@ public class NumberParsingTest
     
     private void _testInvalidIntAccess(int mode) throws Exception
     {
-        JsonParser p = createParser(mode, "[ \"abc\" ]");
+        JsonParser p = createParser(jsonFactory(), mode, "[ \"abc\" ]");
         assertToken(JsonToken.START_ARRAY, p.nextToken());
         assertToken(JsonToken.VALUE_STRING, p.nextToken());
         try {
@@ -838,7 +841,7 @@ public class NumberParsingTest
     
     private void _testInvalidLongAccess(int mode) throws Exception
     {
-        JsonParser p = createParser(mode, "[ false ]");
+        JsonParser p = createParser(jsonFactory(), mode, "[ false ]");
         assertToken(JsonToken.START_ARRAY, p.nextToken());
         assertToken(JsonToken.VALUE_FALSE, p.nextToken());
         try {
@@ -881,7 +884,7 @@ public class NumberParsingTest
 
     public void testInvalidNumber() throws Exception {
         for (int mode : ALL_MODES) {
-            JsonParser p = createParser(mode, " -foo ");
+            JsonParser p = createParser(jsonFactory(), mode, " -foo ");
             try {
                 p.nextToken();
                 fail("Should not pass");


### PR DESCRIPTION
I think we should validate the length of the number string in _parseSlowFloat (BigDecimal flow). This matches waht happens for BigIntegers in _parseSlowInt.