### PR TITLE
expose streamReadConstraints() on TokenStreamFactory

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/TokenStreamFactory.java
+++ b/src/main/java/com/fasterxml/jackson/core/TokenStreamFactory.java
@@ -146,6 +146,21 @@ public abstract class TokenStreamFactory
 
     /*
     /**********************************************************************
+    /* Constraints violation checking (2.15)
+    /**********************************************************************
+     */
+
+    /**
+     * Get the constraints to apply when performing streaming reads.
+     *
+     * @since 2.15
+     */
+    public StreamReadConstraints streamReadConstraints() {
+        return _streamReadConstraints == null ? StreamReadConstraints.defaults() : _streamReadConstraints;
+    }
+
+    /*
+    /**********************************************************************
     /* Factory methods, parsers
     /**********************************************************************
      */


### PR DESCRIPTION
useful for TOML case - the Parser class should validate num length and the TomlFactory that inherits from TokenStreamFactory would be a good place to get to get the constraints.