### PR TITLE
Remove ThreadLocals from schubfach code

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/io/schubfach/DoubleToDecimal.java
+++ b/src/main/java/com/fasterxml/jackson/core/io/schubfach/DoubleToDecimal.java
@@ -22,8 +22,6 @@
 
 package com.fasterxml.jackson.core.io.schubfach;
 
-import java.io.IOException;
-
 import static com.fasterxml.jackson.core.io.schubfach.MathUtils.flog10pow2;
 import static com.fasterxml.jackson.core.io.schubfach.MathUtils.flog10threeQuartersPow2;
 import static com.fasterxml.jackson.core.io.schubfach.MathUtils.flog2pow10;
@@ -122,9 +120,6 @@ final public class DoubleToDecimal {
 
     // Numerical results are created here...
     private final byte[] bytes = new byte[MAX_CHARS];
-
-    // ... and copied here in appendTo()
-    private final char[] chars = new char[MAX_CHARS];
 
     // Index into bytes of rightmost valid character.
     private int index;
@@ -249,22 +244,6 @@ final public class DoubleToDecimal {
         return threadLocalInstance().toDecimalString(v);
     }
 
-    /**
-     * Appends the rendering of the {@code v} to {@code app}.
-     *
-     * <p>The outcome is the same as if {@code v} were first
-     * {@link #toString(double) rendered} and the resulting string were then
-     * {@link Appendable#append(CharSequence) appended} to {@code app}.
-     *
-     * @param v the {@code double} whose rendering is appended.
-     * @param app the {@link Appendable} to append to.
-     * @throws IOException If an I/O error occurs
-     */
-    public static Appendable appendTo(double v, Appendable app)
-            throws IOException {
-        return threadLocalInstance().appendDecimalTo(v, app);
-    }
-
     private static DoubleToDecimal threadLocalInstance() {
         return threadLocal.get();
     }
@@ -277,31 +256,6 @@ final public class DoubleToDecimal {
             case PLUS_INF: return "Infinity";
             case MINUS_INF: return "-Infinity";
             default: return "NaN";
-        }
-    }
-
-    private Appendable appendDecimalTo(double v, Appendable app)
-            throws IOException {
-        switch (toDecimal(v)) {
-            case NON_SPECIAL:
-                for (int i = 0; i <= index; ++i) {
-                    chars[i] = (char) bytes[i];
-                }
-                if (app instanceof StringBuilder) {
-                    return ((StringBuilder) app).append(chars, 0, index + 1);
-                }
-                if (app instanceof StringBuffer) {
-                    return ((StringBuffer) app).append(chars, 0, index + 1);
-                }
-                for (int i = 0; i <= index; ++i) {
-                    app.append(chars[i]);
-                }
-                return app;
-            case PLUS_ZERO: return app.append("0.0");
-            case MINUS_ZERO: return app.append("-0.0");
-            case PLUS_INF: return app.append("Infinity");
-            case MINUS_INF: return app.append("-Infinity");
-            default: return app.append("NaN");
         }
     }
 

--- a/src/main/java/com/fasterxml/jackson/core/io/schubfach/DoubleToDecimal.java
+++ b/src/main/java/com/fasterxml/jackson/core/io/schubfach/DoubleToDecimal.java
@@ -105,10 +105,6 @@ final public class DoubleToDecimal {
     private static final int MINUS_INF = 4;
     private static final int NAN = 5;
 
-    // For thread-safety, each thread gets its own instance of this class.
-    private static final ThreadLocal<DoubleToDecimal> threadLocal =
-            ThreadLocal.withInitial(DoubleToDecimal::new);
-
     /*
     Room for the longer of the forms
         -ddddd.dddddddddddd         H + 2 characters
@@ -241,11 +237,7 @@ final public class DoubleToDecimal {
      * @return a string rendering of the argument.
      */
     public static String toString(double v) {
-        return threadLocalInstance().toDecimalString(v);
-    }
-
-    private static DoubleToDecimal threadLocalInstance() {
-        return threadLocal.get();
+        return new DoubleToDecimal().toDecimalString(v);
     }
 
     private String toDecimalString(double v) {

--- a/src/main/java/com/fasterxml/jackson/core/io/schubfach/FloatToDecimal.java
+++ b/src/main/java/com/fasterxml/jackson/core/io/schubfach/FloatToDecimal.java
@@ -22,8 +22,6 @@
 
 package com.fasterxml.jackson.core.io.schubfach;
 
-import java.io.IOException;
-
 import static com.fasterxml.jackson.core.io.schubfach.MathUtils.flog10pow2;
 import static com.fasterxml.jackson.core.io.schubfach.MathUtils.flog10threeQuartersPow2;
 import static com.fasterxml.jackson.core.io.schubfach.MathUtils.flog2pow10;
@@ -121,9 +119,6 @@ final public class FloatToDecimal {
 
     // Numerical results are created here...
     private final byte[] bytes = new byte[MAX_CHARS];
-
-    // ... and copied here in appendTo()
-    private final char[] chars = new char[MAX_CHARS];
 
     // Index into buf of rightmost valid character.
     private int index;
@@ -248,22 +243,6 @@ final public class FloatToDecimal {
         return threadLocalInstance().toDecimalString(v);
     }
 
-    /**
-     * Appends the rendering of the {@code v} to {@code app}.
-     *
-     * <p>The outcome is the same as if {@code v} were first
-     * {@link #toString(float) rendered} and the resulting string were then
-     * {@link Appendable#append(CharSequence) appended} to {@code app}.
-     *
-     * @param v the {@code float} whose rendering is appended.
-     * @param app the {@link Appendable} to append to.
-     * @throws IOException If an I/O error occurs
-     */
-    public static Appendable appendTo(float v, Appendable app)
-            throws IOException {
-        return threadLocalInstance().appendDecimalTo(v, app);
-    }
-
     private static FloatToDecimal threadLocalInstance() {
         return threadLocal.get();
     }
@@ -276,31 +255,6 @@ final public class FloatToDecimal {
             case PLUS_INF: return "Infinity";
             case MINUS_INF: return "-Infinity";
             default: return "NaN";
-        }
-    }
-
-    private Appendable appendDecimalTo(float v, Appendable app)
-            throws IOException {
-        switch (toDecimal(v)) {
-            case NON_SPECIAL:
-                for (int i = 0; i <= index; ++i) {
-                    chars[i] = (char) bytes[i];
-                }
-                if (app instanceof StringBuilder) {
-                    return ((StringBuilder) app).append(chars, 0, index + 1);
-                }
-                if (app instanceof StringBuffer) {
-                    return ((StringBuffer) app).append(chars, 0, index + 1);
-                }
-                for (int i = 0; i <= index; ++i) {
-                    app.append(chars[i]);
-                }
-                return app;
-            case PLUS_ZERO: return app.append("0.0");
-            case MINUS_ZERO: return app.append("-0.0");
-            case PLUS_INF: return app.append("Infinity");
-            case MINUS_INF: return app.append("-Infinity");
-            default: return app.append("NaN");
         }
     }
 

--- a/src/main/java/com/fasterxml/jackson/core/io/schubfach/FloatToDecimal.java
+++ b/src/main/java/com/fasterxml/jackson/core/io/schubfach/FloatToDecimal.java
@@ -104,10 +104,6 @@ final public class FloatToDecimal {
     private static final int MINUS_INF = 4;
     private static final int NAN = 5;
 
-    // For thread-safety, each thread gets its own instance of this class.
-    private static final ThreadLocal<FloatToDecimal> threadLocal =
-            ThreadLocal.withInitial(FloatToDecimal::new);
-
     /*
     Room for the longer of the forms
         -ddddd.dddd         H + 2 characters
@@ -240,11 +236,7 @@ final public class FloatToDecimal {
      * @return a string rendering of the argument.
      */
     public static String toString(float v) {
-        return threadLocalInstance().toDecimalString(v);
-    }
-
-    private static FloatToDecimal threadLocalInstance() {
-        return threadLocal.get();
+        return new FloatToDecimal().toDecimalString(v);
     }
 
     private String toDecimalString(float v) {


### PR DESCRIPTION
In perf testing, they have a small benefit but not worth it for the maintenance overhead.

```
Benchmark                                 Mode  Cnt        Score       Error  Units
SchubfachBench.doubleWithThreadLocal     thrpt    5  1076597.929 ± 26758.597  ops/s
SchubfachBench.doubleWithoutThreadLocal  thrpt    5   997088.673 ± 15197.149  ops/s
SchubfachBench.floatWithThreadLocal      thrpt    5  1395289.534 ±  5535.617  ops/s
SchubfachBench.floatWithoutThreadLocal   thrpt    5  1353461.663 ±  5967.389  ops/s
```

Also removes some unused code with the benefit of removing the char[] initialized when we parse numbers. Only the byte[] remains.