### PR TITLE
Feature Request - allow all array elements in JsonPointerBasedFilter - updated

### DIFF
--- a/src/main/java/tools/jackson/core/filter/JsonPointerBasedFilter.java
+++ b/src/main/java/tools/jackson/core/filter/JsonPointerBasedFilter.java
@@ -13,25 +13,47 @@ import tools.jackson.core.JsonPointer;
 public class JsonPointerBasedFilter extends TokenFilter
 {
     protected final JsonPointer _pathToMatch;
+    /**
+     * if true include all array elements by ignoring the array index match and advancing the JsonPointer to the next level
+     */
+    protected final boolean _includeAllElements;
 
     public JsonPointerBasedFilter(String ptrExpr) {
-        this(JsonPointer.compile(ptrExpr));
+        this(JsonPointer.compile(ptrExpr), false);
     }
 
     public JsonPointerBasedFilter(JsonPointer match) {
+        this(match, false);
+    }
+
+    /**
+     * @param ptrExpr to extract.
+     * @param includeAllElements if true array indexes in <code>ptrExpr</code> are ignored and all elements will be matched. default: false
+     */
+    public JsonPointerBasedFilter(String ptrExpr, boolean includeAllElements) {
+        this(JsonPointer.compile(ptrExpr), includeAllElements);
+    }
+
+    public JsonPointerBasedFilter(JsonPointer match, boolean includeAllElements) {
         _pathToMatch = match;
+        _includeAllElements = includeAllElements;
     }
 
     @Override
     public TokenFilter includeElement(int index) {
-        JsonPointer next = _pathToMatch.matchElement(index);
+        JsonPointer next;
+        if (_includeAllElements && ! _pathToMatch.mayMatchElement()) {
+            next = _pathToMatch.tail();
+        } else {
+            next = _pathToMatch.matchElement(index);
+        }
         if (next == null) {
             return null;
         }
         if (next.matches()) {
             return TokenFilter.INCLUDE_ALL;
         }
-        return new JsonPointerBasedFilter(next);
+        return new JsonPointerBasedFilter(next, _includeAllElements);
     }
 
     @Override
@@ -43,7 +65,7 @@ public class JsonPointerBasedFilter extends TokenFilter
         if (next.matches()) {
             return TokenFilter.INCLUDE_ALL;
         }
-        return new JsonPointerBasedFilter(next);
+        return new JsonPointerBasedFilter(next, _includeAllElements);
     }
 
     @Override


### PR DESCRIPTION
Currently `JsonPointerBasedFilter` only processes Json Arrays by index. eg `/0/id`.

With this change it is possible to extract all elements using a pointer in the form of `//id`: 

source:
```
[
   {
      "id":1,
      "stuff":[
         {
            "name":"first",
            "type":"a"
         },
         {
            "name":"second",
            "type":"b"
         }
      ]
   },
   {
      "id":2,
      "stuff":[
         {
            "name":"third",
            "type":"c"
         },
         {
            "name":"fourth",
            "type":"d"
         }
      ]
   }
]
```

pointers:
```
"//id"
"//stuff//name"
```

result:
```
[
   {
      "id":1,
      "stuff":[
         {
            "name":"first"
         },
         {
            "name":"second"
         }
      ]
   },
   {
      "id":2,
      "stuff":[
         {
            "name":"third"
         },
         {
            "name":"fourth"
         }
      ]
   }
]
```