### PR TITLE
Fix #1007: add more information on `StreamReadConstraints` violation exception message

### DIFF
--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -16,7 +16,7 @@ JSON library.
 
 2.16.0 (not yet released)
 
-No changes since 2.15
+#1007: Improve error message for `StreamReadConstraints` violations
 
 2.15.1 (not yet released)
 

--- a/src/main/java/com/fasterxml/jackson/core/StreamReadConstraints.java
+++ b/src/main/java/com/fasterxml/jackson/core/StreamReadConstraints.java
@@ -335,10 +335,12 @@ public class StreamReadConstraints
     /**********************************************************************
      */
 
+    // @since 2.16
     protected StreamConstraintsException _constructException(String msgTemplate, Object... args) throws StreamConstraintsException {
         throw new StreamConstraintsException(String.format(msgTemplate, args));
     }
 
+    // @since 2.16
     protected String _constrainRef(String method) {
         return "`StreamReadConstraints."+method+"()`";
     }

--- a/src/main/java/com/fasterxml/jackson/core/StreamReadConstraints.java
+++ b/src/main/java/com/fasterxml/jackson/core/StreamReadConstraints.java
@@ -224,8 +224,10 @@ public class StreamReadConstraints
     public void validateNestingDepth(int depth) throws StreamConstraintsException
     {
         if (depth > _maxNestingDepth) {
-            throw new StreamConstraintsException(String.format("Depth (%d) exceeds the maximum allowed nesting depth (%d)",
-                    depth, _maxNestingDepth));
+            throw _constructException(
+                    "Document nesting depth (%d) exceeds the maximum allowed (%d, from %s)",
+                    depth, _maxNestingDepth,
+                    _constrainRef("getMaxNestingDepth"));
         }
     }
 
@@ -249,8 +251,10 @@ public class StreamReadConstraints
     public void validateFPLength(int length) throws StreamConstraintsException
     {
         if (length > _maxNumLen) {
-            throw new StreamConstraintsException(String.format("Number length (%d) exceeds the maximum length (%d)",
-                    length, _maxNumLen));
+            throw _constructException(
+                    "Number value length (%d) exceeds the maximum allowed (%d, from %s)",
+                    length, _maxNumLen,
+                    _constrainRef("getMaxNumberLength"));
         }
     }
 
@@ -268,8 +272,10 @@ public class StreamReadConstraints
     public void validateIntegerLength(int length) throws StreamConstraintsException
     {
         if (length > _maxNumLen) {
-            throw new StreamConstraintsException(String.format("Number length (%d) exceeds the maximum length (%d)",
-                    length, _maxNumLen));
+            throw _constructException(
+                    "Number value length (%d) exceeds the maximum allowed (%d, from %s)",
+                    length, _maxNumLen,
+                    _constrainRef("getMaxNumberLength"));
         }
     }
 
@@ -287,8 +293,10 @@ public class StreamReadConstraints
     public void validateStringLength(int length) throws StreamConstraintsException
     {
         if (length > _maxStringLen) {
-            throw new StreamConstraintsException(String.format("String length (%d) exceeds the maximum length (%d)",
-                    length, _maxStringLen));
+            throw _constructException(
+                    "String value length (%d) exceeds the maximum allowed (%d, from %s)",
+                    length, _maxStringLen,
+                    _constrainRef("getMaxStringLength"));
         }
     }
 
@@ -315,9 +323,23 @@ public class StreamReadConstraints
         final int limit = MAX_BIGINT_SCALE_MAGNITUDE;
 
         if (absScale > limit) {
-            throw new StreamConstraintsException(String.format(
-                    "BigDecimal scale (%d) magnitude exceeds maximum allowed (%d)",
-                    scale, limit));
+            throw _constructException(
+                    "BigDecimal scale (%d) magnitude exceeds the maximum allowed (%d)",
+                    scale, limit);
         }
+    }
+
+    /*
+    /**********************************************************************
+    /* Error reporting
+    /**********************************************************************
+     */
+
+    protected StreamConstraintsException _constructException(String msgTemplate, Object... args) throws StreamConstraintsException {
+        throw new StreamConstraintsException(String.format(msgTemplate, args));
+    }
+
+    protected String _constrainRef(String method) {
+        return "`StreamReadConstraints."+method+"()`";
     }
 }

--- a/src/test/java/com/fasterxml/jackson/core/constraints/DeeplyNestedContentReadTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/constraints/DeeplyNestedContentReadTest.java
@@ -32,8 +32,8 @@ public class DeeplyNestedContentReadTest
             while (p.nextToken() != null) { }
             fail("expected StreamConstraintsException");
         } catch (StreamConstraintsException e) {
-            assertEquals("Depth ("+(MAX_NESTING+1)
-                    +") exceeds the maximum allowed nesting depth ("+MAX_NESTING+")", e.getMessage());
+            assertEquals("Document nesting depth (1001) exceeds the maximum allowed (1000, from `StreamReadConstraints.getMaxNestingDepth()`)",
+                    e.getMessage());
         }
     }
 
@@ -58,8 +58,8 @@ public class DeeplyNestedContentReadTest
             while (p.nextToken() != null) { }
             fail("expected StreamConstraintsException");
         } catch (StreamConstraintsException e) {
-            assertEquals("Depth ("+(maxNesting+1)
-                    +") exceeds the maximum allowed nesting depth ("+maxNesting+")", e.getMessage());
+            assertEquals("Document nesting depth (41) exceeds the maximum allowed (40, from `StreamReadConstraints.getMaxNestingDepth()`)",
+                    e.getMessage());
         }
     }
     

--- a/src/test/java/com/fasterxml/jackson/core/constraints/LargeNumberReadTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/constraints/LargeNumberReadTest.java
@@ -34,13 +34,13 @@ public class LargeNumberReadTest
             _testBigBigDecimals(MODE_INPUT_STREAM, false);
             fail("Should not pass");
         } catch (StreamConstraintsException e) {
-            verifyException(e, "Invalid numeric value ", "exceeds the maximum length");
+            verifyException(e, "Invalid numeric value ", "exceeds the maximum");
         }
         try {
             _testBigBigDecimals(MODE_INPUT_STREAM_THROTTLED, false);
             fail("Should not pass");
         } catch (StreamConstraintsException jpe) {
-            verifyException(jpe, "Invalid numeric value ", "exceeds the maximum length");
+            verifyException(jpe, "Invalid numeric value ", "exceeds the maximum");
         }
     }
 
@@ -50,7 +50,7 @@ public class LargeNumberReadTest
             _testBigBigDecimals(MODE_READER, false);
             fail("Should not pass");
         } catch (StreamConstraintsException jpe) {
-            verifyException(jpe, "Invalid numeric value ", "exceeds the maximum length");
+            verifyException(jpe, "Invalid numeric value ", "exceeds the maximum");
         }
     }
 
@@ -65,7 +65,7 @@ public class LargeNumberReadTest
             _testBigBigDecimals(MODE_DATA_INPUT, false);
             fail("Should not pass");
         } catch (StreamConstraintsException jpe) {
-            verifyException(jpe, "Invalid numeric value ", "exceeds the maximum length");
+            verifyException(jpe, "Invalid numeric value ", "exceeds the maximum allowed");
         }
     }
 

--- a/src/test/java/com/fasterxml/jackson/core/dos/PerfBigDecimalToInteger968Test.java
+++ b/src/test/java/com/fasterxml/jackson/core/dos/PerfBigDecimalToInteger968Test.java
@@ -22,7 +22,7 @@ public class PerfBigDecimalToInteger968Test
                 p.getBigIntegerValue();
                 Assert.fail("Should not pass");
             } catch (StreamConstraintsException e) {
-                Assert.assertEquals("BigDecimal scale (-25000000) magnitude exceeds maximum allowed (100000)", e.getMessage());
+                Assert.assertEquals("BigDecimal scale (-25000000) magnitude exceeds the maximum allowed (100000)", e.getMessage());
             }
         }
     }
@@ -37,7 +37,7 @@ public class PerfBigDecimalToInteger968Test
                 p.getBigIntegerValue();
                 Assert.fail("Should not pass");
             } catch (StreamConstraintsException e) {
-                Assert.assertEquals("BigDecimal scale (25000000) magnitude exceeds maximum allowed (100000)", e.getMessage());
+                Assert.assertEquals("BigDecimal scale (25000000) magnitude exceeds the maximum allowed (100000)", e.getMessage());
             }
         }
     }

--- a/src/test/java/com/fasterxml/jackson/core/json/async/AsyncStringArrayTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/json/async/AsyncStringArrayTest.java
@@ -153,9 +153,9 @@ public class AsyncStringArrayTest extends AsyncTestBase
             fail("expected IOException");
         } catch (IOException ie) {
             assertTrue("unexpected exception message: " + ie.getMessage(),
-                    ie.getMessage().startsWith("String length"));
+                    ie.getMessage().startsWith("String value length"));
             assertTrue("unexpected exception message: " + ie.getMessage(),
-                    ie.getMessage().endsWith("exceeds the maximum length (100)"));
+                    ie.getMessage().contains("exceeds the maximum allowed (100"));
         }
     }
 


### PR DESCRIPTION
As per #1007 improve exception messages to provide more useful reference for developers, without adding novel-length explanations :)