### PR TITLE
Add StreamWriteConstraints with a nesting depth check

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/JsonGenerator.java
+++ b/src/main/java/com/fasterxml/jackson/core/JsonGenerator.java
@@ -342,6 +342,15 @@ public abstract class JsonGenerator
     public abstract ObjectCodec getCodec();
 
     /**
+     * Get the constraints to apply when performing streaming writes.
+     *
+     * @since 2.16
+     */
+    public StreamWriteConstraints streamWriteConstraints() {
+        return StreamWriteConstraints.defaults();
+    }
+
+    /**
      * Accessor for finding out version of the bundle that provided this generator instance.
      *
      * @return Version of this generator (derived from version declared for

--- a/src/main/java/com/fasterxml/jackson/core/StreamWriteConstraints.java
+++ b/src/main/java/com/fasterxml/jackson/core/StreamWriteConstraints.java
@@ -1,0 +1,157 @@
+package com.fasterxml.jackson.core;
+
+import com.fasterxml.jackson.core.exc.StreamConstraintsException;
+
+/**
+ * The constraints to use for streaming writes: used to guard against problematic
+ * output by preventing processing of "too big" output constructs (values,
+ * structures).
+ * Constraints are registered with {@code TokenStreamFactory} (such as
+ * {@code JsonFactory}); if nothing explicitly specified, default
+ * constraints are used.
+ *<p>
+ * Currently constrained aspects, with default settings, are:
+ * <ul>
+ *  <li>Maximum Nesting depth: default 1000 (see {@link #DEFAULT_MAX_DEPTH})
+ *   </li>
+ * </ul>
+ *
+ * @since 2.16
+ */
+public class StreamWriteConstraints
+    implements java.io.Serializable
+{
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Default setting for maximum depth: see {@link Builder#maxNestingDepth(int)} for details.
+     */
+    public static final int DEFAULT_MAX_DEPTH = 1000;
+
+    protected final int _maxNestingDepth;
+
+    private static final StreamWriteConstraints DEFAULT =
+        new StreamWriteConstraints(DEFAULT_MAX_DEPTH);
+
+    public static final class Builder {
+        private int maxNestingDepth;
+
+        /**
+         * Sets the maximum nesting depth. The depth is a count of objects and arrays that have not
+         * been closed, `{` and `[` respectively.
+         *
+         * @param maxNestingDepth the maximum depth
+         *
+         * @return this builder
+         * @throws IllegalArgumentException if the maxNestingDepth is set to a negative value
+         */
+        public Builder maxNestingDepth(final int maxNestingDepth) {
+            if (maxNestingDepth < 0) {
+                throw new IllegalArgumentException("Cannot set maxNestingDepth to a negative value");
+            }
+            this.maxNestingDepth = maxNestingDepth;
+            return this;
+        }
+
+        Builder() {
+            this(DEFAULT_MAX_DEPTH);
+        }
+
+        Builder(final int maxNestingDepth) {
+            this.maxNestingDepth = maxNestingDepth;
+        }
+
+        Builder(StreamWriteConstraints src) {
+            maxNestingDepth = src._maxNestingDepth;
+        }
+
+        public StreamWriteConstraints build() {
+            return new StreamWriteConstraints(maxNestingDepth);
+        }
+    }
+
+    /*
+    /**********************************************************************
+    /* Life-cycle
+    /**********************************************************************
+     */
+
+    protected StreamWriteConstraints(final int maxNestingDepth) {
+        _maxNestingDepth = maxNestingDepth;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static StreamWriteConstraints defaults() {
+        return DEFAULT;
+    }
+
+    /**
+     * @return New {@link Builder} initialized with settings of this constraints
+     *   instance
+     */
+    public Builder rebuild() {
+        return new Builder(this);
+    }
+
+    /*
+    /**********************************************************************
+    /* Accessors
+    /**********************************************************************
+     */
+
+    /**
+     * Accessor for maximum depth.
+     * see {@link Builder#maxNestingDepth(int)} for details.
+     *
+     * @return Maximum allowed depth
+     */
+    public int getMaxNestingDepth() {
+        return _maxNestingDepth;
+    }
+
+    /*
+    /**********************************************************************
+    /* Convenience methods for validation, document limits
+    /**********************************************************************
+     */
+
+    /**
+     * Convenience method that can be used to verify that the
+     * nesting depth does not exceed the maximum specified by this
+     * constraints object: if it does, a
+     * {@link StreamConstraintsException}
+     * is thrown.
+     *
+     * @param depth count of unclosed objects and arrays
+     *
+     * @throws StreamConstraintsException If depth exceeds maximum
+     */
+    public void validateNestingDepth(int depth) throws StreamConstraintsException
+    {
+        if (depth > _maxNestingDepth) {
+            throw _constructException(
+                    "Document nesting depth (%d) exceeds the maximum allowed (%d, from %s)",
+                    depth, _maxNestingDepth,
+                    _constrainRef("getMaxNestingDepth"));
+        }
+    }
+
+    /*
+    /**********************************************************************
+    /* Error reporting
+    /**********************************************************************
+     */
+
+    // @since 2.16
+    protected StreamConstraintsException _constructException(String msgTemplate, Object... args) throws StreamConstraintsException {
+        throw new StreamConstraintsException(String.format(msgTemplate, args));
+    }
+
+    // @since 2.16
+    protected String _constrainRef(String method) {
+        return "`StreamWriteConstraints."+method+"()`";
+    }
+}

--- a/src/main/java/com/fasterxml/jackson/core/TSFBuilder.java
+++ b/src/main/java/com/fasterxml/jackson/core/TSFBuilder.java
@@ -78,11 +78,18 @@ public abstract class TSFBuilder<F extends JsonFactory,
     protected OutputDecorator _outputDecorator;
 
     /**
-     * Optional StreamReadConfig.
+     * Optional StreamReadConstraints.
      *
      * @since 2.15
      */
     protected StreamReadConstraints _streamReadConstraints;
+
+    /**
+     * Optional StreamWriteConstraints.
+     *
+     * @since 2.16
+     */
+    protected StreamWriteConstraints _streamWriteConstraints;
 
     /*
     /**********************************************************************
@@ -279,6 +286,18 @@ public abstract class TSFBuilder<F extends JsonFactory,
      */
     public B streamReadConstraints(StreamReadConstraints streamReadConstraints) {
         _streamReadConstraints = streamReadConstraints;
+        return _this();
+    }
+
+    /**
+     * Sets the constraints for streaming writes.
+     *
+     * @param streamWriteConstraints constraints for streaming reads
+     * @return this factory
+     * @since 2.16
+     */
+    public B streamWriteConstraints(StreamWriteConstraints streamWriteConstraints) {
+        _streamWriteConstraints = streamWriteConstraints;
         return _this();
     }
 

--- a/src/main/java/com/fasterxml/jackson/core/TokenStreamFactory.java
+++ b/src/main/java/com/fasterxml/jackson/core/TokenStreamFactory.java
@@ -153,6 +153,16 @@ public abstract class TokenStreamFactory
      */
     public abstract StreamReadConstraints streamReadConstraints();
 
+    /**
+     * Get the constraints to apply when performing streaming writes.
+     *
+     * @return Constraints to apply to reads done by {@link JsonGenerator}s constructed
+     *   by this factory.
+     *
+     * @since 2.16
+     */
+    public abstract StreamWriteConstraints streamWriteConstraints();
+
     /*
     /**********************************************************************
     /* Factory methods, parsers

--- a/src/main/java/com/fasterxml/jackson/core/filter/TokenFilterContext.java
+++ b/src/main/java/com/fasterxml/jackson/core/filter/TokenFilterContext.java
@@ -71,6 +71,7 @@ public class TokenFilterContext extends JsonStreamContext
         super();
         _type = type;
         _parent = parent;
+        _nestingDepth = parent == null ? 0 : parent._nestingDepth + 1;
         _filter = filter;
         _index = -1;
         _startHandled = startHandled;

--- a/src/main/java/com/fasterxml/jackson/core/json/JsonGeneratorImpl.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/JsonGeneratorImpl.java
@@ -140,6 +140,17 @@ public abstract class JsonGeneratorImpl extends GeneratorBase
     }
 
     /*
+    /**********************************************************************
+    /* Constraints violation checking (2.16)
+    /**********************************************************************
+     */
+
+    @Override
+    public StreamWriteConstraints streamWriteConstraints() {
+        return _ioContext.streamWriteConstraints();
+    }
+
+    /*
     /**********************************************************
     /* Overridden configuration methods
     /**********************************************************

--- a/src/main/java/com/fasterxml/jackson/core/json/JsonWriteContext.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/JsonWriteContext.java
@@ -69,6 +69,7 @@ public class JsonWriteContext extends JsonStreamContext
         super();
         _type = type;
         _parent = parent;
+        _nestingDepth = parent == null ? 0 : parent._nestingDepth + 1;
         _dups = dups;
         _index = -1;
     }
@@ -79,6 +80,7 @@ public class JsonWriteContext extends JsonStreamContext
         super();
         _type = type;
         _parent = parent;
+        _nestingDepth = parent == null ? 0 : parent._nestingDepth + 1;
         _dups = dups;
         _index = -1;
         _currentValue = currValue;

--- a/src/main/java/com/fasterxml/jackson/core/json/UTF8JsonGenerator.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/UTF8JsonGenerator.java
@@ -312,6 +312,7 @@ public class UTF8JsonGenerator
     {
         _verifyValueWrite("start an array");
         _writeContext = _writeContext.createChildArrayContext();
+        streamWriteConstraints().validateNestingDepth(_writeContext.getNestingDepth());
         if (_cfgPrettyPrinter != null) {
             _cfgPrettyPrinter.writeStartArray(this);
         } else {
@@ -327,6 +328,7 @@ public class UTF8JsonGenerator
     {
         _verifyValueWrite("start an array");
         _writeContext = _writeContext.createChildArrayContext(currentValue);
+        streamWriteConstraints().validateNestingDepth(_writeContext.getNestingDepth());
         if (_cfgPrettyPrinter != null) {
             _cfgPrettyPrinter.writeStartArray(this);
         } else {
@@ -342,6 +344,7 @@ public class UTF8JsonGenerator
     {
         _verifyValueWrite("start an array");
         _writeContext = _writeContext.createChildArrayContext(currentValue);
+        streamWriteConstraints().validateNestingDepth(_writeContext.getNestingDepth());
         if (_cfgPrettyPrinter != null) {
             _cfgPrettyPrinter.writeStartArray(this);
         } else {
@@ -374,6 +377,7 @@ public class UTF8JsonGenerator
     {
         _verifyValueWrite("start an object");
         _writeContext = _writeContext.createChildObjectContext();
+        streamWriteConstraints().validateNestingDepth(_writeContext.getNestingDepth());
         if (_cfgPrettyPrinter != null) {
             _cfgPrettyPrinter.writeStartObject(this);
         } else {
@@ -389,6 +393,7 @@ public class UTF8JsonGenerator
     {
         _verifyValueWrite("start an object");
         JsonWriteContext ctxt = _writeContext.createChildObjectContext(forValue);
+        streamWriteConstraints().validateNestingDepth(ctxt.getNestingDepth());
         _writeContext = ctxt;
         if (_cfgPrettyPrinter != null) {
             _cfgPrettyPrinter.writeStartObject(this);

--- a/src/main/java/com/fasterxml/jackson/core/json/WriterBasedJsonGenerator.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/WriterBasedJsonGenerator.java
@@ -251,6 +251,7 @@ public class WriterBasedJsonGenerator
     {
         _verifyValueWrite("start an array");
         _writeContext = _writeContext.createChildArrayContext();
+        streamWriteConstraints().validateNestingDepth(_writeContext.getNestingDepth());
         if (_cfgPrettyPrinter != null) {
             _cfgPrettyPrinter.writeStartArray(this);
         } else {
@@ -266,6 +267,7 @@ public class WriterBasedJsonGenerator
     {
         _verifyValueWrite("start an array");
         _writeContext = _writeContext.createChildArrayContext(currentValue);
+        streamWriteConstraints().validateNestingDepth(_writeContext.getNestingDepth());
         if (_cfgPrettyPrinter != null) {
             _cfgPrettyPrinter.writeStartArray(this);
         } else {
@@ -281,6 +283,7 @@ public class WriterBasedJsonGenerator
     {
         _verifyValueWrite("start an array");
         _writeContext = _writeContext.createChildArrayContext(currentValue);
+        streamWriteConstraints().validateNestingDepth(_writeContext.getNestingDepth());
         if (_cfgPrettyPrinter != null) {
             _cfgPrettyPrinter.writeStartArray(this);
         } else {
@@ -313,6 +316,7 @@ public class WriterBasedJsonGenerator
     {
         _verifyValueWrite("start an object");
         _writeContext = _writeContext.createChildObjectContext();
+        streamWriteConstraints().validateNestingDepth(_writeContext.getNestingDepth());
         if (_cfgPrettyPrinter != null) {
             _cfgPrettyPrinter.writeStartObject(this);
         } else {
@@ -328,6 +332,7 @@ public class WriterBasedJsonGenerator
     {
         _verifyValueWrite("start an object");
         JsonWriteContext ctxt = _writeContext.createChildObjectContext(forValue);
+        streamWriteConstraints().validateNestingDepth(_writeContext.getNestingDepth());
         _writeContext = ctxt;
         if (_cfgPrettyPrinter != null) {
             _cfgPrettyPrinter.writeStartObject(this);

--- a/src/main/java/com/fasterxml/jackson/core/util/JsonGeneratorDelegate.java
+++ b/src/main/java/com/fasterxml/jackson/core/util/JsonGeneratorDelegate.java
@@ -188,6 +188,17 @@ public class JsonGeneratorDelegate extends JsonGenerator
 
     /*
     /**********************************************************************
+    /* Constraints violation checking (2.16)
+    /**********************************************************************
+     */
+
+    @Override
+    public StreamWriteConstraints streamWriteConstraints() {
+        return delegate.streamWriteConstraints();
+    }
+
+    /*
+    /**********************************************************************
     /* Public API, write methods, structural
     /**********************************************************************
      */

--- a/src/test/java/com/fasterxml/jackson/core/write/WriterBasedJsonGeneratorTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/write/WriterBasedJsonGeneratorTest.java
@@ -1,0 +1,55 @@
+package com.fasterxml.jackson.core.write;
+
+import com.fasterxml.jackson.core.BaseTest;
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.StreamWriteConstraints;
+import com.fasterxml.jackson.core.exc.StreamConstraintsException;
+import com.fasterxml.jackson.core.io.ContentReference;
+import com.fasterxml.jackson.core.io.IOContext;
+import com.fasterxml.jackson.core.json.WriterBasedJsonGenerator;
+import com.fasterxml.jackson.core.util.BufferRecycler;
+
+import java.io.StringWriter;
+
+public class WriterBasedJsonGeneratorTest extends BaseTest
+{
+    private final JsonFactory JSON_F = new JsonFactory();
+
+    public void testNestingDepthWithSmallLimit() throws Exception
+    {
+        StringWriter sw = new StringWriter();
+        IOContext ioc = new IOContext(null,
+                StreamWriteConstraints.builder().maxNestingDepth(1).build(),
+                new BufferRecycler(),
+                ContentReference.rawReference(sw), true);
+        try (JsonGenerator gen = new WriterBasedJsonGenerator(ioc, 0, null, sw, '"')) {
+            gen.writeStartObject();
+            gen.writeFieldName("array");
+            gen.writeStartArray();
+            fail("expected StreamConstraintsException");
+        } catch (StreamConstraintsException sce) {
+            String expected = "Document nesting depth (2) exceeds the maximum allowed (1, from `StreamWriteConstraints.getMaxNestingDepth()`)";
+            assertEquals(expected, sce.getMessage());
+        }
+    }
+
+    public void testNestingDepthWithSmallLimitNestedObject() throws Exception
+    {
+        StringWriter sw = new StringWriter();
+        IOContext ioc = new IOContext(null,
+                StreamWriteConstraints.builder().maxNestingDepth(1).build(),
+                new BufferRecycler(),
+                ContentReference.rawReference(sw), true);
+        try (JsonGenerator gen = new WriterBasedJsonGenerator(ioc, 0, null, sw, '"')) {
+            gen.writeStartObject();
+            gen.writeFieldName("object");
+            gen.writeStartObject();
+            fail("expected StreamConstraintsException");
+        } catch (StreamConstraintsException sce) {
+            String expected = "Document nesting depth (2) exceeds the maximum allowed (1, from `StreamWriteConstraints.getMaxNestingDepth()`)";
+            assertEquals(expected, sce.getMessage());
+        }
+    }
+
+}


### PR DESCRIPTION
* relates to #1048 
* open for discussion - still lots of work to do
* equivalent of StreamReadConstraints
* initially, only max nesting depth is tracked
* the changes in this PR to get the Filtering Delegate Generator to check the depth are probably overkill - the underlying JsonGenerator (the one being delegated to) is probably tracking already
* and tests, of course