### PR TITLE
Retrofit `ContentReference` with new `ErrorReportConfiguration`

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/JsonLocation.java
+++ b/src/main/java/com/fasterxml/jackson/core/JsonLocation.java
@@ -23,7 +23,7 @@ public class JsonLocation
     private static final long serialVersionUID = 2L; // in 2.13
 
     /**
-     * @deprecated Since 2.13 use {@link ContentReference#DEFAULT_MAX_CONTENT_SNIPPET} instead
+     * @deprecated Since 2.13 use {@link ErrorReportConfiguration#DEFAULT_MAX_RAW_CONTENT_LENGTH} instead
      */
     @Deprecated
     public static final int MAX_CONTENT_SNIPPET = 500;

--- a/src/main/java/com/fasterxml/jackson/core/io/ContentReference.java
+++ b/src/main/java/com/fasterxml/jackson/core/io/ContentReference.java
@@ -54,9 +54,7 @@ public class ContentReference
      * logs.
      *
      * @since 2.9
-     * @deprecated Since 2.16. {@link ErrorReportConfiguration#DEFAULT_MAX_RAW_CONTENT_LENGTH} will be used by default or 
-     * as configured by {@link ErrorReportConfiguration.Builder#maxRawContentLength(int)}
-     * will be used instead.
+     * @deprecated Since 2.16. {@link ErrorReportConfiguration.Builder#maxRawContentLength(int)} will be used instead.
      */
     @Deprecated
     public static final int DEFAULT_MAX_CONTENT_SNIPPET = 500;

--- a/src/main/java/com/fasterxml/jackson/core/io/ContentReference.java
+++ b/src/main/java/com/fasterxml/jackson/core/io/ContentReference.java
@@ -103,7 +103,7 @@ public class ContentReference
      */
     @Deprecated
     protected ContentReference(boolean isContentTextual, Object rawContent) {
-        this(isContentTextual, rawContent, -1, -1);
+        this(isContentTextual, rawContent, -1, -1, ErrorReportConfiguration.defaults());
     }
 
     /**

--- a/src/main/java/com/fasterxml/jackson/core/io/ContentReference.java
+++ b/src/main/java/com/fasterxml/jackson/core/io/ContentReference.java
@@ -259,10 +259,10 @@ public class ContentReference
      * which content is counted, either bytes or chars) to use for truncation
      * (so as not to include full content for humongous sources or targets)
      *
-     * @see ErrorReportConfiguration#builder()#_maxRawContentLength
+     * @see ErrorReportConfiguration#getMaxRawContentLength()
      * @return Maximum content snippet to include before truncating
      */
-    protected int maxContentSnippetLength() {
+    protected int maxRawContentLength() {
         return _maxRawContentLength;
     }
 
@@ -323,7 +323,7 @@ public class ContentReference
             String trimmed;
 
             // poor man's tuple...
-            final int maxLen = maxContentSnippetLength();
+            final int maxLen = maxRawContentLength();
             int[] offsets = new int[] { contentOffset(), contentLength() };
 
             if (srcRef instanceof CharSequence) {

--- a/src/main/java/com/fasterxml/jackson/core/io/ContentReference.java
+++ b/src/main/java/com/fasterxml/jackson/core/io/ContentReference.java
@@ -58,6 +58,7 @@ public class ContentReference
      * as configured by {@link ErrorReportConfiguration.Builder#maxRawContentLength(int)}
      * will be used instead.
      */
+    @Deprecated
     public static final int DEFAULT_MAX_CONTENT_SNIPPET = 500;
 
     /**
@@ -106,6 +107,7 @@ public class ContentReference
     /**
      * @deprecated Since 2.16. Use {@link #ContentReference(boolean, Object, int, int, ErrorReportConfiguration)} instead.
      */
+    @Deprecated
     protected ContentReference(boolean isContentTextual, Object rawContent,
             int offset, int length)
     {
@@ -126,7 +128,8 @@ public class ContentReference
      * @since 2.16
      */
     public ContentReference(boolean isContentTextual, Object rawContent,
-                            ErrorReportConfiguration errorReportConfiguration) {
+            ErrorReportConfiguration errorReportConfiguration) 
+    {
         this(isContentTextual, rawContent, -1, -1, errorReportConfiguration);
     }
 
@@ -168,7 +171,7 @@ public class ContentReference
      * @since 2.16
      */
     public static ContentReference construct(boolean isContentTextual, Object rawContent,
-                                             int offset, int length, ErrorReportConfiguration errorReportConfiguration)
+            int offset, int length, ErrorReportConfiguration errorReportConfiguration)
     {
         return new ContentReference(isContentTextual, rawContent, offset, length, errorReportConfiguration);
     }
@@ -176,7 +179,9 @@ public class ContentReference
     /**
      * @since 2.16
      */
-    public static ContentReference construct(boolean isContentTextual, Object rawContent, ErrorReportConfiguration errorReportConfiguration) {
+    public static ContentReference construct(boolean isContentTextual, Object rawContent, 
+                    ErrorReportConfiguration errorReportConfiguration) 
+    {
         return new ContentReference(isContentTextual, rawContent, errorReportConfiguration);
     }
 

--- a/src/main/java/com/fasterxml/jackson/core/io/ContentReference.java
+++ b/src/main/java/com/fasterxml/jackson/core/io/ContentReference.java
@@ -112,6 +112,9 @@ public class ContentReference
         this(isContentTextual, rawContent, offset, length, ErrorReportConfiguration.defaults());
     }
 
+    /**
+     * @since 2.16
+     */
     protected ContentReference(boolean isContentTextual, Object rawContent,
             int offset, int length, ErrorReportConfiguration errorReportConfiguration)
     {
@@ -160,6 +163,10 @@ public class ContentReference
         return new ContentReference(isContentTextual, rawContent);
     }
 
+    /**
+     * @deprecated Since 2.16. Use {@link #construct(boolean, Object, int, int, ErrorReportConfiguration)} instead.
+     */
+    @Deprecated
     public static ContentReference construct(boolean isContentTextual, Object rawContent,
             int offset, int length) {
         return new ContentReference(isContentTextual, rawContent, offset, length, ErrorReportConfiguration.defaults());
@@ -178,7 +185,7 @@ public class ContentReference
      * @since 2.16
      */
     public static ContentReference construct(boolean isContentTextual, Object rawContent, 
-                    ErrorReportConfiguration errorReportConfiguration) 
+            ErrorReportConfiguration errorReportConfiguration) 
     {
         return new ContentReference(isContentTextual, rawContent, errorReportConfiguration);
     }

--- a/src/main/java/com/fasterxml/jackson/core/io/ContentReference.java
+++ b/src/main/java/com/fasterxml/jackson/core/io/ContentReference.java
@@ -1,5 +1,7 @@
 package com.fasterxml.jackson.core.io;
 
+import com.fasterxml.jackson.core.ErrorReportConfiguration;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.ObjectInputStream;
@@ -52,6 +54,9 @@ public class ContentReference
      * logs.
      *
      * @since 2.9
+     * @deprecated Since 2.16. {@link ErrorReportConfiguration#DEFAULT_MAX_RAW_CONTENT_LENGTH} will be used by default or 
+     * as configured by {@link ErrorReportConfiguration.Builder#maxRawContentLength(int)}
+     * will be used instead.
      */
     public static final int DEFAULT_MAX_CONTENT_SNIPPET = 500;
 
@@ -81,6 +86,13 @@ public class ContentReference
      */
     protected final boolean _isContentTextual;
 
+    /**
+     * max raw content to return as configured 
+     *
+     * @since 2.16
+     */
+    protected final int _maxRawContentLength;
+
     /*
     /**********************************************************************
     /* Life-cycle
@@ -91,13 +103,31 @@ public class ContentReference
         this(isContentTextual, rawContent, -1, -1);
     }
 
+    /**
+     * @deprecated Since 2.16. Use {@link #ContentReference(boolean, Object, int, int, ErrorReportConfiguration)} instead.
+     */
     protected ContentReference(boolean isContentTextual, Object rawContent,
             int offset, int length)
+    {
+        this(isContentTextual, rawContent, offset, length, ErrorReportConfiguration.defaults());
+    }
+
+    protected ContentReference(boolean isContentTextual, Object rawContent,
+            int offset, int length, ErrorReportConfiguration errorReportConfiguration)
     {
         _isContentTextual = isContentTextual;
         _rawContent = rawContent;
         _offset = offset;
         _length = length;
+        _maxRawContentLength = errorReportConfiguration.getMaxRawContentLength();
+    }
+
+    /**
+     * @since 2.16
+     */
+    public ContentReference(boolean isContentTextual, Object rawContent,
+                            ErrorReportConfiguration errorReportConfiguration) {
+        this(isContentTextual, rawContent, -1, -1, errorReportConfiguration);
     }
 
     /**
@@ -130,8 +160,24 @@ public class ContentReference
     }
 
     public static ContentReference construct(boolean isContentTextual, Object rawContent,
-            int offset, int length) {
-        return new ContentReference(isContentTextual, rawContent, offset, length);
+                                             int offset, int length) {
+        return new ContentReference(isContentTextual, rawContent, offset, length, ErrorReportConfiguration.defaults());
+    }
+
+    /**
+     * @since 2.16
+     */
+    public static ContentReference construct(boolean isContentTextual, Object rawContent,
+                                             int offset, int length, ErrorReportConfiguration errorReportConfiguration)
+    {
+        return new ContentReference(isContentTextual, rawContent, offset, length, errorReportConfiguration);
+    }
+
+    /**
+     * @since 2.16
+     */
+    public static ContentReference construct(boolean isContentTextual, Object rawContent, ErrorReportConfiguration errorReportConfiguration) {
+        return new ContentReference(isContentTextual, rawContent, errorReportConfiguration);
     }
 
     /**
@@ -203,10 +249,11 @@ public class ContentReference
      * which content is counted, either bytes or chars) to use for truncation
      * (so as not to include full content for humongous sources or targets)
      *
+     * @see ErrorReportConfiguration#builder()#_maxRawContentLength
      * @return Maximum content snippet to include before truncating
      */
     protected int maxContentSnippetLength() {
-        return DEFAULT_MAX_CONTENT_SNIPPET;
+        return _maxRawContentLength;
     }
 
     /*

--- a/src/main/java/com/fasterxml/jackson/core/io/ContentReference.java
+++ b/src/main/java/com/fasterxml/jackson/core/io/ContentReference.java
@@ -160,7 +160,7 @@ public class ContentReference
     }
 
     public static ContentReference construct(boolean isContentTextual, Object rawContent,
-                                             int offset, int length) {
+            int offset, int length) {
         return new ContentReference(isContentTextual, rawContent, offset, length, ErrorReportConfiguration.defaults());
     }
 

--- a/src/main/java/com/fasterxml/jackson/core/io/ContentReference.java
+++ b/src/main/java/com/fasterxml/jackson/core/io/ContentReference.java
@@ -98,6 +98,10 @@ public class ContentReference
     /**********************************************************************
      */
 
+    /**
+     * @deprecated Since 2.16. Use {@link #ContentReference(boolean, Object, ErrorReportConfiguration)} instead.
+     */
+    @Deprecated
     protected ContentReference(boolean isContentTextual, Object rawContent) {
         this(isContentTextual, rawContent, -1, -1);
     }
@@ -115,6 +119,14 @@ public class ContentReference
     /**
      * @since 2.16
      */
+    protected ContentReference(boolean isContentTextual, Object rawContent, ErrorReportConfiguration errorReportConfiguration)
+    {
+        this(isContentTextual, rawContent, -1, -1, errorReportConfiguration);
+    }
+
+    /**
+     * @since 2.16
+     */
     protected ContentReference(boolean isContentTextual, Object rawContent,
             int offset, int length, ErrorReportConfiguration errorReportConfiguration)
     {
@@ -123,15 +135,6 @@ public class ContentReference
         _offset = offset;
         _length = length;
         _maxRawContentLength = errorReportConfiguration.getMaxRawContentLength();
-    }
-
-    /**
-     * @since 2.16
-     */
-    public ContentReference(boolean isContentTextual, Object rawContent,
-            ErrorReportConfiguration errorReportConfiguration) 
-    {
-        this(isContentTextual, rawContent, -1, -1, errorReportConfiguration);
     }
 
     /**
@@ -158,9 +161,14 @@ public class ContentReference
     public static ContentReference redacted() {
         return REDACTED_CONTENT;
     }
-        
+
+
+    /**
+     * @deprecated Since 2.16. Use {@link #construct(boolean, Object, ErrorReportConfiguration)} instead.
+     */
+    @Deprecated
     public static ContentReference construct(boolean isContentTextual, Object rawContent) {
-        return new ContentReference(isContentTextual, rawContent);
+        return new ContentReference(isContentTextual, rawContent, ErrorReportConfiguration.defaults());
     }
 
     /**

--- a/src/test/java/com/fasterxml/jackson/core/ErrorReportConfigurationMaxRawContentLengthTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/ErrorReportConfigurationMaxRawContentLengthTest.java
@@ -1,0 +1,48 @@
+package com.fasterxml.jackson.core;
+
+import com.fasterxml.jackson.core.io.ContentReference;
+
+/**
+ * Unit tests for class {@link ErrorReportConfiguration#getMaxRawContentLength()}.
+ */
+public class ErrorReportConfigurationMaxRawContentLengthTest extends BaseTest {
+    /*
+    /**********************************************************
+    /* Unit Tests
+    /**********************************************************
+     */
+
+    public void testBasicToStringErrorConfig() throws Exception {
+        // Truncated result
+        _verifyToString("abc", 2,
+                "[Source: (String)\"ab\"[truncated 1 chars]; line: 1, column: 1]");
+        // Exact length
+        _verifyToString("abc", 3,
+                "[Source: (String)\"abc\"; line: 1, column: 1]");
+        // Enough length
+        _verifyToString("abc", 4,
+                "[Source: (String)\"abc\"; line: 1, column: 1]");
+    }
+    
+    /*
+    /**********************************************************
+    /* Internal helper methods
+    /**********************************************************
+     */
+
+    private void _verifyToString(String rawSrc, int rawContentLength, String expectedMessage) {
+        ContentReference reference = _sourceRefWithErrorReportConfig(rawSrc, rawContentLength);
+        String location = new JsonLocation(reference, 10L, 10L, 1, 1).toString();
+        assertEquals(expectedMessage, location);
+    }
+
+    private ContentReference _sourceRefWithErrorReportConfig(String rawSrc, int rawContentLength) {
+        return _sourceRef(rawSrc,
+                ErrorReportConfiguration.builder().maxRawContentLength(rawContentLength).build());
+    }
+
+    private ContentReference _sourceRef(String rawSrc, ErrorReportConfiguration errorReportConfiguration) {
+        return ContentReference.construct(true, rawSrc, 0, rawSrc.length(),errorReportConfiguration);
+    }
+
+}

--- a/src/test/java/com/fasterxml/jackson/core/JsonLocationTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/JsonLocationTest.java
@@ -64,7 +64,7 @@ public class JsonLocationTest extends BaseTest
     public void testTruncatedSource() throws Exception
     {
         StringBuilder sb = new StringBuilder();
-        for (int i = 0; i < ContentReference.DEFAULT_MAX_CONTENT_SNIPPET; ++i) {
+        for (int i = 0; i < ErrorReportConfiguration.DEFAULT_MAX_RAW_CONTENT_LENGTH; ++i) {
             sb.append("x");
         }
         String main = sb.toString();


### PR DESCRIPTION
part of #1066
(blocked by #1068)