### PR TITLE
for a PR, only 1 concurrent run (CIFuzz job)

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -1,5 +1,10 @@
 name: CIFuzz
 on: [pull_request]
+
+concurrency:
+  group: ${{ github.workflow }} @ ${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   Fuzzing:
     runs-on: ubuntu-latest


### PR DESCRIPTION
* job is slow
* this is copied from jackson-module-scala
* ensures for a PR that if you do a new commit and the CIFuzz job is running for the last commit, that gets cancelled - the new run for the new commit will proceed