### PR TITLE
support snapshot versioning

### DIFF
--- a/src/main/java/tools/jackson/core/Version.java
+++ b/src/main/java/tools/jackson/core/Version.java
@@ -95,7 +95,7 @@ public class Version
     }
 
     @Override public int hashCode() {
-        return _artifactId.hashCode() ^ _groupId.hashCode()
+        return _artifactId.hashCode() ^ _groupId.hashCode() ^ _snapshotInfo.hashCode()
                 + _majorVersion - _minorVersion + _patchLevel;
     }
 
@@ -130,7 +130,15 @@ public class Version
                     if (diff == 0) {
                         diff = _patchLevel - other._patchLevel;
                         if (diff == 0) {
+                          if (isSnapshot() && other.isSnapshot()) {
                             diff = _snapshotInfo.compareTo(other._snapshotInfo);
+                          } else if (isSnapshot() && !other.isSnapshot()) {
+                            diff = -1;
+                          } else if (!isSnapshot() && other.isSnapshot()) {
+                            diff = 1;
+                          } else {
+                            diff = 0;
+                          }
                         }
                     }
                 }

--- a/src/test/java/tools/jackson/core/VersionTest.java
+++ b/src/test/java/tools/jackson/core/VersionTest.java
@@ -40,4 +40,32 @@ public class VersionTest extends BaseTest
 
       assertTrue(version.compareTo(versionTwo) < 0);
   }
+
+  public void testCompareToSnapshotSame() {
+      Version version = new Version(0, 0, 0, "alpha", null, null);
+      Version versionTwo = new Version(0, 0, 0, "alpha", null, null);
+
+      assertEquals(0, version.compareTo(versionTwo));
+  }
+
+  public void testCompareToSnapshotDifferent() {
+      Version version = new Version(0, 0, 0, "alpha", null, null);
+      Version versionTwo = new Version(0, 0, 0, "beta", null, null);
+
+      assertTrue(version.compareTo(versionTwo) < 0);
+  }
+
+  public void testCompareWhenOnlyFirstHasSnapshot() {
+      Version version = new Version(0, 0, 0, "beta", null, null);
+      Version versionTwo = new Version(0, 0, 0, null, null, null);
+
+      assertEquals(-1, version.compareTo(versionTwo));
+  }
+
+  public void testCompareWhenOnlySecondHasSnapshot() {
+      Version version = new Version(0, 0, 0, "", null, null);
+      Version versionTwo = new Version(0, 0, 0, "beta", null, null);
+
+      assertEquals(1, version.compareTo(versionTwo));
+  }
 }


### PR DESCRIPTION
Fixes the snapshot diffing to reflect semver.com `1.0.0` is considered newer than `1.0.0-beta`

Also adds the snapshot version to hashCode

Closes #1050 
Same as #1053 but rebased onto master