### PR TITLE
make Parser StreamReadConstraints more null safe

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/JsonFactory.java
+++ b/src/main/java/com/fasterxml/jackson/core/JsonFactory.java
@@ -358,7 +358,8 @@ public class JsonFactory
         _generatorFeatures = src._generatorFeatures;
         _inputDecorator = src._inputDecorator;
         _outputDecorator = src._outputDecorator;
-        _streamReadConstraints = src._streamReadConstraints;
+        _streamReadConstraints = src._streamReadConstraints == null ?
+            StreamReadConstraints.defaults() : src._streamReadConstraints;
 
         // JSON-specific
         _characterEscapes = src._characterEscapes;
@@ -383,7 +384,8 @@ public class JsonFactory
         _generatorFeatures = b._streamWriteFeatures;
         _inputDecorator = b._inputDecorator;
         _outputDecorator = b._outputDecorator;
-        _streamReadConstraints = b._streamReadConstraints;
+        _streamReadConstraints = b._streamReadConstraints == null ?
+                StreamReadConstraints.defaults() : b._streamReadConstraints;
 
         // JSON-specific
         _characterEscapes = b._characterEscapes;
@@ -408,7 +410,8 @@ public class JsonFactory
         _generatorFeatures = b._streamWriteFeatures;
         _inputDecorator = b._inputDecorator;
         _outputDecorator = b._outputDecorator;
-        _streamReadConstraints = b._streamReadConstraints;
+        _streamReadConstraints = b._streamReadConstraints == null ?
+                StreamReadConstraints.defaults() : b._streamReadConstraints;
 
         // JSON-specific: need to assign even if not really used
         _characterEscapes = null;

--- a/src/main/java/com/fasterxml/jackson/core/base/ParserBase.java
+++ b/src/main/java/com/fasterxml/jackson/core/base/ParserBase.java
@@ -255,7 +255,9 @@ public abstract class ParserBase extends ParserMinimalBase
     protected ParserBase(IOContext ctxt, int features) {
         super(features);
         _ioContext = ctxt;
-        _streamReadConstraints = ctxt.streamReadConstraints();
+        final StreamReadConstraints streamReadConstraints = ctxt.streamReadConstraints();
+        _streamReadConstraints = streamReadConstraints == null ?
+                StreamReadConstraints.defaults() : streamReadConstraints;
         _textBuffer = ctxt.constructReadConstrainedTextBuffer();
         DupDetector dups = Feature.STRICT_DUPLICATE_DETECTION.enabledIn(features)
                 ? DupDetector.rootDetector(this) : null;


### PR DESCRIPTION
I was testing the TOML code and ran into trouble with TomlMappers created from TomlFactories - in some tests, the Parser StreamReadConstraints was null and it was causing tests to fail.

This code seems a little safer.