### PR TITLE
throw checked exception if growArray has a size that is too big

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/base/ParserBase.java
+++ b/src/main/java/com/fasterxml/jackson/core/base/ParserBase.java
@@ -6,6 +6,7 @@ import java.math.BigInteger;
 import java.util.Arrays;
 
 import com.fasterxml.jackson.core.*;
+import com.fasterxml.jackson.core.exc.StreamConstraintsException;
 import com.fasterxml.jackson.core.io.IOContext;
 import com.fasterxml.jackson.core.io.ContentReference;
 import com.fasterxml.jackson.core.io.NumberInput;
@@ -1553,12 +1554,16 @@ public abstract class ParserBase extends ParserMinimalBase
         return ContentReference.redacted();
     }
 
-    protected static int[] growArrayBy(int[] arr, int more)
+    protected static int[] growArrayBy(int[] arr, int more) throws StreamConstraintsException
     {
         if (arr == null) {
             return new int[more];
         }
-        return Arrays.copyOf(arr, arr.length + more);
+        final long len = arr.length + more;
+        if (len > Integer.MAX_VALUE) {
+            throw new StreamConstraintsException("Unable to grow array to longer to Integer.MAX_VALUE");
+        }
+        return Arrays.copyOf(arr, (int) len);
     }
 
     /*

--- a/src/main/java/com/fasterxml/jackson/core/json/UTF8DataInputJsonParser.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/UTF8DataInputJsonParser.java
@@ -1470,7 +1470,7 @@ public class UTF8DataInputJsonParser
 
             // Nope, no end in sight. Need to grow quad array etc
             if (qlen >= _quadBuffer.length) {
-                _quadBuffer = _growArrayBy(_quadBuffer, qlen);
+                _quadBuffer = growArrayBy(_quadBuffer, qlen);
             }
             _quadBuffer[qlen++] = q;
             q = i;
@@ -1529,7 +1529,7 @@ public class UTF8DataInputJsonParser
                     // Ok, we'll need room for first byte right away
                     if (currQuadBytes >= 4) {
                         if (qlen >= quads.length) {
-                            _quadBuffer = quads = _growArrayBy(quads, quads.length);
+                            _quadBuffer = quads = growArrayBy(quads, quads.length);
                         }
                         quads[qlen++] = currQuad;
                         currQuad = 0;
@@ -1545,7 +1545,7 @@ public class UTF8DataInputJsonParser
                         // need room for middle byte?
                         if (currQuadBytes >= 4) {
                             if (qlen >= quads.length) {
-                                _quadBuffer = quads = _growArrayBy(quads, quads.length);
+                                _quadBuffer = quads = growArrayBy(quads, quads.length);
                             }
                             quads[qlen++] = currQuad;
                             currQuad = 0;
@@ -1564,7 +1564,7 @@ public class UTF8DataInputJsonParser
                 currQuad = (currQuad << 8) | ch;
             } else {
                 if (qlen >= quads.length) {
-                    _quadBuffer = quads = _growArrayBy(quads, quads.length);
+                    _quadBuffer = quads = growArrayBy(quads, quads.length);
                 }
                 quads[qlen++] = currQuad;
                 currQuad = ch;
@@ -1575,7 +1575,7 @@ public class UTF8DataInputJsonParser
 
         if (currQuadBytes > 0) {
             if (qlen >= quads.length) {
-                _quadBuffer = quads = _growArrayBy(quads, quads.length);
+                _quadBuffer = quads = growArrayBy(quads, quads.length);
             }
             quads[qlen++] = pad(currQuad, currQuadBytes);
         }
@@ -1634,7 +1634,7 @@ public class UTF8DataInputJsonParser
                 currQuad = (currQuad << 8) | ch;
             } else {
                 if (qlen >= quads.length) {
-                    _quadBuffer = quads = _growArrayBy(quads, quads.length);
+                    _quadBuffer = quads = growArrayBy(quads, quads.length);
                 }
                 quads[qlen++] = currQuad;
                 currQuad = ch;
@@ -1649,7 +1649,7 @@ public class UTF8DataInputJsonParser
         _nextByte = ch;
         if (currQuadBytes > 0) {
             if (qlen >= quads.length) {
-                _quadBuffer = quads = _growArrayBy(quads, quads.length);
+                _quadBuffer = quads = growArrayBy(quads, quads.length);
             }
             quads[qlen++] = currQuad;
         }
@@ -1703,7 +1703,7 @@ public class UTF8DataInputJsonParser
                     // Ok, we'll need room for first byte right away
                     if (currQuadBytes >= 4) {
                         if (qlen >= quads.length) {
-                            _quadBuffer = quads = _growArrayBy(quads, quads.length);
+                            _quadBuffer = quads = growArrayBy(quads, quads.length);
                         }
                         quads[qlen++] = currQuad;
                         currQuad = 0;
@@ -1719,7 +1719,7 @@ public class UTF8DataInputJsonParser
                         // need room for middle byte?
                         if (currQuadBytes >= 4) {
                             if (qlen >= quads.length) {
-                                _quadBuffer = quads = _growArrayBy(quads, quads.length);
+                                _quadBuffer = quads = growArrayBy(quads, quads.length);
                             }
                             quads[qlen++] = currQuad;
                             currQuad = 0;
@@ -1738,7 +1738,7 @@ public class UTF8DataInputJsonParser
                 currQuad = (currQuad << 8) | ch;
             } else {
                 if (qlen >= quads.length) {
-                    _quadBuffer = quads = _growArrayBy(quads, quads.length);
+                    _quadBuffer = quads = growArrayBy(quads, quads.length);
                 }
                 quads[qlen++] = currQuad;
                 currQuad = ch;
@@ -1749,7 +1749,7 @@ public class UTF8DataInputJsonParser
 
         if (currQuadBytes > 0) {
             if (qlen >= quads.length) {
-                _quadBuffer = quads = _growArrayBy(quads, quads.length);
+                _quadBuffer = quads = growArrayBy(quads, quads.length);
             }
             quads[qlen++] = pad(currQuad, currQuadBytes);
         }
@@ -1814,7 +1814,7 @@ public class UTF8DataInputJsonParser
             throws JsonParseException, StreamConstraintsException
     {
         if (qlen >= quads.length) {
-            _quadBuffer = quads = _growArrayBy(quads, quads.length);
+            _quadBuffer = quads = growArrayBy(quads, quads.length);
         }
         quads[qlen++] = pad(lastQuad, lastQuadBytes);
         String name = _symbols.findName(quads, qlen);
@@ -2844,14 +2844,6 @@ public class UTF8DataInputJsonParser
         throws JsonParseException
     {
         _reportError("Invalid UTF-8 middle byte 0x"+Integer.toHexString(mask));
-    }
-
-    private static int[] _growArrayBy(int[] arr, int more)
-    {
-        if (arr == null) {
-            return new int[more];
-        }
-        return Arrays.copyOf(arr, arr.length + more);
     }
 
     /*


### PR DESCRIPTION
* useful as a check in its own right
* also improves behaviour in https://github.com/FasterXML/jackson-core/issues/1047 case
  * I'm not saying that there shouldn't be a max element name length
  * just that this change sorts out the case where you have a crazy long element name - you get a checked exception (StreamConstraintsException) instead of a java.lang.NegativeArraySizeException 