### PR TITLE
Allow FilteringParserDelegate to skip last elements in array

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/filter/FilteringParserDelegate.java
+++ b/src/main/java/com/fasterxml/jackson/core/filter/FilteringParserDelegate.java
@@ -754,6 +754,11 @@ public class FilteringParserDelegate extends JsonParserDelegate
                     if (returnEnd) {
                         return t;
                     }
+                    if (gotEnd /*|| (_headContext == buffRoot)
+                    this makes BasicParserFilteringTest.testNotAllowMultipleMatchesWithPath4 fail
+                    */) {
+                        return null;
+                    }
                 }
                 continue main_loop;
             case ID_END_OBJECT:
@@ -780,6 +785,11 @@ public class FilteringParserDelegate extends JsonParserDelegate
 
                 if (returnEnd) {
                     return t;
+                }
+                if (gotEnd /*|| (_headContext == buffRoot)
+                    this makes BasicParserFilteringTest.testNotAllowMultipleMatchesWithPath4 fail
+                */) {
+                    return null;
                 }
             }
             continue main_loop;

--- a/src/main/java/com/fasterxml/jackson/core/filter/FilteringParserDelegate.java
+++ b/src/main/java/com/fasterxml/jackson/core/filter/FilteringParserDelegate.java
@@ -754,11 +754,6 @@ public class FilteringParserDelegate extends JsonParserDelegate
                     if (returnEnd) {
                         return t;
                     }
-                    if (gotEnd /*|| (_headContext == buffRoot)
-                    this makes BasicParserFilteringTest.testNotAllowMultipleMatchesWithPath4 fail
-                    */) {
-                        return null;
-                    }
                 }
                 continue main_loop;
             case ID_END_OBJECT:
@@ -786,9 +781,7 @@ public class FilteringParserDelegate extends JsonParserDelegate
                 if (returnEnd) {
                     return t;
                 }
-                if (gotEnd /*|| (_headContext == buffRoot)
-                    this makes BasicParserFilteringTest.testNotAllowMultipleMatchesWithPath4 fail
-                */) {
+                if (gotEnd) {
                     return null;
                 }
             }

--- a/src/main/java/com/fasterxml/jackson/core/filter/FilteringParserDelegate.java
+++ b/src/main/java/com/fasterxml/jackson/core/filter/FilteringParserDelegate.java
@@ -754,9 +754,9 @@ public class FilteringParserDelegate extends JsonParserDelegate
                     if (returnEnd) {
                         return t;
                     }
-//                    if (gotEnd) {
-//                        return null;
-//                    }
+                    if (gotEnd) {
+                        return null;
+                    }
                 }
                 continue main_loop;
             case ID_END_OBJECT:

--- a/src/main/java/com/fasterxml/jackson/core/filter/FilteringParserDelegate.java
+++ b/src/main/java/com/fasterxml/jackson/core/filter/FilteringParserDelegate.java
@@ -754,6 +754,9 @@ public class FilteringParserDelegate extends JsonParserDelegate
                     if (returnEnd) {
                         return t;
                     }
+//                    if (gotEnd) {
+//                        return null;
+//                    }
                 }
                 continue main_loop;
             case ID_END_OBJECT:

--- a/src/test/java/com/fasterxml/jackson/core/filter/BasicParserFilteringTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/filter/BasicParserFilteringTest.java
@@ -753,4 +753,14 @@ public class BasicParserFilteringTest extends BaseTest
         );
         assertEquals(a2q("{'parent':[{'include-1':1},{'include-2':2}]}"), readAndWrite(JSON_F, p));
     }
+    public void testExcludeLastArrayInsideArray() throws Exception {
+        JsonParser p0 = JSON_F.createParser(a2q(
+                "['skipped', [], ['skipped']]"));
+        JsonParser p = new FilteringParserDelegate(p0,
+                INCLUDE_EMPTY_IF_NOT_FILTERED,
+                Inclusion.INCLUDE_ALL_AND_PATH,
+                true // multipleMatches
+        );
+        assertEquals(a2q("[[]]"), readAndWrite(JSON_F, p));
+    }
 }

--- a/src/test/java/com/fasterxml/jackson/core/filter/BasicParserFilteringTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/filter/BasicParserFilteringTest.java
@@ -729,7 +729,6 @@ public class BasicParserFilteringTest extends BaseTest
                 false // multipleMatches
         );
         assertEquals(a2q("{'parent':[{'include':true}]}"), readAndWrite(JSON_F, p));
-
     }
 
     public void testExcludeObjectAtTheEndOfArray() throws Exception {
@@ -753,6 +752,7 @@ public class BasicParserFilteringTest extends BaseTest
         );
         assertEquals(a2q("{'parent':[{'include-1':1},{'include-2':2}]}"), readAndWrite(JSON_F, p));
     }
+
     public void testExcludeLastArrayInsideArray() throws Exception {
         JsonParser p0 = JSON_F.createParser(a2q(
                 "['skipped', [], ['skipped']]"));


### PR DESCRIPTION
FilteringParserDelegate when parsing ID_END_ARRAY or ID_END_OBJECT of the skipped element (when `_headContext.isStartHandled() == false` should be able to exit the loop and continue parsing next tokens. 

This logic was changed accidentally removed in https://github.com/FasterXML/jackson-core/commit/7db467ddec7c2899038249b55695b7e44c7b5c3e#diff-f6642caef61e0c403f51a6150ecf45263034fca5002782fd02eacd01e53fe549L694

closes https://github.com/FasterXML/jackson-core/issues/882