### PR TITLE
make float and double parsing lazy

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/base/ParserBase.java
+++ b/src/main/java/com/fasterxml/jackson/core/base/ParserBase.java
@@ -929,7 +929,7 @@ public abstract class ParserBase extends ParserMinimalBase
         return _numberInt;
     }
 
-    private void _parseSlowFloat(int expType) throws IOException
+    private void _parseSlowFloat(int expType)
     {
         /* Nope: floating point. Here we need to be careful to get
          * optimal parsing strategy: choice is between accurate but


### PR DESCRIPTION
* matches what we do for BigDecimal/BigInteger
* also helps with cases where we might initially choose wrong number type and then need a different type later
  * for instance, if we initially choose 'double' and then need a BigDecimal - in the past, we would have done a lossy conversion to double - so the BigDecimal could have a rounding issue 
  * leaving the underlying value as a string, means that in he example above, the BigDecimal can be parsed from the original text and no double parsing will happen