### PR TITLE
introducing BufferRecyclerPool

### DIFF
--- a/src/main/java/tools/jackson/core/TokenStreamFactory.java
+++ b/src/main/java/tools/jackson/core/TokenStreamFactory.java
@@ -20,7 +20,6 @@ import tools.jackson.core.json.JsonFactory;
 import tools.jackson.core.sym.PropertyNameMatcher;
 import tools.jackson.core.sym.SimpleNameMatcher;
 import tools.jackson.core.util.BufferRecycler;
-import tools.jackson.core.util.BufferRecyclers;
 import tools.jackson.core.util.JacksonFeature;
 import tools.jackson.core.util.Named;
 import tools.jackson.core.util.Snapshottable;
@@ -1183,25 +1182,6 @@ public abstract class TokenStreamFactory
      */
 
     /**
-     * Method used by factory to create buffer recycler instances
-     * for parsers and generators.
-     *<p>
-     * Note: only public to give access for {@code ObjectMapper}
-     *
-     * @return BufferRecycler instance to use
-     */
-    public BufferRecycler _getBufferRecycler()
-    {
-        // 23-Apr-2015, tatu: Let's allow disabling of buffer recycling
-        //   scheme, for cases where it is considered harmful (possibly
-        //   on Android, for example)
-        if (Feature.USE_THREAD_LOCAL_FOR_BUFFER_RECYCLING.enabledIn(_factoryFeatures)) {
-            return BufferRecyclers.getBufferRecycler();
-        }
-        return new BufferRecycler();
-    }
-
-    /**
      * Overridable factory method that actually instantiates desired
      * context object.
      *
@@ -1212,7 +1192,7 @@ public abstract class TokenStreamFactory
      */
     protected IOContext _createContext(ContentReference contentRef, boolean resourceManaged) {
         return new IOContext(_streamReadConstraints, _streamWriteConstraints,
-                _getBufferRecycler(), contentRef,
+                contentRef,
                 resourceManaged, null);
     }
 
@@ -1229,7 +1209,7 @@ public abstract class TokenStreamFactory
     protected IOContext _createContext(ContentReference contentRef, boolean resourceManaged,
             JsonEncoding enc) {
         return new IOContext(_streamReadConstraints, _streamWriteConstraints,
-                _getBufferRecycler(), contentRef,
+                contentRef,
                 resourceManaged, enc);
     }
 

--- a/src/main/java/tools/jackson/core/base/GeneratorBase.java
+++ b/src/main/java/tools/jackson/core/base/GeneratorBase.java
@@ -307,7 +307,11 @@ public abstract class GeneratorBase extends JsonGenerator
      */
 
 //    @Override public abstract void flush();
-    @Override public void close() { _closed = true; }
+    @Override public void close() {
+        _closed = true;
+        _ioContext.close();
+    }
+
     @Override public boolean isClosed() { return _closed; }
 
     /*

--- a/src/main/java/tools/jackson/core/base/ParserBase.java
+++ b/src/main/java/tools/jackson/core/base/ParserBase.java
@@ -292,6 +292,7 @@ public abstract class ParserBase extends ParserMinimalBase
                 // as per [JACKSON-324], do in finally block
                 // Also, internal buffer(s) can now be released as well
                 _releaseBuffers();
+                _ioContext.close();
             }
         }
     }

--- a/src/main/java/tools/jackson/core/json/JsonFactory.java
+++ b/src/main/java/tools/jackson/core/json/JsonFactory.java
@@ -351,7 +351,7 @@ public class JsonFactory
     }
 
     protected IOContext _createNonBlockingContext(Object srcRef) {
-        return new IOContext(_streamReadConstraints, _streamWriteConstraints, _getBufferRecycler(),
+        return new IOContext(_streamReadConstraints, _streamWriteConstraints,
                 ContentReference.rawReference(srcRef), false, JsonEncoding.UTF8);
     }
 

--- a/src/main/java/tools/jackson/core/util/BufferRecyclerPool.java
+++ b/src/main/java/tools/jackson/core/util/BufferRecyclerPool.java
@@ -1,0 +1,13 @@
+package tools.jackson.core.util;
+
+public class BufferRecyclerPool {
+
+    private static final ObjectPool<BufferRecycler> pool = ObjectPool.newLockFreePool(BufferRecycler::new);
+
+    public static BufferRecycler borrowBufferRecycler() {
+        return pool.borrow();
+    }
+    public static void offerBufferRecycler(BufferRecycler bufferRecycler) {
+        pool.offer(bufferRecycler);
+    }
+}

--- a/src/main/java/tools/jackson/core/util/ObjectPool.java
+++ b/src/main/java/tools/jackson/core/util/ObjectPool.java
@@ -1,0 +1,65 @@
+package tools.jackson.core.util;
+
+import java.util.Queue;
+import java.util.concurrent.LinkedTransferQueue;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+public interface ObjectPool<T> extends AutoCloseable {
+
+    T borrow();
+    void offer(T t);
+
+    default void withPooledObject(Consumer<T> objectConsumer) {
+        T t = borrow();
+        try {
+            objectConsumer.accept(t);
+        } finally {
+            offer(t);
+        }
+    }
+
+    static <T> ObjectPool<T> newLockFreePool(Supplier<T> factory) {
+        return new LockFreeObjectPool<>(factory);
+    }
+
+    static <T> ObjectPool<T> newLockFreePool(Supplier<T> factory, Consumer<T> destroyer) {
+        return new LockFreeObjectPool<>(factory, destroyer);
+    }
+
+    class LockFreeObjectPool<T> implements ObjectPool<T> {
+        private final Supplier<T> factory;
+        private final Consumer<T> destroyer;
+
+        private final Queue<T> pool = new LinkedTransferQueue<>();
+
+        public LockFreeObjectPool(Supplier<T> factory) {
+            this(factory, null);
+        }
+
+        public LockFreeObjectPool(Supplier<T> factory, Consumer<T> destroyer) {
+            this.factory = factory;
+            this.destroyer = destroyer;
+        }
+
+        @Override
+        public T borrow() {
+//            System.out.println("Before borrow size: " + pool.size());
+            T t = pool.poll();
+            return t != null ? t : factory.get();
+        }
+
+        @Override
+        public void offer(T t) {
+            pool.offer(t);
+//            System.out.println("After offer size: " + pool.size());
+        }
+
+        @Override
+        public void close() throws Exception {
+            if (destroyer != null) {
+                pool.forEach(destroyer);
+            }
+        }
+    }
+}

--- a/src/test/java/tools/jackson/core/BaseTest.java
+++ b/src/test/java/tools/jackson/core/BaseTest.java
@@ -622,7 +622,6 @@ public abstract class BaseTest
     protected IOContext ioContextForTests(Object source) {
         return new IOContext(StreamReadConstraints.defaults(),
                 StreamWriteConstraints.defaults(),
-                new BufferRecycler(),
                 ContentReference.rawReference(source), true,
                 JsonEncoding.UTF8);
     }

--- a/src/test/java/tools/jackson/core/io/TestIOContext.java
+++ b/src/test/java/tools/jackson/core/io/TestIOContext.java
@@ -12,7 +12,6 @@ public class TestIOContext
     {
         IOContext ctxt = new IOContext(StreamReadConstraints.defaults(),
                 StreamWriteConstraints.defaults(),
-                new BufferRecycler(),
                 ContentReference.rawReference("N/A"), true,
                 JsonEncoding.UTF8);
 

--- a/src/test/java/tools/jackson/core/io/TestMergedStream.java
+++ b/src/test/java/tools/jackson/core/io/TestMergedStream.java
@@ -14,7 +14,6 @@ public class TestMergedStream
     {
         IOContext ctxt = new IOContext(StreamReadConstraints.defaults(),
                 StreamWriteConstraints.defaults(),
-                new BufferRecycler(),
                 ContentReference.UNKNOWN_CONTENT, false, JsonEncoding.UTF8);
         // bit complicated; must use recyclable buffer...
         byte[] first = ctxt.allocReadIOBuffer();

--- a/src/test/java/tools/jackson/core/io/UTF8WriterTest.java
+++ b/src/test/java/tools/jackson/core/io/UTF8WriterTest.java
@@ -105,12 +105,11 @@ public class UTF8WriterTest
     @SuppressWarnings("resource")
     public void testSurrogatesFail() throws Exception
     {
-        BufferRecycler rec = new BufferRecycler();
         ByteArrayOutputStream out;
         UTF8Writer w;
 
         out = new ByteArrayOutputStream();
-        w = new UTF8Writer( _ioContext(rec), out);
+        w = new UTF8Writer( _ioContext(), out);
         try {
             w.write(0xDE03);
             fail("should not pass");
@@ -119,7 +118,7 @@ public class UTF8WriterTest
         }
 
         out = new ByteArrayOutputStream();
-        w = new UTF8Writer(_ioContext(rec), out);
+        w = new UTF8Writer(_ioContext(), out);
         w.write(0xD83D);
         try {
             w.write('a');
@@ -129,7 +128,7 @@ public class UTF8WriterTest
         }
 
         out = new ByteArrayOutputStream();
-        w = new UTF8Writer(_ioContext(rec), out);
+        w = new UTF8Writer(_ioContext(), out);
         try {
             w.write("\uDE03");
             fail("should not pass");
@@ -138,7 +137,7 @@ public class UTF8WriterTest
         }
 
         out = new ByteArrayOutputStream();
-        w = new UTF8Writer(_ioContext(rec), out);
+        w = new UTF8Writer(_ioContext(), out);
         try {
             w.write("\uD83Da");
             fail("should not pass");
@@ -148,11 +147,7 @@ public class UTF8WriterTest
     }
 
     private IOContext _ioContext() {
-        return _ioContext(new BufferRecycler());
-    }
-
-    private IOContext _ioContext(BufferRecycler br) {
-        return new IOContext(StreamReadConstraints.defaults(), StreamWriteConstraints.defaults(), br,
+        return new IOContext(StreamReadConstraints.defaults(), StreamWriteConstraints.defaults(),
                 ContentReference.unknown(), false, JsonEncoding.UTF8);
     }
 }

--- a/src/test/java/tools/jackson/core/util/ReadConstrainedTextBufferTest.java
+++ b/src/test/java/tools/jackson/core/util/ReadConstrainedTextBufferTest.java
@@ -49,7 +49,6 @@ class ReadConstrainedTextBufferTest {
         IOContext ioContext = new IOContext(
                 streamReadConstraints,
                 StreamWriteConstraints.defaults(),
-                new BufferRecycler(),
                 ContentReference.rawReference("N/A"), true, JsonEncoding.UTF8);
         return ioContext.constructReadConstrainedTextBuffer();
     }

--- a/src/test/java/tools/jackson/core/write/UTF8GeneratorTest.java
+++ b/src/test/java/tools/jackson/core/write/UTF8GeneratorTest.java
@@ -51,7 +51,6 @@ public class UTF8GeneratorTest extends BaseTest
         ByteArrayOutputStream bytes = new ByteArrayOutputStream();
         IOContext ioc = new IOContext(StreamReadConstraints.defaults(),
                 StreamWriteConstraints.builder().maxNestingDepth(1).build(),
-                new BufferRecycler(),
                 ContentReference.rawReference(bytes), true,
                 JsonEncoding.UTF8);
         try (JsonGenerator gen = new UTF8JsonGenerator(ObjectWriteContext.empty(), ioc, 0, 0, bytes,
@@ -72,7 +71,6 @@ public class UTF8GeneratorTest extends BaseTest
         ByteArrayOutputStream bytes = new ByteArrayOutputStream();
         IOContext ioc = new IOContext(StreamReadConstraints.defaults(),
                 StreamWriteConstraints.builder().maxNestingDepth(1).build(),
-                new BufferRecycler(),
                 ContentReference.rawReference(bytes), true,
                 JsonEncoding.UTF8);
         try (JsonGenerator gen = new UTF8JsonGenerator(ObjectWriteContext.empty(), ioc, 0, 0, bytes,

--- a/src/test/java/tools/jackson/core/write/WriterBasedJsonGeneratorTest.java
+++ b/src/test/java/tools/jackson/core/write/WriterBasedJsonGeneratorTest.java
@@ -22,7 +22,6 @@ public class WriterBasedJsonGeneratorTest extends BaseTest
         StringWriter sw = new StringWriter();
         IOContext ioc = new IOContext(StreamReadConstraints.defaults(),
                 StreamWriteConstraints.builder().maxNestingDepth(1).build(),
-                new BufferRecycler(),
                 ContentReference.rawReference(sw), true,
                 JsonEncoding.UTF8);
         try (JsonGenerator gen = new WriterBasedJsonGenerator(ObjectWriteContext.empty(), ioc, 0, 0, sw,
@@ -43,7 +42,6 @@ public class WriterBasedJsonGeneratorTest extends BaseTest
         StringWriter sw = new StringWriter();
         IOContext ioc = new IOContext(StreamReadConstraints.defaults(),
                 StreamWriteConstraints.builder().maxNestingDepth(1).build(),
-                new BufferRecycler(),
                 ContentReference.rawReference(sw), true,
                 JsonEncoding.UTF8);
         try (JsonGenerator gen = new WriterBasedJsonGenerator(ObjectWriteContext.empty(), ioc, 0, 0, sw,


### PR DESCRIPTION
This pull request is a work in progress and at the moment it is **not** intended to be merged as it is. This is mostly to start a discussion and proposing a first tentative fix for the problem reported [here](https://github.com/FasterXML/jackson-core/issues/919). 

In particular this is trying to implement the solution 1. suggested by @franz1981. The solution 2. would have the advantage of being the less invasive for jackson (and would be probably guarantee better performances), but it is totally impossible now and even in a near or far future it is very unlikely that the JDK team will agree to make the per-carrier-thread cache generally available since it would break some of the virtual threads encapsulations.

Also following what suggested in [this comment](https://github.com/FasterXML/jackson-core/issues/919#issuecomment-1425028482) by @cowtowncoder, I'm trying to better define the lifecycle of the `JsonParser` and `JsonGenerator` making their `close` methods to even close the underlying `IOContext`. The `IOContext` is now the only owner of its `BufferRecycler`: instead of being injected with a `BufferRecycler` instance as an argument of its constructor, it borrows the `BufferRecycler` directly from the new `ObjectPool`, and put it back into the pool when it is closed.

This solution of course relies on the fact that the `close` methods of the `JsonParser` and `JsonGenerator` are always called correctly. I haven't found a place when this doesn't happen and in reality I conversely found at least [one situation when this happens twice](https://github.com/FasterXML/jackson-jr/blob/master/jr-objects/src/main/java/tools/jackson/jr/ob/JSON.java#L1466), without any apparent valid reason.

The `ObjectPool` implementation is extremely naive and the main reason why this pull request has to be considered just a draft. However it only has the `borrow` and `offer` methods, so I believe that it could be easily replaced by any real-world and battle tested high performance implementation. To this purpose I'd prefer to avoid reinventing the wheel and reusing one of the object pool implementations already available like the one in JCTools suggested by @franz1981 or one of the many alternatives listed [here](https://medium.com/@chrishantha/benchmarking-object-pools-6df007a31ada), even though not all of them are really an option because some also internally relies on `ThreadLocal`s in some way. 

So here the first questions: is it ok for `jackson-core` to directly depend on one of those libraries providing a production ready object pool or do we need/want to have an implementation directly inside jackson codebase? Do you know any of those libraries/implementations or have a specific preference for any of them? /cc @cowtowncoder @pjfanning 

Finally I also made a first attempt to check the performance of this solution, despite and regardless the poor object pool implementation, using a benchmark that I'm pasting at the end of this comment. Running this benchmark against the current master branch I obtained the following results:

```
Benchmark                                                                           (parallelTasks)  (useVirtualThreads)   Mode  Cnt         Score        Error   Units
JacksonMultithreadWriteVanilla.writePojoMediaItem                                              1000                 true  thrpt    5       509.060 ±      6.795   ops/s
JacksonMultithreadWriteVanilla.writePojoMediaItem                                              1000                false  thrpt    5      1402.935 ±     56.546   ops/s

```

while rerunning again using this pull request I got:

```
Benchmark                                                                           (parallelTasks)  (useVirtualThreads)   Mode  Cnt        Score       Error   Units
JacksonMultithreadWriteVanilla.writePojoMediaItem                                              1000                 true  thrpt    5      680.704 ±    14.860   ops/s
JacksonMultithreadWriteVanilla.writePojoMediaItem                                              1000                false  thrpt    5     1279.282 ±     4.998   ops/s
```

As expected the native threads execution is suffering of the worse performing object pool implementation, compared with the current `ThreadLocal` based one, while the one running on virtual threads is already faster in my version, so I'm confident of being on the right path for a good solution once the object pooling problem will be properly addressed.

Any remark or suggestion to improve this (including any concern on why this solution couldn't work) is warmly welcome. The code of the benchmark I implemented and used follows:

```
package com.fasterxml.jackson.perf.json;

import tools.jackson.jr.ob.JSON;
import com.fasterxml.jackson.perf.model.MediaItem;
import com.fasterxml.jackson.perf.model.MediaItems;
import com.fasterxml.jackson.perf.util.NopOutputStream;
import org.openjdk.jmh.annotations.*;
import org.openjdk.jmh.infra.Blackhole;

import java.util.concurrent.CountDownLatch;
import java.util.concurrent.Executors;
import java.util.concurrent.TimeUnit;
import java.util.function.Consumer;

@State(value = Scope.Benchmark)
@Fork(1)
public class JacksonMultithreadWriteVanilla {
    private static final JSON json = JSON.std;

    private static final MediaItem item = MediaItems.stdMediaItem();

    @Param({"true", "false"})
    private boolean useVirtualThreads;

    @Param({"1000"})
    private int parallelTasks;

    private Consumer<Runnable> runner;

    @Setup
    public void setup() {
        this.runner = createRunner(useVirtualThreads);
    }

    @Benchmark
    @OutputTimeUnit(TimeUnit.SECONDS)
    public void writePojoMediaItem(Blackhole bh) throws Exception {
        CountDownLatch countDown = new CountDownLatch(parallelTasks);

        for (int i = 0; i < parallelTasks; i++) {
            runner.accept(() -> {
                bh.consume(write(item, json));
                countDown.countDown();
            });
        }

        try {
            countDown.await();
        } catch (InterruptedException e) {
            throw new RuntimeException(e);
        }
    }

    protected final int write(Object value, JSON writer) {
        NopOutputStream out = new NopOutputStream();
        writer.write(value, out);
        return out.size();
    }

    private Consumer<Runnable> createRunner(boolean useVirtualThreads) {
        if (useVirtualThreads) {
            return Thread::startVirtualThread;
        } else {
            return Executors.newWorkStealingPool()::execute;
        }
    }
}
```


