### PR TITLE
Minor re-factoring wrt #968

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/base/ParserBase.java
+++ b/src/main/java/com/fasterxml/jackson/core/base/ParserBase.java
@@ -1098,16 +1098,16 @@ public abstract class ParserBase extends ParserMinimalBase
     {
         if ((_numTypesValid & NR_BIGDECIMAL) != 0) {
             // here it'll just get truncated, no exceptions thrown
-            _numberBigInt = _getBigDecimal().toBigInteger();
+            _numberBigInt = _convertBigDecimalToBigInteger(_getBigDecimal());
         } else if ((_numTypesValid & NR_LONG) != 0) {
             _numberBigInt = BigInteger.valueOf(_numberLong);
         } else if ((_numTypesValid & NR_INT) != 0) {
             _numberBigInt = BigInteger.valueOf(_numberInt);
         } else if ((_numTypesValid & NR_DOUBLE) != 0) {
             if (_numberString != null) {
-                _numberBigInt = _getBigDecimal().toBigInteger();
+                _numberBigInt = _convertBigDecimalToBigInteger(_getBigDecimal());
             } else {
-                _numberBigInt = BigDecimal.valueOf(_getNumberDouble()).toBigInteger();
+                _numberBigInt = _convertBigDecimalToBigInteger(BigDecimal.valueOf(_getNumberDouble()));
             }
         } else {
             _throwInternal();
@@ -1212,6 +1212,12 @@ public abstract class ParserBase extends ParserMinimalBase
             _throwInternal();
         }
         _numTypesValid |= NR_BIGDECIMAL;
+    }
+
+    // @since 2.15
+    protected BigInteger _convertBigDecimalToBigInteger(BigDecimal bigDec) throws IOException {
+        // 04-Apr-2022, tatu: wrt [core#968] Need to limit max scale magnitude
+        return bigDec.toBigInteger();
     }
 
     /**

--- a/src/main/java/com/fasterxml/jackson/core/io/NumberInput.java
+++ b/src/main/java/com/fasterxml/jackson/core/io/NumberInput.java
@@ -16,6 +16,9 @@ public final class NumberInput
 {
     // numbers with more than these characters are better parsed with BigDecimalParser
     // parsing numbers with many digits in Java is slower than O(n)
+
+    // 04-Apr-2023, tatu: NOTE! This is above default "longest number by chars"
+    //   limit
     private final static int LARGE_INT_SIZE = 1250;
 
     /**

--- a/src/test/java/com/fasterxml/jackson/failing/PerfBigDecimalToInteger968.java
+++ b/src/test/java/com/fasterxml/jackson/failing/PerfBigDecimalToInteger968.java
@@ -1,5 +1,7 @@
 package com.fasterxml.jackson.failing;
 
+import java.math.BigInteger;
+
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -11,16 +13,28 @@ public class PerfBigDecimalToInteger968
     private final JsonFactory JSON_F = new JsonFactory();
     
     // For [core#968]: shouldn't take multiple seconds
-    @Test(timeout = 3000)
+    @Test(timeout = 2000)
     public void bigIntegerViaBigDecimal() throws Exception {
-        final String DOC = "1e20000000";
+        final String DOC = "1e25000000";
 
         try (JsonParser p = JSON_F.createParser(DOC)) {
             assertToken(JsonToken.VALUE_NUMBER_FLOAT, p.nextToken());
-            Assert.assertNotNull(p.getBigIntegerValue());
+            BigInteger value = p.getBigIntegerValue();
+            Assert.assertNotNull(value);
         }
     }
 
+    @Test(timeout = 2000)
+    public void tinyIntegerViaBigDecimal() throws Exception {
+        final String DOC = "1e-25000000";
+
+        try (JsonParser p = JSON_F.createParser(DOC)) {
+            assertToken(JsonToken.VALUE_NUMBER_FLOAT, p.nextToken());
+            BigInteger value = p.getBigIntegerValue();
+            Assert.assertNotNull(value);
+        }
+    }
+    
     protected void assertToken(JsonToken expToken, JsonToken actToken)
     {
         if (actToken != expToken) {


### PR DESCRIPTION
As per title, add a method in which we can block conversion of too-big/too-small BigDecimals into `BigInteger`.