### PR TITLE
StreamWriteConstraints.overrideDefaultStreamWriteConstraints

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/StreamWriteConstraints.java
+++ b/src/main/java/com/fasterxml/jackson/core/StreamWriteConstraints.java
@@ -30,8 +30,31 @@ public class StreamWriteConstraints
 
     protected final int _maxNestingDepth;
 
-    private static final StreamWriteConstraints DEFAULT =
-        new StreamWriteConstraints(DEFAULT_MAX_DEPTH);
+    private static StreamWriteConstraints DEFAULT = new StreamWriteConstraints(DEFAULT_MAX_DEPTH);
+
+    /**
+     * Override the default StreamWriteConstraints. These defaults are only used when {@link JsonFactory}
+     * instances are not configured with their own StreamWriteConstraints.
+     * <p>
+     * Library maintainers should not set this as it will affect other code that uses Jackson.
+     * Library maintainers who want to configure StreamWriteConstraints for the Jackson usage within their
+     * lib should create <code>ObjectMapper</code> instances that have a {@link JsonFactory} instance with
+     * the required StreamWriteConstraints.
+     * <p>
+     * This method is meant for users delivering applications. If they use this, they set it when they start
+     * their application to avoid having other code initialize their mappers before the defaults are overridden.
+     *
+     * @param streamWriteConstraints new default for StreamWriteConstraints (a null value will reset to built-in default)
+     * @see #defaults()
+     * @see #builder()
+     */
+    public static void overrideDefaultStreamWriteConstraints(final StreamWriteConstraints streamWriteConstraints) {
+        if (streamWriteConstraints == null) {
+            DEFAULT = new StreamWriteConstraints(DEFAULT_MAX_DEPTH);
+        } else {
+            DEFAULT = streamWriteConstraints;
+        }
+    }
 
     public static final class Builder {
         private int maxNestingDepth;
@@ -84,6 +107,10 @@ public class StreamWriteConstraints
         return new Builder();
     }
 
+    /**
+     * @return the default {@link StreamWriteConstraints} (when none is set on the {@link JsonFactory} explicitly)
+     * @see #overrideDefaultStreamWriteConstraints(StreamWriteConstraints)
+     */
     public static StreamWriteConstraints defaults() {
         return DEFAULT;
     }

--- a/src/test/java/com/fasterxml/jackson/core/constraints/StreamWriteConstraintsDefaultsTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/constraints/StreamWriteConstraintsDefaultsTest.java
@@ -1,0 +1,24 @@
+package com.fasterxml.jackson.core.constraints;
+
+import com.fasterxml.jackson.core.StreamWriteConstraints;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class StreamWriteConstraintsDefaultsTest {
+    @Test
+    public void testOverride() {
+        final int depth = 123;
+        StreamWriteConstraints constraints = StreamWriteConstraints.builder()
+                .maxNestingDepth(depth)
+                .build();
+        try {
+            StreamWriteConstraints.overrideDefaultStreamWriteConstraints(constraints);
+            assertEquals(depth, StreamWriteConstraints.defaults().getMaxNestingDepth());
+        } finally {
+            StreamWriteConstraints.overrideDefaultStreamWriteConstraints(null);
+            assertEquals(StreamWriteConstraints.DEFAULT_MAX_DEPTH,
+                    StreamWriteConstraints.defaults().getMaxNestingDepth());
+        }
+    }
+}


### PR DESCRIPTION
* matches up to StreamReadConstraints.overrideDefaultStreamReadConstraints
* added for similar reasons