### PR TITLE
Add constraint validation for TextBuffer.append

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/util/TextBuffer.java
+++ b/src/main/java/com/fasterxml/jackson/core/util/TextBuffer.java
@@ -711,11 +711,10 @@ public class TextBuffer
         _resultString = null;
         _resultArray = null;
 
-        validateAppend(1);
-
         // Room in current segment?
         char[] curr = _currentSegment;
         if (_currentSize >= curr.length) {
+            validateAppend(1);
             expand();
             curr = _currentSegment;
         }
@@ -731,8 +730,6 @@ public class TextBuffer
         _resultString = null;
         _resultArray = null;
 
-        validateAppend(len);
-
         // Room in current segment?
         char[] curr = _currentSegment;
         int max = curr.length - _currentSize;
@@ -742,6 +739,9 @@ public class TextBuffer
             _currentSize += len;
             return;
         }
+
+        validateAppend(len);
+
         // No room for all, need to copy part(s):
         if (max > 0) {
             System.arraycopy(c, start, curr, _currentSize, max);
@@ -769,8 +769,6 @@ public class TextBuffer
         _resultString = null;
         _resultArray = null;
 
-        validateAppend(len);
-
         // Room in current segment?
         char[] curr = _currentSegment;
         int max = curr.length - _currentSize;
@@ -779,6 +777,9 @@ public class TextBuffer
             _currentSize += len;
             return;
         }
+
+        validateAppend(len);
+
         // No room for all, need to copy part(s):
         if (max > 0) {
             str.getChars(offset, offset+max, curr, _currentSize);

--- a/src/main/java/com/fasterxml/jackson/core/util/TextBuffer.java
+++ b/src/main/java/com/fasterxml/jackson/core/util/TextBuffer.java
@@ -710,6 +710,9 @@ public class TextBuffer
         }
         _resultString = null;
         _resultArray = null;
+
+        validateAppend(1);
+
         // Room in current segment?
         char[] curr = _currentSegment;
         if (_currentSize >= curr.length) {
@@ -727,6 +730,8 @@ public class TextBuffer
         }
         _resultString = null;
         _resultArray = null;
+
+        validateAppend(len);
 
         // Room in current segment?
         char[] curr = _currentSegment;
@@ -764,6 +769,8 @@ public class TextBuffer
         _resultString = null;
         _resultArray = null;
 
+        validateAppend(len);
+
         // Room in current segment?
         char[] curr = _currentSegment;
         int max = curr.length - _currentSize;
@@ -788,6 +795,15 @@ public class TextBuffer
             offset += amount;
             len -= amount;
         } while (len > 0);
+    }
+
+    private void validateAppend(int toAppend) {
+        int newTotalLength = _segmentSize + _currentSize + toAppend;
+        // guard against overflow
+        if (newTotalLength < 0) {
+            newTotalLength = Integer.MAX_VALUE;
+        }
+        validateStringLength(newTotalLength);
     }
 
     /*

--- a/src/test/java/com/fasterxml/jackson/core/util/ReadConstrainedTextBufferTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/util/ReadConstrainedTextBufferTest.java
@@ -9,30 +9,32 @@ import org.junit.jupiter.api.Test;
 import java.util.Arrays;
 
 class ReadConstrainedTextBufferTest {
+    private static final int SEGMENT_SIZE = TextBuffer.MIN_SEGMENT_LEN;
+
     @Test
     public void appendCharArray() {
-        TextBuffer constrained = makeConstrainedBuffer(100);
-        char[] chars = new char[100];
+        TextBuffer constrained = makeConstrainedBuffer(SEGMENT_SIZE);
+        char[] chars = new char[SEGMENT_SIZE];
         Arrays.fill(chars, 'A');
-        constrained.append(chars, 0, 100);
-        Assertions.assertThrows(IllegalStateException.class, () -> constrained.append(chars, 0, 100));
+        constrained.append(chars, 0, SEGMENT_SIZE);
+        Assertions.assertThrows(IllegalStateException.class, () -> constrained.append(chars, 0, SEGMENT_SIZE));
     }
 
     @Test
     public void appendString() {
-        TextBuffer constrained = makeConstrainedBuffer(100);
-        char[] chars = new char[100];
+        TextBuffer constrained = makeConstrainedBuffer(SEGMENT_SIZE);
+        char[] chars = new char[SEGMENT_SIZE];
         Arrays.fill(chars, 'A');
-        constrained.append(new String(chars), 0, 100);
-        Assertions.assertThrows(IllegalStateException.class, () -> constrained.append(new String(chars), 0, 100));
+        constrained.append(new String(chars), 0, SEGMENT_SIZE);
+        Assertions.assertThrows(IllegalStateException.class, () -> constrained.append(new String(chars), 0, SEGMENT_SIZE));
     }
 
     @Test
     public void appendSingle() {
-        TextBuffer constrained = makeConstrainedBuffer(100);
-        char[] chars = new char[100];
+        TextBuffer constrained = makeConstrainedBuffer(SEGMENT_SIZE);
+        char[] chars = new char[SEGMENT_SIZE];
         Arrays.fill(chars, 'A');
-        constrained.append(chars, 0, 100);
+        constrained.append(chars, 0, SEGMENT_SIZE);
         Assertions.assertThrows(IllegalStateException.class, () -> constrained.append('x'));
     }
 
@@ -44,7 +46,6 @@ class ReadConstrainedTextBufferTest {
                 constraints,
                 new BufferRecycler(),
                 ContentReference.rawReference("N/A"), true);
-        TextBuffer constrained = ioContext.constructReadConstrainedTextBuffer();
-        return constrained;
+        return ioContext.constructReadConstrainedTextBuffer();
     }
 }

--- a/src/test/java/com/fasterxml/jackson/core/util/ReadConstrainedTextBufferTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/util/ReadConstrainedTextBufferTest.java
@@ -1,0 +1,50 @@
+package com.fasterxml.jackson.core.util;
+
+import com.fasterxml.jackson.core.StreamReadConstraints;
+import com.fasterxml.jackson.core.io.ContentReference;
+import com.fasterxml.jackson.core.io.IOContext;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+class ReadConstrainedTextBufferTest {
+    @Test
+    public void appendCharArray() {
+        TextBuffer constrained = makeConstrainedBuffer(100);
+        char[] chars = new char[100];
+        Arrays.fill(chars, 'A');
+        constrained.append(chars, 0, 100);
+        Assertions.assertThrows(IllegalStateException.class, () -> constrained.append(chars, 0, 100));
+    }
+
+    @Test
+    public void appendString() {
+        TextBuffer constrained = makeConstrainedBuffer(100);
+        char[] chars = new char[100];
+        Arrays.fill(chars, 'A');
+        constrained.append(new String(chars), 0, 100);
+        Assertions.assertThrows(IllegalStateException.class, () -> constrained.append(new String(chars), 0, 100));
+    }
+
+    @Test
+    public void appendSingle() {
+        TextBuffer constrained = makeConstrainedBuffer(100);
+        char[] chars = new char[100];
+        Arrays.fill(chars, 'A');
+        constrained.append(chars, 0, 100);
+        Assertions.assertThrows(IllegalStateException.class, () -> constrained.append('x'));
+    }
+
+    private static TextBuffer makeConstrainedBuffer(int maxStringLen) {
+        StreamReadConstraints constraints = StreamReadConstraints.builder()
+                .maxStringLength(maxStringLen)
+                .build();
+        IOContext ioContext = new IOContext(
+                constraints,
+                new BufferRecycler(),
+                ContentReference.rawReference("N/A"), true);
+        TextBuffer constrained = ioContext.constructReadConstrainedTextBuffer();
+        return constrained;
+    }
+}


### PR DESCRIPTION
This fixes https://github.com/FasterXML/jackson-dataformats-text/issues/384, the tests now fail in the append call, not just on contentsAsString.

FYI @pjfanning 