### PR TITLE
Fastdoubleparser 0.5.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -239,7 +239,7 @@ com.fasterxml.jackson.core.*;version=${project.version}
     <dependency>
       <groupId>ch.randelshofer</groupId>
       <artifactId>fastdoubleparser</artifactId>
-      <version>0.5.2</version>
+      <version>0.5.3</version>
     </dependency>
     <!-- Test dependencies -->
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -239,7 +239,7 @@ com.fasterxml.jackson.core.*;version=${project.version}
     <dependency>
       <groupId>ch.randelshofer</groupId>
       <artifactId>fastdoubleparser</artifactId>
-      <version>0.5.3</version>
+      <version>0.5.4</version>
     </dependency>
     <!-- Test dependencies -->
     <dependency>

--- a/src/test/java/com/fasterxml/jackson/core/io/BigDecimalParserTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/io/BigDecimalParserTest.java
@@ -21,17 +21,15 @@ public class BigDecimalParserTest extends com.fasterxml.jackson.core.BaseTest {
         }
     }
 
-    /* there is an open issue at https://github.com/wrandelshofer/FastDoubleParser/issues/24 about this
     public void testLongStringFastParseBigInteger() {
         try {
-            BigDecimalParser.parseBigIntegerWithFastParser(genLongString());
+            System.out.println(BigIntegerParser.parseWithFastParser(genLongString()));
             fail("expected NumberFormatException");
         } catch (NumberFormatException nfe) {
             assertTrue("exception message starts as expected?", nfe.getMessage().startsWith("Value \"AAAAA"));
             assertTrue("exception message value contains truncated", nfe.getMessage().contains("truncated"));
         }
     }
-    */
 
     private String genLongString() {
         final int len = 1500;

--- a/src/test/java/com/fasterxml/jackson/core/io/BigDecimalParserTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/io/BigDecimalParserTest.java
@@ -23,7 +23,7 @@ public class BigDecimalParserTest extends com.fasterxml.jackson.core.BaseTest {
 
     public void testLongStringFastParseBigInteger() {
         try {
-            System.out.println(BigIntegerParser.parseWithFastParser(genLongString()));
+            BigIntegerParser.parseWithFastParser(genLongString());
             fail("expected NumberFormatException");
         } catch (NumberFormatException nfe) {
             assertTrue("exception message starts as expected?", nfe.getMessage().startsWith("Value \"AAAAA"));


### PR DESCRIPTION
fixes an issue where parsing invalid values can result in a valid looking BigInteger instead of throwing a NumberFormatException