### PR TITLE
Try to get Release workflow working wrt SLSA provenance (fix #844)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,16 +59,16 @@ jobs:
               -Dexpression=project.version -q -DforceStdout)"
           echo "artifact_name=$ARTIFACT_NAME" >> "$GITHUB_OUTPUT"
 
-          cd ./target
+          cd ./checkout/target
           echo "hash=$( \
             sha256sum $ARTIFACT_NAME*.jar | \
             base64 -w0 \
           )" >> "$GITHUB_OUTPUT"
 
           echo "DEBUG: After SLSA hash generation we have:"
-          ls
-          ls ./target
           echo "DEBUG: ARTIFACT_NAME = $ARTIFACT_NAME"
+          ls ./checkout
+          ls ./checkout/target
   provenance:
     needs: [release]
     permissions:


### PR DESCRIPTION
As per title looks like build target directory is in different place; hopefully this works for 2.15.0 final.
