### PR TITLE
 Add read-only top-level workflow permissions

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -1,6 +1,9 @@
 name: CIFuzz
 on: [pull_request]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }} @ ${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,9 @@ on:
       - "!*.pr*"
       - "!*b"
 
+permissions:
+  contents: read
+
 jobs:
   release:
     runs-on: "ubuntu-20.04"


### PR DESCRIPTION
Closes #952

As per the linked issue, this PR adds top-level read-only permissions to cifuzz.yml and release.yml.

It is my understanding that the actions in those workflows do not require any permissions greater than `content: read`. If that is not the case, I'll gladly amend the PR as needed.