### PR TITLE
add method needed by jackson-dataformat-csv

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/util/TextBuffer.java
+++ b/src/main/java/com/fasterxml/jackson/core/util/TextBuffer.java
@@ -329,6 +329,7 @@ public final class TextBuffer
      *    could be 0 in the case of first character is
      *    delimiter or end-of-line
      * @param trimTrailingSpaces Whether trailing spaces should be trimmed or not
+     * @return token as text
      * @since 2.15
      */
     public String finishAndReturn(int lastSegmentEnd, boolean trimTrailingSpaces)

--- a/src/main/java/com/fasterxml/jackson/core/util/TextBuffer.java
+++ b/src/main/java/com/fasterxml/jackson/core/util/TextBuffer.java
@@ -324,6 +324,49 @@ public final class TextBuffer
         return _currentSegment;
     }
 
+    /**
+     * @param lastSegmentEnd End offset in the currently active segment,
+     *    could be 0 in the case of first character is
+     *    delimiter or end-of-line
+     * @param trimTrailingSpaces Whether trailing spaces should be trimmed or not
+     * @since 2.15
+     */
+    public String finishAndReturn(int lastSegmentEnd, boolean trimTrailingSpaces)
+    {
+        if (trimTrailingSpaces) {
+            // First, see if it's enough to trim end of current segment:
+            int ptr = lastSegmentEnd - 1;
+            if (ptr < 0 || _currentSegment[ptr] <= 0x0020) {
+                return _doTrim(ptr);
+            }
+        }
+        _currentSize = lastSegmentEnd;
+        return contentsAsString();
+    }
+
+    private String _doTrim(int ptr)
+    {
+        while (true) {
+            final char[] curr = _currentSegment;
+            while (--ptr >= 0) {
+                if (curr[ptr] > 0x0020) { // found the ending non-space char, all done:
+                    _currentSize = ptr+1;
+                    return contentsAsString();
+                }
+            }
+            // nope: need to handle previous segment; if there is one:
+            if (_segments == null || _segments.isEmpty()) {
+                break;
+            }
+            _currentSegment = _segments.remove(_segments.size() - 1);
+            ptr = _currentSegment.length;
+        }
+        // we get here if everything was trimmed, so:
+        _currentSize = 0;
+        _hasSegments = false;
+        return contentsAsString();
+    }
+
     // Helper method used to find a buffer to use, ideally one
     // recycled earlier.
     private char[] buf(int needed)


### PR DESCRIPTION
Adding this method to TextBuffer allows me to rework jackson-dataformat-csv to use this TextBuffer instead of its CsvTextBuffer - tested on my laptop.