### PR TITLE
constructor param ignored

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/util/ByteArrayBuilder.java
+++ b/src/main/java/com/fasterxml/jackson/core/util/ByteArrayBuilder.java
@@ -63,7 +63,7 @@ public final class ByteArrayBuilder extends OutputStream
     }
 
     private ByteArrayBuilder(BufferRecycler br, byte[] initialBlock, int initialLen) {
-        _bufferRecycler = null;
+        _bufferRecycler = br;
         _currBlock = initialBlock;
         _currBlockPtr = initialLen;
     }


### PR DESCRIPTION
* relates to #1058 
* the only usage is from this method which hardcodes bufferRecycler=null
```
    public static ByteArrayBuilder fromInitial(byte[] initialBlock, int length) {
        return new ByteArrayBuilder(null, initialBlock, length);
    }
```
* seems tidier to not ignore to constructor param in case something else starts using the constructor