### PR TITLE
Fix inconsistent JavaDoc of `ParserBase._contentReferenceRedacted()`

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/base/ParserBase.java
+++ b/src/main/java/com/fasterxml/jackson/core/base/ParserBase.java
@@ -1543,7 +1543,7 @@ public abstract class ParserBase extends ParserMinimalBase
      * and source information is <b>NOT</b> to be included
      * ({@code StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION} disabled).
      *<p>
-     * Default implementation will simply return {@code ContentReference.unknown()}.
+     * Default implementation will simply return {@link ContentReference#redacted()}.
      *
      * @return ContentReference object to use when source is not to be included
      *


### PR DESCRIPTION
The actual implementation is

```java
    protected ContentReference _contentReferenceRedacted() {
        return ContentReference.redacted();
    }
```

... whereas the JavaDoc says
```java
*<p>
* Default implementation will simply return {@code ContentReference.unknown()}.
```