### PR TITLE
deprecate method that is removed in v2.15 branch

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/util/TextBuffer.java
+++ b/src/main/java/com/fasterxml/jackson/core/util/TextBuffer.java
@@ -487,6 +487,7 @@ public final class TextBuffer
      *
      * @throws NumberFormatException if contents are not a valid Java number
      */
+    @Deprecated // @since 2.14.2
     public BigDecimal contentsAsDecimal() throws NumberFormatException
     {
         // Already got a pre-cut array?


### PR DESCRIPTION
This method is not used in main source of jackson-core (in 2.14 branch).

It was removed in recent 2.15 commits. Seems ok to remove it.

Just seems tidiest to flag it for deprecation in 2.14 branch.