### PR TITLE
Optimize parsing 19 digit longs

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/base/ParserBase.java
+++ b/src/main/java/com/fasterxml/jackson/core/base/ParserBase.java
@@ -939,7 +939,6 @@ public abstract class ParserBase extends ParserMinimalBase
 
     private void _parseSlowInt(int expType) throws IOException
     {
-        final String numStr = _textBuffer.contentsAsString();
         try {
             int len = _intLength;
             char[] buf = _textBuffer.getTextBuffer();
@@ -949,10 +948,10 @@ public abstract class ParserBase extends ParserMinimalBase
             }
             // Some long cases still...
             if (NumberInput.inLongRange(buf, offset, len, _numberNegative)) {
-                // Probably faster to construct a String, call parse, than to use BigInteger
-                _numberLong = NumberInput.parseLong(numStr);
+                _numberLong = NumberInput.parseLong19(buf, offset, _numberNegative);
                 _numTypesValid = NR_LONG;
             } else {
+                String numStr = _textBuffer.contentsAsString();
                 // 16-Oct-2018, tatu: Need to catch "too big" early due to [jackson-core#488]
                 if ((expType == NR_INT) || (expType == NR_LONG)) {
                     _reportTooLongIntegral(expType, numStr);
@@ -970,6 +969,7 @@ public abstract class ParserBase extends ParserMinimalBase
                 }
             }
         } catch (NumberFormatException nex) {
+            String numStr = _textBuffer.contentsAsString();
             // Can this ever occur? Due to overflow, maybe?
             _wrapError("Malformed numeric value ("+_longNumberDesc(numStr)+")", nex);
         }

--- a/src/main/java/com/fasterxml/jackson/core/io/NumberInput.java
+++ b/src/main/java/com/fasterxml/jackson/core/io/NumberInput.java
@@ -152,6 +152,32 @@ public final class NumberInput
         long val = parseInt(ch, off, len1) * L_BILLION;
         return val + (long) parseInt(ch, off+len1, 9);
     }
+    
+    /**
+     * Parses an unsigned long made up of exactly 19 digits.
+     * <p>
+     * It is the callers responsibility to make sure the input is exactly 19 digits.
+     * and fits into a 64bit long by calling {@link #inLongRange(char[], int, int, boolean)}
+     * first.
+     * <p>
+     * Note that input String must NOT contain leading minus sign (even
+     * if {@code negative} is set to true).
+     * 
+     * @param ch Buffer that contains integer value to decode
+     * @param off Offset of the first digit character in buffer
+     * @param negative Whether original number had a minus sign
+     * @return Decoded {@code long} value
+     */
+    public static long parseLong19(char[] ch, int off, boolean negative)
+    {
+        // Note: caller must ensure length is [10, 18]
+        long num = 0L;
+        for (int i = 0; i < 19; i++) {
+            char c = ch[off + i];
+            num = (num * 10) + (c - '0');
+        }
+        return negative ? -num : num;
+    }
 
     /**
      * Similar to {@link #parseInt(String)} but for {@code long} values.

--- a/src/test/java/com/fasterxml/jackson/core/read/NumberParsingTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/read/NumberParsingTest.java
@@ -278,7 +278,9 @@ public class NumberParsingTest
         for (int mode : ALL_MODES) {
             long belowMinInt = -1L + Integer.MIN_VALUE;
             long aboveMaxInt = 1L + Integer.MAX_VALUE;
-            String input = "[ "+Long.MAX_VALUE+","+Long.MIN_VALUE+","+aboveMaxInt+", "+belowMinInt+" ]";
+            long belowMaxLong = -1L + Long.MAX_VALUE;
+            long aboveMinLong = 1L + Long.MIN_VALUE;
+            String input = "[ "+Long.MAX_VALUE+","+Long.MIN_VALUE+","+aboveMaxInt+", "+belowMinInt+","+belowMaxLong+", "+aboveMinLong+" ]";
             JsonParser p = createParser(jsonFactory(), mode, input);
             assertToken(JsonToken.START_ARRAY, p.nextToken());
             assertToken(JsonToken.VALUE_NUMBER_INT, p.nextToken());
@@ -296,6 +298,14 @@ public class NumberParsingTest
             assertToken(JsonToken.VALUE_NUMBER_INT, p.nextToken());
             assertEquals(JsonParser.NumberType.LONG, p.getNumberType());
             assertEquals(belowMinInt, p.getLongValue());
+
+            assertToken(JsonToken.VALUE_NUMBER_INT, p.nextToken());
+            assertEquals(JsonParser.NumberType.LONG, p.getNumberType());
+            assertEquals(belowMaxLong, p.getLongValue());
+
+            assertToken(JsonToken.VALUE_NUMBER_INT, p.nextToken());
+            assertEquals(JsonParser.NumberType.LONG, p.getNumberType());
+            assertEquals(aboveMinLong, p.getLongValue());
 
             
             assertToken(JsonToken.END_ARRAY, p.nextToken());        


### PR DESCRIPTION
Parsing 19 digit long values is significantly slower than parsing 18 digit long values as we are hitting a slow path that does a string allocation.

19 digit long values are quite common when a random number generator is used to generate long values.

We have to pay attention that we only use this fast path if the value is a valid long. This can be achieved by calling `#inLongRange` first.

In the following synthetic microbenchmark a throughput increase of about 33% with a drastic reduction in the allocation rate can be achieved.

```java

@OutputTimeUnit(TimeUnit.SECONDS)
public class JacksonStdLongReadVanilla
{

    private static final JsonFactory JSON_FACTORY = new JsonFactory();

    private static final String JSON;

    static {
        StringBuilder json = new StringBuilder();
        Random random = new Random(0L);
        json.append('[');
        for (int i = 0; i < 1_000; i++) {
            if (i > 0) {
                json.append(',');
            }
            json.append(random.nextLong());
        }
        json.append(']');
        JSON = json.toString();
    }

    @Benchmark
    public void parseLong(Blackhole blackhole) throws IOException {
        try (JsonParser parser = JSON_FACTORY.createParser(JSON)) {
            parser.nextToken();

            JsonToken nextToken = parser.nextToken();
            while (nextToken == JsonToken.VALUE_NUMBER_INT) {
                blackhole.consume(parser.getLongValue());
                nextToken = parser.nextToken();
            }
        }
    }

}

```

If we have a look at the allocations before we see that it is dominated by `byte[]` allocations for `String` allocations

![allocation-site-before](https://user-images.githubusercontent.com/471021/207910102-4dd41f72-73b0-4aaf-a4f6-541f68e25e53.png)

Resulting in many gcs

![gcs-before](https://user-images.githubusercontent.com/471021/207910097-7642ddad-33ec-4933-9263-faa80c8c6e21.png)

With the changes in this PR the  `byte[]` and `String` allocations are gone

![allocation-site-after](https://user-images.githubusercontent.com/471021/207910103-6dedc3c3-3df7-4d88-96cb-4026c61ae4e9.png)

Resulting in no more gcs

![gcs-after](https://user-images.githubusercontent.com/471021/207910100-76bb889e-551a-4536-8fc9-0cdb95cdfc0f.png)


