### PR TITLE
[2.14 only] backport removal of BigDecimal to BigInt conversion

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/io/NumberInput.java
+++ b/src/main/java/com/fasterxml/jackson/core/io/NumberInput.java
@@ -8,10 +8,6 @@ import java.math.BigInteger;
 
 public final class NumberInput
 {
-    // numbers with more than these characters are better parsed with BigDecimalParser
-    // parsing numbers with many digits in Java is slower than O(n)
-    private final static int LARGE_INT_SIZE = 1250;
-
     /**
      * Formerly used constant for a value that was problematic on certain
      * pre-1.8 JDKs.
@@ -398,10 +394,7 @@ public final class NumberInput
      * @throws NumberFormatException if string cannot be represented by a BigInteger
      * @since v2.14
      */
-    public static BigInteger parseBigInteger(String s) throws NumberFormatException {
-        if (s.length() > LARGE_INT_SIZE) {
-            return BigDecimalParser.parse(s).toBigInteger();
-        }
+    public static BigInteger parseBigInteger(final String s) throws NumberFormatException {
         return new BigInteger(s);
     }
 }

--- a/src/test/java/com/fasterxml/jackson/core/io/TestNumberInput.java
+++ b/src/test/java/com/fasterxml/jackson/core/io/TestNumberInput.java
@@ -41,5 +41,15 @@ public class TestNumberInput
         String test2000 = stringBuilder.toString();
         assertEquals(new BigInteger(test2000), NumberInput.parseBigInteger(test2000));
     }
+
+    public void testParseBigIntegerFailsWithENotation()
+    {
+        try {
+            NumberInput.parseBigInteger("1e10");
+            fail("expected NumberFormatException");
+        } catch (NumberFormatException nfe) {
+            // expected
+        }
+    }
 }
 


### PR DESCRIPTION
parse BigIntegers using BigInteger class to avoid issues with BigDecimal#toBigInteger