### PR TITLE
Lazy num parsing - bring to master from 2.15

### DIFF
--- a/src/main/java/tools/jackson/core/base/ParserBase.java
+++ b/src/main/java/tools/jackson/core/base/ParserBase.java
@@ -841,13 +841,13 @@ public abstract class ParserBase extends ParserMinimalBase
 
         if ((_numTypesValid & NR_BIGDECIMAL) != 0) {
             if (_numberString != null) {
-                _numberDouble = _getNumberFloat();
+                _numberDouble = _getNumberDouble();
             } else {
                 _numberDouble = _getBigDecimal().doubleValue();
             }
         } else if ((_numTypesValid & NR_BIGINT) != 0) {
             if (_numberString != null) {
-                _numberDouble = _getNumberFloat();
+                _numberDouble = _getNumberDouble();
             } else {
                 _numberDouble = _getBigInteger().doubleValue();
             }


### PR DESCRIPTION
fixes the issue where PerfBigDecimalToInteger968 failing test does not work properly on master. On master currently, that test rushes on and parses as a Double but the value is too big and becomes Double.Infinity and this causes a failure when we try to convert the double to a BigInt.