### PR TITLE
change parseLong to try to improve performance

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/io/NumberInput.java
+++ b/src/main/java/com/fasterxml/jackson/core/io/NumberInput.java
@@ -190,14 +190,55 @@ public final class NumberInput
      */
     public static long parseLong(String s)
     {
-        // Ok, now; as the very first thing, let's just optimize case of "fake longs";
-        // that is, if we know they must be ints, call int parsing
-        int length = s.length();
-        if (length <= 9) {
-            return (long) parseInt(s);
+        /* Ok: let's keep strategy simple: ignoring optional minus sign,
+         * we'll accept 1 - 19 digits and parse things efficiently;
+         * otherwise just defer to JDK parse functionality.
+         */
+        char c = s.charAt(0);
+        int len = s.length();
+        boolean neg = (c == '-');
+        int offset = 1;
+        // must have 1 - 19 digits after optional sign:
+        // negative?
+        if (neg) {
+            if (len == 1 || len > 20) {
+                return Long.parseLong(s);
+            }
+            c = s.charAt(offset++);
+        } else {
+            if (len > 19) {
+                return Long.parseLong(s);
+            }
         }
-        // !!! TODO: implement efficient 2-int parsing...
-        return Long.parseLong(s);
+        if (c > '9' || c < '0') {
+            return Integer.parseInt(s);
+        }
+        long num = c - '0';
+        if (offset < len) {
+            c = s.charAt(offset++);
+            if (c > '9' || c < '0') {
+                return Long.parseLong(s);
+            }
+            num = (num * 10) + (c - '0');
+            if (offset < len) {
+                c = s.charAt(offset++);
+                if (c > '9' || c < '0') {
+                    return Long.parseLong(s);
+                }
+                num = (num * 10) + (c - '0');
+                // Let's just loop if we have more than 3 digits:
+                if (offset < len) {
+                    do {
+                        c = s.charAt(offset++);
+                        if (c > '9' || c < '0') {
+                            return Long.parseLong(s);
+                        }
+                        num = (num * 10) + (c - '0');
+                    } while (offset < len);
+                }
+            }
+        }
+        return neg ? -num : num;
     }
 
     /**

--- a/src/main/java/com/fasterxml/jackson/core/io/NumberInput.java
+++ b/src/main/java/com/fasterxml/jackson/core/io/NumberInput.java
@@ -211,7 +211,7 @@ public final class NumberInput
             }
         }
         if (c > '9' || c < '0') {
-            return Integer.parseInt(s);
+            return Long.parseLong(s);
         }
         long num = c - '0';
         if (offset < len) {


### PR DESCRIPTION
I changed NumberInput.parseLong(String) to work more like NumberInput,parseInt(String). Iterating over the chars and scaling them and added the scaled results.

Recent changes added a parseLong19 but this is unaffected by this change (it is used by a different code path).

This seems to have improved performance based on https://github.com/pjfanning/jackson-number-parse-bench/commit/f86dfcbead34cf60a6aeb0b31f4782dbfd582c23

Tested using Java 8 on my Macbook:
```
Benchmark                               Mode  Cnt      Score     Error  Units
LongParserBench.alternateJacksonParse  thrpt    5  25442.760 ± 212.009  ops/s
LongParserBench.existingJacksonParse   thrpt    5  14697.121 ± 323.988  ops/s
```

With Java 17, the performance results see the existingJacksonParse almost catch up (but there is still a non-trivial advantage to alternateJacksonParse).

Only open for discussion at the moment - @marschall, @cowtowncoder  could you have a look?