### PR TITLE
Make "too-long-number" use new StreamConstraintsException too

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/StreamReadConstraints.java
+++ b/src/main/java/com/fasterxml/jackson/core/StreamReadConstraints.java
@@ -165,12 +165,12 @@ public class StreamReadConstraints
      *
      * @param length Length of number in input units
      *
-     * @throws NumberFormatException If length exceeds maximum
+     * @throws StreamConstraintsException If length exceeds maximum
      */
-    public void validateFPLength(int length) throws NumberFormatException
+    public void validateFPLength(int length) throws StreamConstraintsException
     {
         if (length > _maxNumLen) {
-            throw new NumberFormatException(String.format("Number length (%d) exceeds the maximum length (%d)",
+            throw new StreamConstraintsException(String.format("Number length (%d) exceeds the maximum length (%d)",
                     length, _maxNumLen));
         }
     }
@@ -184,12 +184,12 @@ public class StreamReadConstraints
      *
      * @param length Length of number in input units
      *
-     * @throws NumberFormatException If length exceeds maximum
+     * @throws StreamConstraintsException If length exceeds maximum
      */
-    public void validateIntegerLength(int length) throws NumberFormatException
+    public void validateIntegerLength(int length) throws StreamConstraintsException
     {
         if (length > _maxNumLen) {
-            throw new NumberFormatException(String.format("Number length (%d) exceeds the maximum length (%d)",
+            throw new StreamConstraintsException(String.format("Number length (%d) exceeds the maximum length (%d)",
                     length, _maxNumLen));
         }
     }

--- a/src/main/java/com/fasterxml/jackson/core/base/ParserBase.java
+++ b/src/main/java/com/fasterxml/jackson/core/base/ParserBase.java
@@ -555,7 +555,7 @@ public abstract class ParserBase extends ParserMinimalBase
     // // // Life-cycle of number-parsing
 
     protected final JsonToken reset(boolean negative, int intLen, int fractLen, int expLen)
-        throws JsonParseException
+        throws IOException
     {
         if (fractLen < 1 && expLen < 1) { // integer
             return resetInt(negative, intLen);
@@ -564,15 +564,10 @@ public abstract class ParserBase extends ParserMinimalBase
     }
 
     protected final JsonToken resetInt(boolean negative, int intLen)
-        throws JsonParseException
+        throws IOException
     {
-        // Inelegant but we know how to create StreamReadExceptions,
-        // constraints object doesn't. May refactor in near future.
-        try {
-            _streamReadConstraints.validateIntegerLength(intLen);
-        } catch (NumberFormatException e) {
-            reportInvalidNumber(e.getMessage());
-        }
+        // May throw StreamConstraintsException:
+        _streamReadConstraints.validateIntegerLength(intLen);
         _numberNegative = negative;
         _intLength = intLen;
         _fractLength = 0;
@@ -582,16 +577,10 @@ public abstract class ParserBase extends ParserMinimalBase
     }
 
     protected final JsonToken resetFloat(boolean negative, int intLen, int fractLen, int expLen)
-        throws JsonParseException
+        throws IOException
     {
-        // Inelegant but we know how to create StreamReadExceptions,
-        // constraints object doesn't. May refactor in near future.
-        // Length is approximate, good enough for validation
-        try {
-            _streamReadConstraints.validateFPLength(intLen + fractLen + expLen);
-        } catch (NumberFormatException e) {
-            reportInvalidNumber(e.getMessage());
-        }
+        // May throw StreamConstraintsException:
+        _streamReadConstraints.validateFPLength(intLen + fractLen + expLen);
         _numberNegative = negative;
         _intLength = intLen;
         _fractLength = fractLen;

--- a/src/test/java/com/fasterxml/jackson/core/read/NumberParsingTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/read/NumberParsingTest.java
@@ -9,6 +9,7 @@ import java.math.BigInteger;
 
 import com.fasterxml.jackson.core.*;
 import com.fasterxml.jackson.core.exc.InputCoercionException;
+import com.fasterxml.jackson.core.exc.StreamConstraintsException;
 import com.fasterxml.jackson.core.exc.StreamReadException;
 import com.fasterxml.jackson.core.io.NumberInput;
 import com.fasterxml.jackson.core.json.JsonReadFeature;
@@ -546,13 +547,13 @@ public class NumberParsingTest
         try {
             _testBigBigDecimals(MODE_INPUT_STREAM, false);
             fail("Should not pass");
-        } catch (StreamReadException e) {
+        } catch (StreamConstraintsException e) {
             verifyException(e, "Invalid numeric value ", "exceeds the maximum length");
         }
         try {
             _testBigBigDecimals(MODE_INPUT_STREAM_THROTTLED, false);
             fail("Should not pass");
-        } catch (StreamReadException jpe) {
+        } catch (StreamConstraintsException jpe) {
             verifyException(jpe, "Invalid numeric value ", "exceeds the maximum length");
         }
     }
@@ -562,7 +563,7 @@ public class NumberParsingTest
         try {
             _testBigBigDecimals(MODE_READER, false);
             fail("Should not pass");
-        } catch (StreamReadException jpe) {
+        } catch (StreamConstraintsException jpe) {
             verifyException(jpe, "Invalid numeric value ", "exceeds the maximum length");
         }
     }
@@ -577,7 +578,7 @@ public class NumberParsingTest
         try {
             _testBigBigDecimals(MODE_DATA_INPUT, false);
             fail("Should not pass");
-        } catch (StreamReadException jpe) {
+        } catch (StreamConstraintsException jpe) {
             verifyException(jpe, "Invalid numeric value ", "exceeds the maximum length");
         }
     }


### PR DESCRIPTION
More work for #937: make all validation fails use `StreamConstraintsException`