### PR TITLE
Implement JsonParser.getNumberValueDeferred(), add tests

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/JsonParser.java
+++ b/src/main/java/com/fasterxml/jackson/core/JsonParser.java
@@ -1661,6 +1661,37 @@ public abstract class JsonParser
     }
 
     /**
+     * Method similar to {@link #getNumberValue} but that returns
+     * <b>either</b> same {@link Number} value as {@link #getNumberValue()}
+     * (if already decoded), <b>or</b> {@code String} representation of
+     * as-of-yet undecoded number.
+     * Typically textual formats allow deferred decoding from String, whereas
+     * binary formats either decode numbers eagerly or have binary representation
+     * from which to decode value to return.
+     *<p>
+     * Same constraints apply to calling this method as to {@link #getNumberValue()}:
+     * current token must be either
+     * {@link JsonToken#VALUE_NUMBER_INT} or
+     * {@link JsonToken#VALUE_NUMBER_FLOAT};
+     * otherwise an exception is thrown
+     *<p>
+     * Default implementation simply returns {@link #getNumberValue()}
+     * 
+     * @return Either {@link Number} (for already decoded numbers) or
+     *   {@link String} (for deferred decoding).
+     *
+     * @throws IOException Problem with access: {@link JsonParseException} if
+     *    the current token is not numeric, or if decoding of the value fails
+     *    (invalid format for numbers); plain {@link IOException} if underlying
+     *    content read fails (possible if values are extracted lazily)
+     *
+     * @since 2.15
+     */
+    public Object getNumberValueDeferred() throws IOException {
+        return getNumberValue();
+    }
+
+    /**
      * If current token is of type 
      * {@link JsonToken#VALUE_NUMBER_INT} or
      * {@link JsonToken#VALUE_NUMBER_FLOAT}, returns

--- a/src/main/java/com/fasterxml/jackson/core/base/ParserBase.java
+++ b/src/main/java/com/fasterxml/jackson/core/base/ParserBase.java
@@ -694,6 +694,50 @@ public abstract class ParserBase extends ParserMinimalBase
         return _getNumberDouble();
     }
 
+    @Override // since 2.15
+    public Object getNumberValueDeferred() throws IOException
+    {
+        if (_currToken == JsonToken.VALUE_NUMBER_INT) {
+            if (_numTypesValid == NR_UNKNOWN) {
+                _parseNumericValue(NR_UNKNOWN);
+            }
+            if ((_numTypesValid & NR_INT) != 0) {
+                return _numberInt;
+            }
+            if ((_numTypesValid & NR_LONG) != 0) {
+                return _numberLong;
+            }
+            if ((_numTypesValid & NR_BIGINT) != 0) {
+                // from _getBigInteger()
+                if (_numberBigInt != null) {
+                    return _numberBigInt;
+                } else if (_numberString != null) {
+                    return _numberString;
+                }
+                return _getBigInteger(); // will fail
+            }
+            _throwInternal();
+        }
+        if (_currToken == JsonToken.VALUE_NUMBER_FLOAT) {
+            // Ok this gets tricky since flags are not set quite as with
+            // integers
+            if ((_numTypesValid & NR_BIGDECIMAL) != 0) {
+                return _getBigDecimal();
+            }
+            if ((_numTypesValid & NR_DOUBLE) != 0) { // sanity check
+                return _getNumberDouble();
+            }
+            if ((_numTypesValid & NR_FLOAT) != 0) {
+                return _getNumberFloat();
+            }
+            // Should be able to rely on this; might want to set _numberString
+            // but state keeping looks complicated so don't do that yet
+            return _textBuffer.contentsAsString();
+        }
+        // We'll just force exception by:
+        return getNumberValue();
+    }
+
     @Override
     public NumberType getNumberType() throws IOException
     {

--- a/src/main/java/com/fasterxml/jackson/core/util/JsonParserDelegate.java
+++ b/src/main/java/com/fasterxml/jackson/core/util/JsonParserDelegate.java
@@ -226,6 +226,9 @@ public class JsonParserDelegate extends JsonParser
     @Override
     public Number getNumberValueExact() throws IOException { return delegate.getNumberValueExact(); }
 
+    @Override
+    public Object getNumberValueDeferred() throws IOException { return delegate.getNumberValueDeferred(); }
+
     /*
     /**********************************************************************
     /* Public API, access to token information, coercion/conversion

--- a/src/test/java/com/fasterxml/jackson/core/json/async/AsyncNumberCoercionTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/json/async/AsyncNumberCoercionTest.java
@@ -13,7 +13,7 @@ import com.fasterxml.jackson.core.JsonToken;
 
 public class AsyncNumberCoercionTest extends AsyncTestBase
 {
-    private final JsonFactory JSON_F = new JsonFactory();
+    private final JsonFactory JSON_F = newStreamFactory();
 
     /*
     /**********************************************************

--- a/src/test/java/com/fasterxml/jackson/core/json/async/AsyncNumberDeferredReadTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/json/async/AsyncNumberDeferredReadTest.java
@@ -1,0 +1,127 @@
+package com.fasterxml.jackson.core.json.async;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParser.NumberType;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.core.async.AsyncTestBase;
+import com.fasterxml.jackson.core.testsupport.AsyncReaderWrapper;
+
+public class AsyncNumberDeferredReadTest extends AsyncTestBase
+{
+    private final JsonFactory JSON_F = newStreamFactory();
+
+    /*
+    /**********************************************************************
+    /* Tests, integral types
+    /**********************************************************************
+     */
+
+    // Int, long eagerly decoded, always
+    public void testDeferredInt() throws Exception
+    {
+        // trailing space to avoid problems with DataInput
+        try (AsyncReaderWrapper p = createParser(" 12345 ")) {
+            assertToken(JsonToken.VALUE_NUMBER_INT, p.nextToken());
+            assertEquals(Integer.valueOf(12345), p.getNumberValueDeferred());
+            assertEquals(NumberType.INT, p.getNumberType());
+            assertNull(p.nextToken());
+        }
+    }
+
+    public void testDeferredLong() throws Exception
+    {
+        final long value = 100L + Integer.MAX_VALUE;
+        try (AsyncReaderWrapper p = createParser(" "+value+" ")) {
+            assertToken(JsonToken.VALUE_NUMBER_INT, p.nextToken());
+            assertEquals(Long.valueOf(value), p.getNumberValueDeferred());
+            assertEquals(NumberType.LONG, p.getNumberType());
+            assertNull(p.nextToken());
+        }
+    }
+
+    public void testDeferredBigInteger() throws Exception
+    {
+        BigInteger value = BigInteger.valueOf(Long.MAX_VALUE).add(BigInteger.TEN);
+        try (AsyncReaderWrapper p = createParser(" "+value+" ")) {
+            assertToken(JsonToken.VALUE_NUMBER_INT, p.nextToken());
+            assertEquals(NumberType.BIG_INTEGER, p.getNumberType());
+            Object nr = p.getNumberValueDeferred();
+            assertEquals(String.class, nr.getClass());
+            assertEquals(value.toString(), nr);
+
+            // But if forced to, we'll get BigInteger
+            assertEquals(value, p.getBigIntegerValue());
+            assertEquals(value, p.getNumberValueDeferred());
+        }
+    }
+
+    /*
+    /**********************************************************************
+    /* Tests, floating point types
+    /**********************************************************************
+     */
+
+    public void testDeferredFloatingPoint() throws Exception
+    {
+        // Try with BigDecimal/Double/Float; work very similarly
+        try (AsyncReaderWrapper p = createParser(" 0.25 ")) {
+            BigDecimal value = new BigDecimal("0.25");
+            assertToken(JsonToken.VALUE_NUMBER_FLOAT, p.nextToken());
+
+            // NOTE! Important NOT to call "p.getNumberType()" as that'll fix
+            // type to Double...
+            Object nr = p.getNumberValueDeferred();
+            assertEquals(String.class, nr.getClass());
+            assertEquals(value.toString(), nr);
+
+            // But if forced to, we'll get BigInteger
+            assertEquals(value, p.getDecimalValue());
+            assertEquals(value, p.getNumberValueDeferred());
+            assertEquals(NumberType.BIG_DECIMAL, p.getNumberType());
+        }
+
+        try (AsyncReaderWrapper p = createParser(" 0.25 ")) {
+            Double value = 0.25d;
+            assertToken(JsonToken.VALUE_NUMBER_FLOAT, p.nextToken());
+
+            Object nr = p.getNumberValueDeferred();
+            assertEquals(String.class, nr.getClass());
+            assertEquals(value.toString(), nr);
+
+            // But if forced to, we'll get BigInteger
+            assertEquals(value, p.getDoubleValue());
+            assertEquals(value, p.getNumberValueDeferred());
+            assertEquals(NumberType.DOUBLE, p.getNumberType());
+        }
+
+        try (AsyncReaderWrapper p = createParser(" 0.25 ")) {
+            Float value = 0.25f;
+            assertToken(JsonToken.VALUE_NUMBER_FLOAT, p.nextToken());
+
+            Object nr = p.getNumberValueDeferred();
+            assertEquals(String.class, nr.getClass());
+            assertEquals(value.toString(), nr);
+
+            // But if forced to, we'll get BigInteger
+            assertEquals(value, p.getFloatValue());
+            assertEquals(value, p.getNumberValueDeferred());
+            assertEquals(NumberType.FLOAT, p.getNumberType());
+        }
+    }
+
+    /*
+    /**********************************************************************
+    /* Helper methods
+    /**********************************************************************
+     */
+
+    private AsyncReaderWrapper createParser(String doc) throws IOException
+    {
+        return asyncForBytes(JSON_F, 1, _jsonDoc(doc), 1);
+    }
+
+}

--- a/src/test/java/com/fasterxml/jackson/core/read/NumberDeferredReadTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/read/NumberDeferredReadTest.java
@@ -1,0 +1,148 @@
+package com.fasterxml.jackson.core.read;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonParser.NumberType;
+import com.fasterxml.jackson.core.JsonToken;
+
+public class NumberDeferredReadTest
+    extends com.fasterxml.jackson.core.BaseTest
+{
+    protected JsonFactory jsonFactory() {
+        return sharedStreamFactory();
+    }
+
+    /*
+    /**********************************************************************
+    /* Tests, integral types
+    /**********************************************************************
+     */
+
+    // Int, long eagerly decoded, always
+    public void testDeferredInt() throws Exception
+    {
+        _testDeferredInt(MODE_INPUT_STREAM);
+        _testDeferredInt(MODE_INPUT_STREAM_THROTTLED);
+        _testDeferredInt(MODE_READER);
+        _testDeferredInt(MODE_DATA_INPUT);
+    }
+
+    private void _testDeferredInt(int mode) throws Exception
+    {
+        // trailing space to avoid problems with DataInput
+        try (JsonParser p = createParser(jsonFactory(), mode, " 12345 ")) {
+            assertToken(JsonToken.VALUE_NUMBER_INT, p.nextToken());
+            assertEquals(Integer.valueOf(12345), p.getNumberValueDeferred());
+            assertEquals(NumberType.INT, p.getNumberType());
+            assertNull(p.nextToken());
+        }
+    }
+
+    public void testDeferredLong() throws Exception
+    {
+        _testDeferredLong(MODE_INPUT_STREAM);
+        _testDeferredLong(MODE_INPUT_STREAM_THROTTLED);
+        _testDeferredLong(MODE_READER);
+        _testDeferredLong(MODE_DATA_INPUT);
+    }
+
+    private void _testDeferredLong(int mode) throws Exception
+    {
+        final long value = 100L + Integer.MAX_VALUE;
+        try (JsonParser p = createParser(jsonFactory(), mode, " "+value+" ")) {
+            assertToken(JsonToken.VALUE_NUMBER_INT, p.nextToken());
+            assertEquals(Long.valueOf(value), p.getNumberValueDeferred());
+            assertEquals(NumberType.LONG, p.getNumberType());
+            assertNull(p.nextToken());
+        }
+    }
+
+    public void testDeferredBigInteger() throws Exception
+    {
+        _testDeferredBigInteger(MODE_INPUT_STREAM);
+        _testDeferredBigInteger(MODE_INPUT_STREAM_THROTTLED);
+        _testDeferredBigInteger(MODE_READER);
+        _testDeferredBigInteger(MODE_DATA_INPUT);
+    }
+
+    private void _testDeferredBigInteger(int mode) throws Exception
+    {
+        BigInteger value = BigInteger.valueOf(Long.MAX_VALUE).add(BigInteger.TEN);
+        try (JsonParser p = createParser(jsonFactory(), mode, " "+value+" ")) {
+            assertToken(JsonToken.VALUE_NUMBER_INT, p.nextToken());
+            assertEquals(NumberType.BIG_INTEGER, p.getNumberType());
+            Object nr = p.getNumberValueDeferred();
+            assertEquals(String.class, nr.getClass());
+            assertEquals(value.toString(), nr);
+
+            // But if forced to, we'll get BigInteger
+            assertEquals(value, p.getBigIntegerValue());
+            assertEquals(value, p.getNumberValueDeferred());
+        }
+    }
+
+    /*
+    /**********************************************************************
+    /* Tests, floating point types
+    /**********************************************************************
+     */
+
+    public void testDeferredFloatingPoint() throws Exception
+    {
+        _testDeferredFloatingPoint(MODE_INPUT_STREAM);
+        _testDeferredFloatingPoint(MODE_INPUT_STREAM_THROTTLED);
+        _testDeferredFloatingPoint(MODE_READER);
+        _testDeferredFloatingPoint(MODE_DATA_INPUT);
+    }
+
+    private void _testDeferredFloatingPoint(int mode) throws Exception
+    {
+        // Try with BigDecimal/Double/Float; work very similarly
+        try (JsonParser p = createParser(jsonFactory(), mode, " 0.25 ")) {
+            BigDecimal value = new BigDecimal("0.25");
+            assertToken(JsonToken.VALUE_NUMBER_FLOAT, p.nextToken());
+
+            // NOTE! Important NOT to call "p.getNumberType()" as that'll fix
+            // type to Double...
+            Object nr = p.getNumberValueDeferred();
+            assertEquals(String.class, nr.getClass());
+            assertEquals(value.toString(), nr);
+
+            // But if forced to, we'll get BigInteger
+            assertEquals(value, p.getDecimalValue());
+            assertEquals(value, p.getNumberValueDeferred());
+            assertEquals(NumberType.BIG_DECIMAL, p.getNumberType());
+        }
+
+        try (JsonParser p = createParser(jsonFactory(), mode, " 0.25 ")) {
+            Double value = 0.25d;
+            assertToken(JsonToken.VALUE_NUMBER_FLOAT, p.nextToken());
+
+            Object nr = p.getNumberValueDeferred();
+            assertEquals(String.class, nr.getClass());
+            assertEquals(value.toString(), nr);
+
+            // But if forced to, we'll get BigInteger
+            assertEquals(value, p.getDoubleValue());
+            assertEquals(value, p.getNumberValueDeferred());
+            assertEquals(NumberType.DOUBLE, p.getNumberType());
+        }
+
+        try (JsonParser p = createParser(jsonFactory(), mode, " 0.25 ")) {
+            Float value = 0.25f;
+            assertToken(JsonToken.VALUE_NUMBER_FLOAT, p.nextToken());
+
+            Object nr = p.getNumberValueDeferred();
+            assertEquals(String.class, nr.getClass());
+            assertEquals(value.toString(), nr);
+
+            // But if forced to, we'll get BigInteger
+            assertEquals(value, p.getFloatValue());
+            assertEquals(value, p.getNumberValueDeferred());
+            assertEquals(NumberType.FLOAT, p.getNumberType());
+        }
+    }
+}

--- a/src/test/java/com/fasterxml/jackson/core/testsupport/AsyncReaderWrapper.java
+++ b/src/test/java/com/fasterxml/jackson/core/testsupport/AsyncReaderWrapper.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.core.JsonStreamContext;
 import com.fasterxml.jackson.core.JsonToken;
 
 public abstract class AsyncReaderWrapper
+    implements AutoCloseable
 {
     protected final JsonParser _streamReader;
 
@@ -69,6 +70,9 @@ public abstract class AsyncReaderWrapper
     public Number getNumberValue() throws IOException { return _streamReader.getNumberValue(); }
     public NumberType getNumberType() throws IOException { return _streamReader.getNumberType(); }
 
+    public Object getNumberValueDeferred() throws IOException { return _streamReader.getNumberValueDeferred(); }
+
+    @Override
     public void close() throws IOException { _streamReader.close(); }
 
     public boolean isClosed() {


### PR DESCRIPTION
So here is my suggested alternative for #893. Instead of adding wrappers here, use bit of polymorphism and let caller handle distinctions: in case of databind `TokenBuffer` I think it works fine and allows deferring decoding which is beneficial for 2 things:

1. Deferring decision of "right" floating-point type to use (`BigDecimal` vs `Double`/`Float`) until we know what that is
2. Avoiding decoding altogether in case number value is to be skipped (case for `@JsonCreator` handling, esp. affects Kotlin and Scala modules), only holding on to `String` until value is actually needed

