### PR TITLE
Fix breaking builds by removing `assertj` dependency and test usage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -317,11 +317,6 @@ com.fasterxml.jackson.core.*;version=${project.version}
       <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.assertj</groupId>
-      <artifactId>assertj-core</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
 </project>

--- a/src/test/java/com/fasterxml/jackson/core/JsonLocationTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/JsonLocationTest.java
@@ -6,8 +6,6 @@ import java.io.InputStream;
 
 import com.fasterxml.jackson.core.io.ContentReference;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 public class JsonLocationTest extends BaseTest
 {
     static class Foobar { }
@@ -122,7 +120,7 @@ public class JsonLocationTest extends BaseTest
         verifyException(e, "unrecognized token");
         JsonLocation loc = e.getLocation();
         assertNull(loc.contentReference().getRawContent());
-        assertThat(loc.sourceDescription()).startsWith("REDACTED");
+        assertTrue(loc.sourceDescription().startsWith("REDACTED"));
     }
     
     // for [jackson-core#739]: try to support equality


### PR DESCRIPTION
This should fix failing builds. I suppose `assertj` dependency was added automatically by IDE, by accident? 🤔

Please feel free to close the PR if this seems unncessary, thanks! 🙏🏼