### PR TITLE
StreamReadConstraints: support different BigNumber and FP number size limits

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/StreamReadConstraints.java
+++ b/src/main/java/com/fasterxml/jackson/core/StreamReadConstraints.java
@@ -145,9 +145,9 @@ public class StreamReadConstraints
      */
     public void validateFPLength(int length) throws NumberFormatException
     {
-        if (length > _maxNumLen) {
+        if (length > _maxFPLen) {
             throw new NumberFormatException(String.format("Number length (%d) exceeds the maximum length (%d)",
-                    length, _maxNumLen));
+                    length, _maxFPLen));
         }
     }
 

--- a/src/main/java/com/fasterxml/jackson/core/StreamReadConstraints.java
+++ b/src/main/java/com/fasterxml/jackson/core/StreamReadConstraints.java
@@ -18,6 +18,7 @@ public class StreamReadConstraints
     public static final int DEFAULT_MAX_NUM_LEN = 1000;
 
     protected final int _maxNumLen;
+    protected final int _maxFPLen;
 
     private static final StreamReadConstraints DEFAULT =
         new StreamReadConstraints(DEFAULT_MAX_NUM_LEN);
@@ -69,6 +70,9 @@ public class StreamReadConstraints
 
     StreamReadConstraints(int maxNumLen) {
         _maxNumLen = maxNumLen;
+        // 768 limit comes from Daniel Lemire, Number Parsing at a Gigabyte per Second, Software: Practice and Experience
+        // 51 (8), 2021, Chapter 11 Processing Numbers Quickly
+        _maxFPLen = Math.min(768, _maxNumLen);
     }
 
     public static Builder builder() {
@@ -108,6 +112,25 @@ public class StreamReadConstraints
     /* Convenience methods for validation
     /**********************************************************************
      */
+
+    /**
+     * Convenience method that can be used to verify that a BigDecimal or BigInteger
+     * number of specified length does not exceed maximum specific by this
+     * constraints object: if it does, a
+     * {@link NumberFormatException}
+     * is thrown.
+     *
+     * @param length Length of number in input units
+     *
+     * @throws NumberFormatException If length exceeds maximum
+     */
+    public void validateBigNumberLength(int length) throws NumberFormatException
+    {
+        if (length > _maxNumLen) {
+            throw new NumberFormatException(String.format("Number length (%d) exceeds the maximum length (%d)",
+                    length, _maxNumLen));
+        }
+    }
 
     /**
      * Convenience method that can be used to verify that a floating-point

--- a/src/main/java/com/fasterxml/jackson/core/StreamReadConstraints.java
+++ b/src/main/java/com/fasterxml/jackson/core/StreamReadConstraints.java
@@ -17,8 +17,21 @@ public class StreamReadConstraints
      */
     public static final int DEFAULT_MAX_NUM_LEN = 1000;
 
+    /**
+     * Longest <code>int</code> or <code>long</code> allowed but <code>StreamReadConstraints</code>.
+     * See {@link Builder#maxNumberLength(int)} for full details of how this applied.
+     */
+    public static final int MAX_INT_LEN = 20;
+
+    /**
+     * Longest <code>float</code> or <code>double</code> allowed but <code>StreamReadConstraints</code>.
+     * See {@link Builder#maxNumberLength(int)} for full details of how this applied.
+     */
+    public static final int MAX_FLOAT_LEN = 768;
+
     protected final int _maxNumLen;
     protected final int _maxFPLen;
+    protected final int _maxIntLen;
 
     private static final StreamReadConstraints DEFAULT =
         new StreamReadConstraints(DEFAULT_MAX_NUM_LEN);
@@ -29,6 +42,12 @@ public class StreamReadConstraints
         /**
          * Sets the maximum number length (in chars or bytes, depending on input context).
          * The default is 1000.
+         * <ul>
+         *     <li>This limit is applied when parsing {@link java.math.BigDecimal} and {@link java.math.BigInteger}.</li>
+         *     </li>When parsing <code>float</code>s and <code>double</code>s, the limit is the lower of 768 and this value.</li>
+         *     </li>When parsing <code>int</code>s and <code>long</code>s, the limit is the lower of 20 and this value
+         *     (but the parsing code itself can fail for smaller numbers anyway, especially with ints).</li>
+         * </ul>
          *
          * @param maxNumLen the maximum number length (in chars or bytes, depending on input context)
          *
@@ -72,7 +91,8 @@ public class StreamReadConstraints
         _maxNumLen = maxNumLen;
         // 768 limit comes from Daniel Lemire, Number Parsing at a Gigabyte per Second, Software: Practice and Experience
         // 51 (8), 2021, Chapter 11 Processing Numbers Quickly
-        _maxFPLen = Math.min(768, _maxNumLen);
+        _maxFPLen = Math.min(MAX_FLOAT_LEN, _maxNumLen);
+        _maxIntLen = Math.min(MAX_INT_LEN, _maxNumLen);
     }
 
     public static Builder builder() {
@@ -164,9 +184,9 @@ public class StreamReadConstraints
      */
     public void validateIntegerLength(int length) throws NumberFormatException
     {
-        if (length > _maxNumLen) {
+        if (length > _maxIntLen) {
             throw new NumberFormatException(String.format("Number length (%d) exceeds the maximum length (%d)",
-                    length, _maxNumLen));
+                    length, _maxIntLen));
         }
     }
 }

--- a/src/main/java/com/fasterxml/jackson/core/StreamReadConstraints.java
+++ b/src/main/java/com/fasterxml/jackson/core/StreamReadConstraints.java
@@ -18,14 +18,14 @@ public class StreamReadConstraints
     public static final int DEFAULT_MAX_NUM_LEN = 1000;
 
     /**
-     * Longest <code>int</code> or <code>long</code> allowed but <code>StreamReadConstraints</code>.
-     * See {@link Builder#maxNumberLength(int)} for full details of how this applied.
+     * Longest <code>int</code> or <code>long</code> allowed.
+     * See {@link Builder#maxNumberLength(int)} for full details of how this is applied.
      */
     public static final int MAX_INT_LEN = 20;
 
     /**
-     * Longest <code>float</code> or <code>double</code> allowed but <code>StreamReadConstraints</code>.
-     * See {@link Builder#maxNumberLength(int)} for full details of how this applied.
+     * Longest <code>float</code> or <code>double</code> allowed.
+     * See {@link Builder#maxNumberLength(int)} for full details of how this is applied.
      */
     public static final int MAX_FLOAT_LEN = 768;
 

--- a/src/main/java/com/fasterxml/jackson/core/base/ParserBase.java
+++ b/src/main/java/com/fasterxml/jackson/core/base/ParserBase.java
@@ -962,7 +962,7 @@ public abstract class ParserBase extends ParserMinimalBase
                     _numberDouble = NumberInput.parseDouble(numStr, isEnabled(Feature.USE_FAST_DOUBLE_PARSER));
                     _numTypesValid = NR_DOUBLE;
                 } else {
-                    streamReadConstraints().validateIntegerLength(numStr.length());
+                    streamReadConstraints().validateBigNumberLength(numStr.length());
                     // nope, need the heavy guns... (rare case) - since Jackson v2.14, BigInteger parsing is lazy
                     _numberBigInt = null;
                     _numberString = numStr;

--- a/src/main/java/com/fasterxml/jackson/core/base/ParserBase.java
+++ b/src/main/java/com/fasterxml/jackson/core/base/ParserBase.java
@@ -915,7 +915,7 @@ public abstract class ParserBase extends ParserMinimalBase
                 //    value is actually needed.
                 _numberBigDecimal = null;
                 String numStr = _textBuffer.contentsAsString();
-                streamReadConstraints().validateFPLength(numStr.length());
+                streamReadConstraints().validateBigNumberLength(numStr.length());
                 _numberString = numStr;
                 _numTypesValid = NR_BIGDECIMAL;
             } else if (expType == NR_FLOAT) {
@@ -1134,7 +1134,7 @@ public abstract class ParserBase extends ParserMinimalBase
             // Let's actually parse from String representation, to avoid
             // rounding errors that non-decimal floating operations could incur
             final String numStr = getText();
-            streamReadConstraints().validateFPLength(numStr.length());
+            streamReadConstraints().validateBigNumberLength(numStr.length());
             _numberBigDecimal = NumberInput.parseBigDecimal(numStr);
         } else if ((_numTypesValid & NR_BIGINT) != 0) {
             _numberBigDecimal = new BigDecimal(_getBigInteger());

--- a/src/main/java/com/fasterxml/jackson/core/base/ParserMinimalBase.java
+++ b/src/main/java/com/fasterxml/jackson/core/base/ParserMinimalBase.java
@@ -388,6 +388,7 @@ public abstract class ParserMinimalBase extends JsonParser
                 if (_hasTextualNull(str)) {
                     return 0;
                 }
+                streamReadConstraints().validateIntegerLength(str.length());
                 return NumberInput.parseAsInt(str, defaultValue);
             case ID_TRUE:
                 return 1;
@@ -429,6 +430,7 @@ public abstract class ParserMinimalBase extends JsonParser
                 if (_hasTextualNull(str)) {
                     return 0L;
                 }
+                streamReadConstraints().validateIntegerLength(str.length());
                 return NumberInput.parseAsLong(str, defaultValue);
             case ID_TRUE:
                 return 1L;

--- a/src/main/java/com/fasterxml/jackson/core/util/TextBuffer.java
+++ b/src/main/java/com/fasterxml/jackson/core/util/TextBuffer.java
@@ -497,22 +497,22 @@ public final class TextBuffer
     {
         // Already got a pre-cut array?
         if (_resultArray != null) {
-            constraints.validateFPLength(_resultArray.length);
+            constraints.validateBigNumberLength(_resultArray.length);
             return NumberInput.parseBigDecimal(_resultArray, useFastParser);
         }
         // Or a shared buffer?
         if ((_inputStart >= 0) && (_inputBuffer != null)) {
-            constraints.validateFPLength(_inputLen);
+            constraints.validateBigNumberLength(_inputLen);
             return NumberInput.parseBigDecimal(_inputBuffer, _inputStart, _inputLen, useFastParser);
         }
         // Or if not, just a single buffer (the usual case)
         if ((_segmentSize == 0) && (_currentSegment != null)) {
-            constraints.validateFPLength(_currentSize);
+            constraints.validateBigNumberLength(_currentSize);
             return NumberInput.parseBigDecimal(_currentSegment, 0, _currentSize, useFastParser);
         }
         // If not, let's just get it aggregated...
         final char[] numArray = contentsAsArray();
-        constraints.validateFPLength(numArray.length);
+        constraints.validateBigNumberLength(numArray.length);
         return NumberInput.parseBigDecimal(numArray, useFastParser);
     }
 

--- a/src/test/java/com/fasterxml/jackson/core/read/NumberOverflowTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/read/NumberOverflowTest.java
@@ -107,13 +107,17 @@ public class NumberOverflowTest
     {
         for (int mode : ALL_STREAMING_MODES) {
             final String doc = BIG_POS_DOC;
-            JsonParser p = createParser(FACTORY, mode, doc);
-            assertToken(JsonToken.START_ARRAY, p.nextToken());
-            assertToken(JsonToken.VALUE_NUMBER_INT, p.nextToken());
-            double d = p.getDoubleValue();
-            assertEquals(Double.valueOf(BIG_POS_INTEGER), d);
-            assertToken(JsonToken.END_ARRAY, p.nextToken());
-            p.close();
+            try (JsonParser p = createParser(FACTORY, mode, doc)) {
+                assertToken(JsonToken.START_ARRAY, p.nextToken());
+                assertToken(JsonToken.VALUE_NUMBER_INT, p.nextToken());
+                try {
+                    p.getDoubleValue();
+                    fail("expected JsonParseException");
+                } catch (JsonParseException jpe) {
+                    assertTrue("unexpected exception message: " + jpe.getMessage(),
+                            jpe.getMessage().startsWith("Malformed numeric value ([number with 199999 characters])"));
+                }
+            }
         }
     }    
 
@@ -122,13 +126,17 @@ public class NumberOverflowTest
     {
         for (int mode : ALL_STREAMING_MODES) {
             final String doc = BIG_POS_DOC;
-            JsonParser p = createParser(FACTORY, mode, doc);
-            assertToken(JsonToken.START_ARRAY, p.nextToken());
-            assertToken(JsonToken.VALUE_NUMBER_INT, p.nextToken());
-            float f = p.getFloatValue();
-            assertEquals(Float.valueOf(BIG_POS_INTEGER), f);
-            assertToken(JsonToken.END_ARRAY, p.nextToken());
-            p.close();
+            try (JsonParser p = createParser(FACTORY, mode, doc)) {
+                assertToken(JsonToken.START_ARRAY, p.nextToken());
+                assertToken(JsonToken.VALUE_NUMBER_INT, p.nextToken());
+                try {
+                    p.getFloatValue();
+                    fail("expected JsonParseException");
+                } catch (JsonParseException jpe) {
+                    assertTrue("unexpected exception message: " + jpe.getMessage(),
+                            jpe.getMessage().startsWith("Malformed numeric value ([number with 199999 characters])"));
+                }
+            }
         }
     }
 }

--- a/src/test/java/com/fasterxml/jackson/core/read/NumberParsingTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/read/NumberParsingTest.java
@@ -20,31 +20,6 @@ import com.fasterxml.jackson.core.json.JsonReadFeature;
 public class NumberParsingTest
     extends com.fasterxml.jackson.core.BaseTest
 {
-    private static final String BASE_FRACTION =
-            "01610253934481930774151441507943554511027782188707463024288149352877602369090537"
-                    +"80583522838238149455840874862907649203136651528841378405339370751798532555965157588"
-                    +"51877960056849468879933122908090021571162427934915567330612627267701300492535817858"
-                    +"36107216979078343419634586362681098115326893982589327952357032253344676618872460059"
-                    +"52652865429180458503533715200184512956356092484787210672008123556320998027133021328"
-                    +"04777044107393832707173313768807959788098545050700242134577863569636367439867566923"
-                    +"33479277494056927358573496400831024501058434838492057410330673302052539013639792877"
-                    +"76670882022964335417061758860066263335250076803973514053909274208258510365484745192"
-                    +"39425298649420795296781692303253055152441850691276044546565109657012938963181532017"
-                    +"97420631515930595954388119123373317973532146157980827838377034575940814574561703270"
-                    +"54949003909864767732479812702835339599792873405133989441135669998398892907338968744"
-                    +"39682249327621463735375868408190435590094166575473967368412983975580104741004390308"
-                    +"45302302121462601506802738854576700366634229106405188353120298347642313881766673834"
-                    +"60332729485083952142460470270121052469394888775064758246516888122459628160867190501"
-                    +"92476878886543996441778751825677213412487177484703116405390741627076678284295993334"
-                    +"23142914551517616580884277651528729927553693274406612634848943914370188078452131231"
-                    +"17351787166509190240927234853143290940647041705485514683182501795615082930770566118"
-                    +"77488417962195965319219352314664764649802231780262169742484818333055713291103286608"
-                    +"64318433253572997833038335632174050981747563310524775762280529871176578487487324067"
-                    +"90242862159403953039896125568657481354509805409457993946220531587293505986329150608"
-                    +"18702520420240989908678141379300904169936776618861221839938283876222332124814830207"
-                    +"073816864076428273177778788053613345444299361357958409716099682468768353446625063";
-
-
     protected JsonFactory jsonFactory() {
         return sharedStreamFactory();
     }
@@ -552,89 +527,51 @@ public class NumberParsingTest
         _testBigBigDecimals(MODE_READER, true);
     }
 
-    public void testBigBigDecimalsDataInputFailByDefault() throws Exception
+    public void testBigBigDecimalsFailByDefault() throws Exception
     {
-        try {
-            _testBigBigDecimals(MODE_DATA_INPUT, false);
-        } catch (JsonParseException jpe) {
-            assertTrue("unexpected exception message: " + jpe.getMessage(),
-                    jpe.getMessage().startsWith("Malformed numeric value ([number with 1824 characters])"));
+        for (int mode : ALL_STREAMING_MODES) {
+            try {
+                _testBigBigDecimals(mode, false);
+            } catch (JsonParseException jpe) {
+                assertTrue("unexpected exception message: " + jpe.getMessage(),
+                        jpe.getMessage().startsWith("Malformed numeric value ([number with 1824 characters])"));
+            }
         }
     }
 
     public void testBigBigDecimalsDataInput() throws Exception
     {
-        _testBigBigDecimals(MODE_DATA_INPUT, true);
-    }
-
-    public void testBigBigDoubleDataInputFail() throws Exception
-    {
-        try {
-            // fails even though maxNumberLength is set to Integer.MAX_VALUE
-            _testBigBigDouble(MODE_DATA_INPUT);
-        } catch (JsonParseException jpe) {
-            assertTrue("unexpected exception message: " + jpe.getMessage(),
-                    jpe.getMessage().startsWith("Malformed numeric value ([number with 1824 characters])"));
-        }
-    }
-
-    public void testBigBigFloatDataInputFail() throws Exception
-    {
-        try {
-            // fails even though maxNumberLength is set to Integer.MAX_VALUE
-            _testBigBigFloat(MODE_DATA_INPUT);
-        } catch (JsonParseException jpe) {
-            assertTrue("unexpected exception message: " + jpe.getMessage(),
-                    jpe.getMessage().startsWith("Malformed numeric value ([number with 1824 characters])"));
-        }
-    }
-
-    public void testBigBigFloatReaderFail() throws Exception
-    {
-        try {
-            // fails even though maxNumberLength is set to Integer.MAX_VALUE
-            _testBigBigFloat(MODE_READER);
-        } catch (JsonParseException jpe) {
-            assertTrue("unexpected exception message: " + jpe.getMessage(),
-                    jpe.getMessage().startsWith("Malformed numeric value ([number with 1824 characters])"));
-        }
-    }
-
-    public void testBigBigFloatReaderThrottledFail() throws Exception
-    {
-        try {
-            // fails even though maxNumberLength is set to Integer.MAX_VALUE
-            _testBigBigFloat(MODE_READER_THROTTLED);
-        } catch (JsonParseException jpe) {
-            assertTrue("unexpected exception message: " + jpe.getMessage(),
-                    jpe.getMessage().startsWith("Malformed numeric value ([number with 1824 characters])"));
-        }
-    }
-
-    public void testBigBigFloatInputStreamFail() throws Exception
-    {
-        try {
-            // fails even though maxNumberLength is set to Integer.MAX_VALUE
-            _testBigBigFloat(MODE_INPUT_STREAM);
-        } catch (JsonParseException jpe) {
-            assertTrue("unexpected exception message: " + jpe.getMessage(),
-                    jpe.getMessage().startsWith("Malformed numeric value ([number with 1824 characters])"));
-        }
-    }
-
-    public void testBigBigFloatInputStreamThrottledFail() throws Exception
-    {
-        try {
-            // fails even though maxNumberLength is set to Integer.MAX_VALUE
-            _testBigBigFloat(MODE_INPUT_STREAM_THROTTLED);
-        } catch (JsonParseException jpe) {
-            assertTrue("unexpected exception message: " + jpe.getMessage(),
-                    jpe.getMessage().startsWith("Malformed numeric value ([number with 1824 characters])"));
+        for (int mode : ALL_STREAMING_MODES) {
+            _testBigBigDecimals(mode, true);
         }
     }
 
     private void _testBigBigDecimals(final int mode, final boolean enableUnlimitedNumberLen) throws Exception
     {
+        final String BASE_FRACTION =
+                "01610253934481930774151441507943554511027782188707463024288149352877602369090537"
+                        +"80583522838238149455840874862907649203136651528841378405339370751798532555965157588"
+                        +"51877960056849468879933122908090021571162427934915567330612627267701300492535817858"
+                        +"36107216979078343419634586362681098115326893982589327952357032253344676618872460059"
+                        +"52652865429180458503533715200184512956356092484787210672008123556320998027133021328"
+                        +"04777044107393832707173313768807959788098545050700242134577863569636367439867566923"
+                        +"33479277494056927358573496400831024501058434838492057410330673302052539013639792877"
+                        +"76670882022964335417061758860066263335250076803973514053909274208258510365484745192"
+                        +"39425298649420795296781692303253055152441850691276044546565109657012938963181532017"
+                        +"97420631515930595954388119123373317973532146157980827838377034575940814574561703270"
+                        +"54949003909864767732479812702835339599792873405133989441135669998398892907338968744"
+                        +"39682249327621463735375868408190435590094166575473967368412983975580104741004390308"
+                        +"45302302121462601506802738854576700366634229106405188353120298347642313881766673834"
+                        +"60332729485083952142460470270121052469394888775064758246516888122459628160867190501"
+                        +"92476878886543996441778751825677213412487177484703116405390741627076678284295993334"
+                        +"23142914551517616580884277651528729927553693274406612634848943914370188078452131231"
+                        +"17351787166509190240927234853143290940647041705485514683182501795615082930770566118"
+                        +"77488417962195965319219352314664764649802231780262169742484818333055713291103286608"
+                        +"64318433253572997833038335632174050981747563310524775762280529871176578487487324067"
+                        +"90242862159403953039896125568657481354509805409457993946220531587293505986329150608"
+                        +"18702520420240989908678141379300904169936776618861221839938283876222332124814830207"
+                        +"073816864076428273177778788053613345444299361357958409716099682468768353446625063";
+
         for (String asText : new String[] {
                 "50."+BASE_FRACTION,
                 "-37."+BASE_FRACTION,
@@ -659,40 +596,6 @@ public class NumberParsingTest
                 final BigDecimal exp = new BigDecimal(asText);
                 assertEquals(exp, p.getDecimalValue());
             }
-        }
-    }
-
-    private void _testBigBigDouble(final int mode) throws Exception
-    {
-        final String num = "50."+BASE_FRACTION;
-        final String DOC = "[ "+num+" ]";
-
-        JsonFactory jsonFactory = jsonFactory()
-                .rebuild()
-                .streamReadConstraints(StreamReadConstraints.builder().maxNumberLength(Integer.MAX_VALUE).build())
-                .build();
-
-        try (JsonParser p = createParser(jsonFactory, mode, DOC)) {
-            assertToken(JsonToken.START_ARRAY, p.nextToken());
-            assertToken(JsonToken.VALUE_NUMBER_FLOAT, p.nextToken());
-            p.getDoubleValue();
-        }
-    }
-
-    private void _testBigBigFloat(final int mode) throws Exception
-    {
-        final String num = "50."+BASE_FRACTION;
-        final String DOC = "[ "+num+" ]";
-
-        JsonFactory jsonFactory = jsonFactory()
-                .rebuild()
-                .streamReadConstraints(StreamReadConstraints.builder().maxNumberLength(Integer.MAX_VALUE).build())
-                .build();
-
-        try (JsonParser p = createParser(jsonFactory, mode, DOC)) {
-            assertToken(JsonToken.START_ARRAY, p.nextToken());
-            assertToken(JsonToken.VALUE_NUMBER_FLOAT, p.nextToken());
-            p.getFloatValue();
         }
     }
 

--- a/src/test/java/com/fasterxml/jackson/core/read/NumberParsingTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/read/NumberParsingTest.java
@@ -20,6 +20,31 @@ import com.fasterxml.jackson.core.json.JsonReadFeature;
 public class NumberParsingTest
     extends com.fasterxml.jackson.core.BaseTest
 {
+    private static final String BASE_FRACTION =
+            "01610253934481930774151441507943554511027782188707463024288149352877602369090537"
+                    +"80583522838238149455840874862907649203136651528841378405339370751798532555965157588"
+                    +"51877960056849468879933122908090021571162427934915567330612627267701300492535817858"
+                    +"36107216979078343419634586362681098115326893982589327952357032253344676618872460059"
+                    +"52652865429180458503533715200184512956356092484787210672008123556320998027133021328"
+                    +"04777044107393832707173313768807959788098545050700242134577863569636367439867566923"
+                    +"33479277494056927358573496400831024501058434838492057410330673302052539013639792877"
+                    +"76670882022964335417061758860066263335250076803973514053909274208258510365484745192"
+                    +"39425298649420795296781692303253055152441850691276044546565109657012938963181532017"
+                    +"97420631515930595954388119123373317973532146157980827838377034575940814574561703270"
+                    +"54949003909864767732479812702835339599792873405133989441135669998398892907338968744"
+                    +"39682249327621463735375868408190435590094166575473967368412983975580104741004390308"
+                    +"45302302121462601506802738854576700366634229106405188353120298347642313881766673834"
+                    +"60332729485083952142460470270121052469394888775064758246516888122459628160867190501"
+                    +"92476878886543996441778751825677213412487177484703116405390741627076678284295993334"
+                    +"23142914551517616580884277651528729927553693274406612634848943914370188078452131231"
+                    +"17351787166509190240927234853143290940647041705485514683182501795615082930770566118"
+                    +"77488417962195965319219352314664764649802231780262169742484818333055713291103286608"
+                    +"64318433253572997833038335632174050981747563310524775762280529871176578487487324067"
+                    +"90242862159403953039896125568657481354509805409457993946220531587293505986329150608"
+                    +"18702520420240989908678141379300904169936776618861221839938283876222332124814830207"
+                    +"073816864076428273177778788053613345444299361357958409716099682468768353446625063";
+
+
     protected JsonFactory jsonFactory() {
         return sharedStreamFactory();
     }
@@ -542,32 +567,74 @@ public class NumberParsingTest
         _testBigBigDecimals(MODE_DATA_INPUT, true);
     }
 
+    public void testBigBigDoubleDataInputFail() throws Exception
+    {
+        try {
+            // fails even though maxNumberLength is set to Integer.MAX_VALUE
+            _testBigBigDouble(MODE_DATA_INPUT);
+        } catch (JsonParseException jpe) {
+            assertTrue("unexpected exception message: " + jpe.getMessage(),
+                    jpe.getMessage().startsWith("Malformed numeric value ([number with 1824 characters])"));
+        }
+    }
+
+    public void testBigBigFloatDataInputFail() throws Exception
+    {
+        try {
+            // fails even though maxNumberLength is set to Integer.MAX_VALUE
+            _testBigBigFloat(MODE_DATA_INPUT);
+        } catch (JsonParseException jpe) {
+            assertTrue("unexpected exception message: " + jpe.getMessage(),
+                    jpe.getMessage().startsWith("Malformed numeric value ([number with 1824 characters])"));
+        }
+    }
+
+    public void testBigBigFloatReaderFail() throws Exception
+    {
+        try {
+            // fails even though maxNumberLength is set to Integer.MAX_VALUE
+            _testBigBigFloat(MODE_READER);
+        } catch (JsonParseException jpe) {
+            assertTrue("unexpected exception message: " + jpe.getMessage(),
+                    jpe.getMessage().startsWith("Malformed numeric value ([number with 1824 characters])"));
+        }
+    }
+
+    public void testBigBigFloatReaderThrottledFail() throws Exception
+    {
+        try {
+            // fails even though maxNumberLength is set to Integer.MAX_VALUE
+            _testBigBigFloat(MODE_READER_THROTTLED);
+        } catch (JsonParseException jpe) {
+            assertTrue("unexpected exception message: " + jpe.getMessage(),
+                    jpe.getMessage().startsWith("Malformed numeric value ([number with 1824 characters])"));
+        }
+    }
+
+    public void testBigBigFloatInputStreamFail() throws Exception
+    {
+        try {
+            // fails even though maxNumberLength is set to Integer.MAX_VALUE
+            _testBigBigFloat(MODE_INPUT_STREAM);
+        } catch (JsonParseException jpe) {
+            assertTrue("unexpected exception message: " + jpe.getMessage(),
+                    jpe.getMessage().startsWith("Malformed numeric value ([number with 1824 characters])"));
+        }
+    }
+
+    public void testBigBigFloatInputStreamThrottledFail() throws Exception
+    {
+        try {
+            // fails even though maxNumberLength is set to Integer.MAX_VALUE
+            _testBigBigFloat(MODE_INPUT_STREAM_THROTTLED);
+        } catch (JsonParseException jpe) {
+            assertTrue("unexpected exception message: " + jpe.getMessage(),
+                    jpe.getMessage().startsWith("Malformed numeric value ([number with 1824 characters])"));
+        }
+    }
+
     private void _testBigBigDecimals(final int mode, final boolean enableUnlimitedNumberLen) throws Exception
     {
-        final String BASE_FRACTION =
- "01610253934481930774151441507943554511027782188707463024288149352877602369090537"
-+"80583522838238149455840874862907649203136651528841378405339370751798532555965157588"
-+"51877960056849468879933122908090021571162427934915567330612627267701300492535817858"
-+"36107216979078343419634586362681098115326893982589327952357032253344676618872460059"
-+"52652865429180458503533715200184512956356092484787210672008123556320998027133021328"
-+"04777044107393832707173313768807959788098545050700242134577863569636367439867566923"
-+"33479277494056927358573496400831024501058434838492057410330673302052539013639792877"
-+"76670882022964335417061758860066263335250076803973514053909274208258510365484745192"
-+"39425298649420795296781692303253055152441850691276044546565109657012938963181532017"
-+"97420631515930595954388119123373317973532146157980827838377034575940814574561703270"
-+"54949003909864767732479812702835339599792873405133989441135669998398892907338968744"
-+"39682249327621463735375868408190435590094166575473967368412983975580104741004390308"
-+"45302302121462601506802738854576700366634229106405188353120298347642313881766673834"
-+"60332729485083952142460470270121052469394888775064758246516888122459628160867190501"
-+"92476878886543996441778751825677213412487177484703116405390741627076678284295993334"
-+"23142914551517616580884277651528729927553693274406612634848943914370188078452131231"
-+"17351787166509190240927234853143290940647041705485514683182501795615082930770566118"
-+"77488417962195965319219352314664764649802231780262169742484818333055713291103286608"
-+"64318433253572997833038335632174050981747563310524775762280529871176578487487324067"
-+"90242862159403953039896125568657481354509805409457993946220531587293505986329150608"
-+"18702520420240989908678141379300904169936776618861221839938283876222332124814830207"
-+"073816864076428273177778788053613345444299361357958409716099682468768353446625063";
-
         for (String asText : new String[] {
                 "50."+BASE_FRACTION,
                 "-37."+BASE_FRACTION,
@@ -592,6 +659,40 @@ public class NumberParsingTest
                 final BigDecimal exp = new BigDecimal(asText);
                 assertEquals(exp, p.getDecimalValue());
             }
+        }
+    }
+
+    private void _testBigBigDouble(final int mode) throws Exception
+    {
+        final String num = "50."+BASE_FRACTION;
+        final String DOC = "[ "+num+" ]";
+
+        JsonFactory jsonFactory = jsonFactory()
+                .rebuild()
+                .streamReadConstraints(StreamReadConstraints.builder().maxNumberLength(Integer.MAX_VALUE).build())
+                .build();
+
+        try (JsonParser p = createParser(jsonFactory, mode, DOC)) {
+            assertToken(JsonToken.START_ARRAY, p.nextToken());
+            assertToken(JsonToken.VALUE_NUMBER_FLOAT, p.nextToken());
+            p.getDoubleValue();
+        }
+    }
+
+    private void _testBigBigFloat(final int mode) throws Exception
+    {
+        final String num = "50."+BASE_FRACTION;
+        final String DOC = "[ "+num+" ]";
+
+        JsonFactory jsonFactory = jsonFactory()
+                .rebuild()
+                .streamReadConstraints(StreamReadConstraints.builder().maxNumberLength(Integer.MAX_VALUE).build())
+                .build();
+
+        try (JsonParser p = createParser(jsonFactory, mode, DOC)) {
+            assertToken(JsonToken.START_ARRAY, p.nextToken());
+            assertToken(JsonToken.VALUE_NUMBER_FLOAT, p.nextToken());
+            p.getFloatValue();
         }
     }
 

--- a/src/test/java/com/fasterxml/jackson/core/read/NumberParsingTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/read/NumberParsingTest.java
@@ -490,43 +490,6 @@ public class NumberParsingTest
     /**********************************************************************
      */
 
-    public void testBigBigDecimalsBytesFailByDefault() throws Exception
-    {
-        _testBigBigDecimals(MODE_INPUT_STREAM, true);
-        _testBigBigDecimals(MODE_INPUT_STREAM_THROTTLED, true);
-    }
-
-    public void testBigBigDecimalsBytes() throws Exception
-    {
-        try {
-            _testBigBigDecimals(MODE_INPUT_STREAM, false);
-        } catch (JsonParseException jpe) {
-            assertTrue("unexpected exception message: " + jpe.getMessage(),
-                    jpe.getMessage().startsWith("Malformed numeric value ([number with 1824 characters])"));
-        }
-        try {
-            _testBigBigDecimals(MODE_INPUT_STREAM_THROTTLED, false);
-        } catch (JsonParseException jpe) {
-            assertTrue("unexpected exception message: " + jpe.getMessage(),
-                    jpe.getMessage().startsWith("Malformed numeric value ([number with 1824 characters])"));
-        }
-    }
-
-    public void testBigBigDecimalsCharsFailByDefault() throws Exception
-    {
-        try {
-            _testBigBigDecimals(MODE_READER, false);
-        } catch (JsonParseException jpe) {
-            assertTrue("unexpected exception message: " + jpe.getMessage(),
-                    jpe.getMessage().startsWith("Malformed numeric value ([number with 1824 characters])"));
-        }
-    }
-
-    public void testBigBigDecimalsChars() throws Exception
-    {
-        _testBigBigDecimals(MODE_READER, true);
-    }
-
     public void testBigBigDecimalsFailByDefault() throws Exception
     {
         for (int mode : ALL_STREAMING_MODES) {
@@ -539,7 +502,7 @@ public class NumberParsingTest
         }
     }
 
-    public void testBigBigDecimalsDataInput() throws Exception
+    public void testBigBigDecimals() throws Exception
     {
         for (int mode : ALL_STREAMING_MODES) {
             _testBigBigDecimals(mode, true);


### PR DESCRIPTION
Relates to https://github.com/FasterXML/jackson-core/issues/869

Will need some updates in jackson-databind and jackson-dataformats libs too