### PR TITLE
Allow override of `StreamReadContraints` default with `overrideDefaultStreamReadConstraints()`

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/StreamReadConstraints.java
+++ b/src/main/java/com/fasterxml/jackson/core/StreamReadConstraints.java
@@ -54,8 +54,31 @@ public class StreamReadConstraints
     protected final int _maxNumLen;
     protected final int _maxStringLen;
 
-    private static final StreamReadConstraints DEFAULT =
+    private static StreamReadConstraints DEFAULT =
         new StreamReadConstraints(DEFAULT_MAX_DEPTH, DEFAULT_MAX_NUM_LEN, DEFAULT_MAX_STRING_LEN);
+
+    /**
+     * Override the default StreamReadConstraints. These defaults are only used when {@link JsonFactory}
+     * instances are not configured with their own StreamReadConstraints.
+     * <p>
+     * Library maintainers should not set this as it will affect other code that uses Jackson.
+     * Library maintainers should configure the <code>ObjectMapper</code>s that they create using a
+     * {@link JsonFactory} instance.
+     * This method is meant for users delivering applications. If they use this, they set it when they start
+     * their application to avoid having other code initialize their mappers before the defaults are overridden.
+     *
+     * @param streamReadConstraints new default for StreamReadConstraints (a null value will reset to built-in default)
+     * @see #defaults()
+     * @see #builder()
+     * @since v2.15.1
+     */
+    public static void overrideDefaultStreamReadConstraints(final StreamReadConstraints streamReadConstraints) {
+        if (streamReadConstraints == null) {
+            DEFAULT = new StreamReadConstraints(DEFAULT_MAX_DEPTH, DEFAULT_MAX_NUM_LEN, DEFAULT_MAX_STRING_LEN);
+        } else {
+            DEFAULT = streamReadConstraints;
+        }
+    }
 
     public static final class Builder {
         private int maxNestingDepth;

--- a/src/main/java/com/fasterxml/jackson/core/StreamReadConstraints.java
+++ b/src/main/java/com/fasterxml/jackson/core/StreamReadConstraints.java
@@ -75,7 +75,7 @@ public class StreamReadConstraints
      * @param streamReadConstraints new default for StreamReadConstraints (a null value will reset to built-in default)
      * @see #defaults()
      * @see #builder()
-     * @since v2.15.1
+     * @since v2.15.2
      */
     public static void overrideDefaultStreamReadConstraints(final StreamReadConstraints streamReadConstraints) {
         if (streamReadConstraints == null) {

--- a/src/main/java/com/fasterxml/jackson/core/StreamReadConstraints.java
+++ b/src/main/java/com/fasterxml/jackson/core/StreamReadConstraints.java
@@ -181,6 +181,10 @@ public class StreamReadConstraints
         return new Builder();
     }
 
+    /**
+     * @return the default {@link StreamReadConstraints} (when none is set on the {@link JsonFactory} explicitly)
+     * @see #overrideDefaultStreamReadConstraints
+     */
     public static StreamReadConstraints defaults() {
         return DEFAULT;
     }

--- a/src/main/java/com/fasterxml/jackson/core/StreamReadConstraints.java
+++ b/src/main/java/com/fasterxml/jackson/core/StreamReadConstraints.java
@@ -62,8 +62,10 @@ public class StreamReadConstraints
      * instances are not configured with their own StreamReadConstraints.
      * <p>
      * Library maintainers should not set this as it will affect other code that uses Jackson.
-     * Library maintainers should configure the <code>ObjectMapper</code>s that they create using a
-     * {@link JsonFactory} instance.
+     * Library maintainers who want to configure StreamReadConstraints for the Jackson usage within their
+     * lib should create <code>ObjectMapper</code> instances that have a {@link JsonFactory} instance with
+     * the required StreamReadConstraints.
+     * <p>
      * This method is meant for users delivering applications. If they use this, they set it when they start
      * their application to avoid having other code initialize their mappers before the defaults are overridden.
      *

--- a/src/test/java/com/fasterxml/jackson/core/TestStreamReadConstraints.java
+++ b/src/test/java/com/fasterxml/jackson/core/TestStreamReadConstraints.java
@@ -1,0 +1,33 @@
+package com.fasterxml.jackson.core;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class TestStreamReadConstraints {
+    @Test
+    public void testOverride() {
+        final int numLen = 1234;
+        final int strLen = 12345;
+        final int depth = 123;
+        StreamReadConstraints constraints = StreamReadConstraints.builder()
+                .maxNumberLength(numLen)
+                .maxStringLength(strLen)
+                .maxNestingDepth(depth)
+                .build();
+        try {
+            StreamReadConstraints.overrideDefaultStreamReadConstraints(constraints);
+            assertEquals(depth, StreamReadConstraints.defaults().getMaxNestingDepth());
+            assertEquals(strLen, StreamReadConstraints.defaults().getMaxStringLength());
+            assertEquals(numLen, StreamReadConstraints.defaults().getMaxNumberLength());
+        } finally {
+            StreamReadConstraints.overrideDefaultStreamReadConstraints(null);
+            assertEquals(StreamReadConstraints.DEFAULT_MAX_DEPTH,
+                    StreamReadConstraints.defaults().getMaxNestingDepth());
+            assertEquals(StreamReadConstraints.DEFAULT_MAX_STRING_LEN,
+                    StreamReadConstraints.defaults().getMaxStringLength());
+            assertEquals(StreamReadConstraints.DEFAULT_MAX_NUM_LEN,
+                    StreamReadConstraints.defaults().getMaxNumberLength());
+        }
+    }
+}


### PR DESCRIPTION
if this approach is acceptable, I can extend this PR with some tests