### PR TITLE
support latest fastdoubleparser release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -239,7 +239,7 @@ com.fasterxml.jackson.core.*;version=${project.version}
     <dependency>
       <groupId>ch.randelshofer</groupId>
       <artifactId>fastdoubleparser</artifactId>
-      <version>0.5.4</version>
+      <version>0.6.0</version>
     </dependency>
     <!-- Test dependencies -->
     <dependency>

--- a/src/main/java/com/fasterxml/jackson/core/io/BigIntegerParser.java
+++ b/src/main/java/com/fasterxml/jackson/core/io/BigIntegerParser.java
@@ -26,4 +26,15 @@ public final class BigIntegerParser
                     + "\" can not be represented as `java.math.BigDecimal`, reason: " + nfe.getMessage());
         }
     }
+
+    public static BigInteger parseWithFastParser(final String valueStr, final int radix) {
+        try {
+            return JavaBigIntegerParser.parseBigInteger(valueStr, radix);
+        } catch (NumberFormatException nfe) {
+            final String reportNum = valueStr.length() <= MAX_CHARS_TO_REPORT ?
+                    valueStr : valueStr.substring(0, MAX_CHARS_TO_REPORT) + " [truncated]";
+            throw new NumberFormatException("Value \"" + reportNum
+                    + "\" can not be represented as `java.math.BigDecimal`, reason: " + nfe.getMessage());
+        }
+    }
 }

--- a/src/main/java/com/fasterxml/jackson/core/io/BigIntegerParser.java
+++ b/src/main/java/com/fasterxml/jackson/core/io/BigIntegerParser.java
@@ -23,7 +23,7 @@ public final class BigIntegerParser
             final String reportNum = valueStr.length() <= MAX_CHARS_TO_REPORT ?
                     valueStr : valueStr.substring(0, MAX_CHARS_TO_REPORT) + " [truncated]";
             throw new NumberFormatException("Value \"" + reportNum
-                    + "\" can not be represented as `java.math.BigDecimal`, reason: " + nfe.getMessage());
+                    + "\" can not be represented as `java.math.BigInteger`, reason: " + nfe.getMessage());
         }
     }
 
@@ -34,7 +34,8 @@ public final class BigIntegerParser
             final String reportNum = valueStr.length() <= MAX_CHARS_TO_REPORT ?
                     valueStr : valueStr.substring(0, MAX_CHARS_TO_REPORT) + " [truncated]";
             throw new NumberFormatException("Value \"" + reportNum
-                    + "\" can not be represented as `java.math.BigDecimal`, reason: " + nfe.getMessage());
+                    + "\" can not be represented as `java.math.BigInteger` with radix " + radix +
+                    ", reason: " + nfe.getMessage());
         }
     }
 }

--- a/src/main/java/com/fasterxml/jackson/core/io/NumberInput.java
+++ b/src/main/java/com/fasterxml/jackson/core/io/NumberInput.java
@@ -513,4 +513,21 @@ public final class NumberInput
             return parseBigInteger(s);
         }
     }
+
+    /**
+     * @param s a string representing a number to parse
+     * @param radix for parse
+     * @param useFastParser whether to use custom fast parser (true) or JDK default (false) parser
+     * @return a BigInteger
+     * @throws NumberFormatException if string cannot be represented by a BigInteger
+     * @since v2.15
+     */
+    public static BigInteger parseBigIntegerWithRadix(final String s, final int radix,
+                                                      final boolean useFastParser) throws NumberFormatException {
+        if (useFastParser) {
+            return BigIntegerParser.parseWithFastParser(s, radix);
+        } else {
+            return new BigInteger(s, radix);
+        }
+    }
 }

--- a/src/test/java/com/fasterxml/jackson/core/io/BigIntegerParserTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/io/BigIntegerParserTest.java
@@ -1,9 +1,10 @@
 package com.fasterxml.jackson.core.io;
 
-public class BigDecimalParserTest extends com.fasterxml.jackson.core.BaseTest {
-    public void testLongStringParse() {
+public class BigIntegerParserTest extends com.fasterxml.jackson.core.BaseTest {
+
+    public void testLongStringFastParseBigInteger() {
         try {
-            BigDecimalParser.parse(genLongString());
+            BigIntegerParser.parseWithFastParser(genLongString());
             fail("expected NumberFormatException");
         } catch (NumberFormatException nfe) {
             assertTrue("exception message starts as expected?", nfe.getMessage().startsWith("Value \"AAAAA"));
@@ -11,9 +12,9 @@ public class BigDecimalParserTest extends com.fasterxml.jackson.core.BaseTest {
         }
     }
 
-    public void testLongStringFastParse() {
+    public void testLongStringFastParseBigIntegerRadix() {
         try {
-            BigDecimalParser.parseWithFastParser(genLongString());
+            BigIntegerParser.parseWithFastParser(genLongString(), 8);
             fail("expected NumberFormatException");
         } catch (NumberFormatException nfe) {
             assertTrue("exception message starts as expected?", nfe.getMessage().startsWith("Value \"AAAAA"));
@@ -21,7 +22,12 @@ public class BigDecimalParserTest extends com.fasterxml.jackson.core.BaseTest {
         }
     }
 
-    private String genLongString() {
-        return BigIntegerParserTest.genLongString();
+    static String genLongString() {
+        final int len = 1500;
+        final StringBuilder sb = new StringBuilder(len);
+        for (int i = 0; i < len; i++) {
+            sb.append("A");
+        }
+        return sb.toString();
     }
 }

--- a/src/test/java/com/fasterxml/jackson/core/io/BigIntegerParserTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/io/BigIntegerParserTest.java
@@ -8,7 +8,8 @@ public class BigIntegerParserTest extends com.fasterxml.jackson.core.BaseTest {
             fail("expected NumberFormatException");
         } catch (NumberFormatException nfe) {
             assertTrue("exception message starts as expected?", nfe.getMessage().startsWith("Value \"AAAAA"));
-            assertTrue("exception message value contains truncated", nfe.getMessage().contains("truncated"));
+            assertTrue("exception message value contains: truncated", nfe.getMessage().contains("truncated"));
+            assertTrue("exception message value contains: BigInteger", nfe.getMessage().contains("BigInteger"));
         }
     }
 
@@ -18,7 +19,9 @@ public class BigIntegerParserTest extends com.fasterxml.jackson.core.BaseTest {
             fail("expected NumberFormatException");
         } catch (NumberFormatException nfe) {
             assertTrue("exception message starts as expected?", nfe.getMessage().startsWith("Value \"AAAAA"));
-            assertTrue("exception message value contains truncated", nfe.getMessage().contains("truncated"));
+            assertTrue("exception message value contains: truncated", nfe.getMessage().contains("truncated"));
+            assertTrue("exception message value contains: radix 8", nfe.getMessage().contains("radix 8"));
+            assertTrue("exception message value contains: BigInteger", nfe.getMessage().contains("BigInteger"));
         }
     }
 

--- a/src/test/java/com/fasterxml/jackson/core/io/TestNumberInput.java
+++ b/src/test/java/com/fasterxml/jackson/core/io/TestNumberInput.java
@@ -43,5 +43,14 @@ public class TestNumberInput
         assertEquals(new BigInteger(test2000), NumberInput.parseBigInteger(test2000));
         assertEquals(new BigInteger(test2000), NumberInput.parseBigInteger(test2000, true));
     }
+
+    public void testBigIntegerWithRadix()
+    {
+        final String val = "1ABCDEF";
+        final int radix = 16;
+        BigInteger expected = new BigInteger(val, radix);
+        assertEquals(expected, NumberInput.parseBigIntegerWithRadix(val, radix, true));
+        assertEquals(expected, NumberInput.parseBigIntegerWithRadix(val, radix, false));
+    }
 }
 


### PR DESCRIPTION
* https://github.com/wrandelshofer/FastDoubleParser/releases/tag/v0.6.0
* new release supports BigIntegers with radixes - some jackson-datafomats-text code supports this, so adding NumberInput support seems useful