### PR TITLE
shading jar exclude is causing failures in downstream projects

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -157,14 +157,6 @@ com.fasterxml.jackson.core.*;version=${project.version}
           <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
           <createDependencyReducedPom>true</createDependencyReducedPom>
           <minimizeJar>true</minimizeJar>
-          <filters>
-            <filter>
-              <artifact>*:*</artifact>
-              <excludes>
-                <exclude>**/*FromCharArray*</exclude>
-              </excludes>
-            </filter>
-          </filters>
         </configuration>
         <executions>
           <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -161,7 +161,6 @@ com.fasterxml.jackson.core.*;version=${project.version}
             <filter>
               <artifact>*:*</artifact>
               <excludes>
-                <exclude>**/*FromByteArray*</exclude>
                 <exclude>**/*FromCharArray*</exclude>
               </excludes>
             </filter>


### PR DESCRIPTION
* https://github.com/FasterXML/jackson-dataformats-text/pull/367
* looks like fastdoubleparser code has been refactored and that we can't exclude these classes any more