### PR TITLE
Fix #1014: increase max string value length from 5 to 20 million characters

### DIFF
--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -20,6 +20,7 @@ JSON library.
    `ch.randelshofer:fastdoubleparser`
   (reported by Chris R)
 #1003: Add FastDoubleParser section to `NOTICE`
+#1014: Increase default max allowed String value length from 5 megs to 20 megs
 
 2.15.0 (23-Apr-2023)
 

--- a/src/main/java/com/fasterxml/jackson/core/StreamReadConstraints.java
+++ b/src/main/java/com/fasterxml/jackson/core/StreamReadConstraints.java
@@ -14,7 +14,7 @@ import com.fasterxml.jackson.core.exc.StreamConstraintsException;
  * <ul>
  *  <li>Maximum Number value length: default 1000 (see {@link #DEFAULT_MAX_NUM_LEN})
  *   </li>
- *  <li>Maximum String value length: default 5_000_000 (see {@link #DEFAULT_MAX_STRING_LEN})
+ *  <li>Maximum String value length: default 20_000_000 (see {@link #DEFAULT_MAX_STRING_LEN})
  *   </li>
  *  <li>Maximum Nesting depth: default 1000 (see {@link #DEFAULT_MAX_DEPTH})
  *   </li>
@@ -38,9 +38,12 @@ public class StreamReadConstraints
     public static final int DEFAULT_MAX_NUM_LEN = 1000;
 
     /**
-     * Default setting for maximum string length: see {@link Builder#maxStringLength(int)} for details.
+     * Default setting for maximum string length: see {@link Builder#maxStringLength(int)}
+     * for details.
+     *<p>
+     * NOTE: Jackson 2.15.0 initially used a lower setting (5_000_000).
      */
-    public static final int DEFAULT_MAX_STRING_LEN = 5_000_000;
+    public static final int DEFAULT_MAX_STRING_LEN = 20_000_000;
 
     /**
      * Limit for the maximum magnitude of Scale of {@link java.math.BigDecimal} that can be
@@ -98,13 +101,15 @@ public class StreamReadConstraints
 
         /**
          * Sets the maximum string length (in chars or bytes, depending on input context).
-         * The default is 5,000,000. This limit is not exact, the limit is applied when we increase
+         * The default is 20,000,000. This limit is not exact, the limit is applied when we increase
          * internal buffer sizes and an exception will happen at sizes greater than this limit. Some
          * text values that are a little bigger than the limit may be treated as valid but no text
          * values with sizes less than or equal to this limit will be treated as invalid.
          * <p>
          *   Setting this value to lower than the {@link #maxNumberLength(int)} is not recommended.
          * </p>
+         *<p>
+         * NOTE: Jackson 2.15.0 initially used a lower setting (5_000_000).
          *
          * @param maxStringLen the maximum string length (in chars or bytes, depending on input context)
          *


### PR DESCRIPTION
Fixes #1014 by increasing max string value length to 20 M from 5 M