### PR TITLE
prevent TextBuffer toString from throwing exceptions

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/util/TextBuffer.java
+++ b/src/main/java/com/fasterxml/jackson/core/util/TextBuffer.java
@@ -958,7 +958,13 @@ public class TextBuffer
      * {@link #contentsAsString}, since it's not guaranteed that resulting
      * String is cached.
      */
-    @Override public String toString() { return contentsAsString(); }
+    @Override public String toString() {
+        try {
+            return contentsAsString();
+        } catch (RuntimeException e) {
+            return "TextBuffer: Exception when reading contents";
+        }
+    }
 
     /*
     /**********************************************************


### PR DESCRIPTION
The call to `contentsToString()` can lead to an `IllegalStateException`.
* not needed if #933 is merged (similar change in there but there we need to catch JsonParseException)

There is an argument to remove the custom `toString()` support in this class (altogether). When you debug the TextBuffer code, an IDE will call the toString() to display the heap values and this call affects the behaviour of TextBuffer.