### PR TITLE
validate the length of names

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/json/ReaderBasedJsonParser.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/ReaderBasedJsonParser.java
@@ -1848,9 +1848,11 @@ public class ReaderBasedJsonParser
             int ch = _inputBuffer[ptr];
             if (ch < codes.length && codes[ch] != 0) {
                 if (ch == '"') {
-                    int start = _inputPtr;
+                    final int start = _inputPtr;
                     _inputPtr = ptr+1; // to skip the quote
-                    return _symbols.findSymbol(_inputBuffer, start, ptr - start, hash);
+                    final int len = ptr - start;
+                    _streamReadConstraints.validateNameLength(len);
+                    return _symbols.findSymbol(_inputBuffer, start, len, hash);
                 }
                 break;
             }
@@ -1864,7 +1866,9 @@ public class ReaderBasedJsonParser
 
     private String _parseName2(int startPtr, int hash, int endChar) throws IOException
     {
-        _textBuffer.resetWithShared(_inputBuffer, startPtr, (_inputPtr - startPtr));
+        final int initLen = _inputPtr - startPtr;
+        _streamReadConstraints.validateNameLength(initLen);
+        _textBuffer.resetWithShared(_inputBuffer, startPtr, initLen);
 
         /* Output pointers; calls will also ensure that the buffer is
          * not shared and has room for at least one more char.
@@ -1908,10 +1912,11 @@ public class ReaderBasedJsonParser
         }
         _textBuffer.setCurrentLength(outPtr);
         {
-            TextBuffer tb = _textBuffer;
-            char[] buf = tb.getTextBuffer();
-            int start = tb.getTextOffset();
-            int len = tb.size();
+            final TextBuffer tb = _textBuffer;
+            final char[] buf = tb.getTextBuffer();
+            final int start = tb.getTextOffset();
+            final int len = tb.size();
+            _streamReadConstraints.validateNameLength(len);
             return _symbols.findSymbol(buf, start, len, hash);
         }
     }
@@ -1962,14 +1967,18 @@ public class ReaderBasedJsonParser
                 int ch = _inputBuffer[ptr];
                 if (ch < maxCode) {
                     if (codes[ch] != 0) {
-                        int start = _inputPtr-1; // -1 to bring back first char
+                        final int start = _inputPtr-1; // -1 to bring back first char
                         _inputPtr = ptr;
-                        return _symbols.findSymbol(_inputBuffer, start, ptr - start, hash);
+                        final int len = ptr - start;
+                        _streamReadConstraints.validateNameLength(len);
+                        return _symbols.findSymbol(_inputBuffer, start, len, hash);
                     }
                 } else if (!Character.isJavaIdentifierPart((char) ch)) {
-                    int start = _inputPtr-1; // -1 to bring back first char
+                    final int start = _inputPtr-1; // -1 to bring back first char
                     _inputPtr = ptr;
-                    return _symbols.findSymbol(_inputBuffer, start, ptr - start, hash);
+                    final int len = ptr - start;
+                    _streamReadConstraints.validateNameLength(len);
+                    return _symbols.findSymbol(_inputBuffer, start, len, hash);
                 }
                 hash = (hash * CharsToNameCanonicalizer.HASH_MULT) + ch;
                 ++ptr;
@@ -1996,7 +2005,9 @@ public class ReaderBasedJsonParser
                 if (ch == '\'') {
                     int start = _inputPtr;
                     _inputPtr = ptr+1; // to skip the quote
-                    return _symbols.findSymbol(_inputBuffer, start, ptr - start, hash);
+                    final int len = ptr - start;
+                    _streamReadConstraints.validateNameLength(len);
+                    return _symbols.findSymbol(_inputBuffer, start, len, hash);
                 }
                 if (ch < maxCode && codes[ch] != 0) {
                     break;
@@ -2029,7 +2040,7 @@ public class ReaderBasedJsonParser
         switch (i) {
         case '\'':
             /* Allow single quotes? Unlike with regular Strings, we'll eagerly parse
-             * contents; this so that there'sno need to store information on quote char used.
+             * contents; this so that there's no need to store information on quote char used.
              * Also, no separation to fast/slow parsing; we'll just do
              * one regular (~= slowish) parsing, to keep code simple
              */
@@ -2129,7 +2140,9 @@ public class ReaderBasedJsonParser
 
     private String _handleOddName2(int startPtr, int hash, int[] codes) throws IOException
     {
-        _textBuffer.resetWithShared(_inputBuffer, startPtr, (_inputPtr - startPtr));
+        final int initLen = _inputPtr - startPtr;
+        _streamReadConstraints.validateNameLength(initLen);
+        _textBuffer.resetWithShared(_inputBuffer, startPtr, initLen);
         char[] outBuf = _textBuffer.getCurrentSegment();
         int outPtr = _textBuffer.getCurrentSegmentSize();
         final int maxCode = codes.length;
@@ -2162,11 +2175,11 @@ public class ReaderBasedJsonParser
         }
         _textBuffer.setCurrentLength(outPtr);
         {
-            TextBuffer tb = _textBuffer;
-            char[] buf = tb.getTextBuffer();
-            int start = tb.getTextOffset();
-            int len = tb.size();
-
+            final TextBuffer tb = _textBuffer;
+            final char[] buf = tb.getTextBuffer();
+            final int start = tb.getTextOffset();
+            final int len = tb.size();
+            _streamReadConstraints.validateNameLength(len);
             return _symbols.findSymbol(buf, start, len, hash);
         }
     }

--- a/src/main/java/com/fasterxml/jackson/core/json/ReaderBasedJsonParser.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/ReaderBasedJsonParser.java
@@ -1850,9 +1850,7 @@ public class ReaderBasedJsonParser
                 if (ch == '"') {
                     final int start = _inputPtr;
                     _inputPtr = ptr+1; // to skip the quote
-                    final int len = ptr - start;
-                    _streamReadConstraints.validateNameLength(len);
-                    return _symbols.findSymbol(_inputBuffer, start, len, hash);
+                    return _symbols.findSymbol(_inputBuffer, start, ptr - start, hash);
                 }
                 break;
             }
@@ -1915,9 +1913,7 @@ public class ReaderBasedJsonParser
             final TextBuffer tb = _textBuffer;
             final char[] buf = tb.getTextBuffer();
             final int start = tb.getTextOffset();
-            final int len = tb.size();
-            _streamReadConstraints.validateNameLength(len);
-            return _symbols.findSymbol(buf, start, len, hash);
+            return _symbols.findSymbol(buf, start, tb.size(), hash);
         }
     }
 
@@ -1969,16 +1965,12 @@ public class ReaderBasedJsonParser
                     if (codes[ch] != 0) {
                         final int start = _inputPtr-1; // -1 to bring back first char
                         _inputPtr = ptr;
-                        final int len = ptr - start;
-                        _streamReadConstraints.validateNameLength(len);
-                        return _symbols.findSymbol(_inputBuffer, start, len, hash);
+                        return _symbols.findSymbol(_inputBuffer, start, ptr - start, hash);
                     }
                 } else if (!Character.isJavaIdentifierPart((char) ch)) {
                     final int start = _inputPtr-1; // -1 to bring back first char
                     _inputPtr = ptr;
-                    final int len = ptr - start;
-                    _streamReadConstraints.validateNameLength(len);
-                    return _symbols.findSymbol(_inputBuffer, start, len, hash);
+                    return _symbols.findSymbol(_inputBuffer, start, ptr - start, hash);
                 }
                 hash = (hash * CharsToNameCanonicalizer.HASH_MULT) + ch;
                 ++ptr;
@@ -2005,9 +1997,7 @@ public class ReaderBasedJsonParser
                 if (ch == '\'') {
                     int start = _inputPtr;
                     _inputPtr = ptr+1; // to skip the quote
-                    final int len = ptr - start;
-                    _streamReadConstraints.validateNameLength(len);
-                    return _symbols.findSymbol(_inputBuffer, start, len, hash);
+                    return _symbols.findSymbol(_inputBuffer, start, ptr - start, hash);
                 }
                 if (ch < maxCode && codes[ch] != 0) {
                     break;
@@ -2178,9 +2168,7 @@ public class ReaderBasedJsonParser
             final TextBuffer tb = _textBuffer;
             final char[] buf = tb.getTextBuffer();
             final int start = tb.getTextOffset();
-            final int len = tb.size();
-            _streamReadConstraints.validateNameLength(len);
-            return _symbols.findSymbol(buf, start, len, hash);
+            return _symbols.findSymbol(buf, start, tb.size(), hash);
         }
     }
 

--- a/src/main/java/com/fasterxml/jackson/core/json/ReaderBasedJsonParser.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/ReaderBasedJsonParser.java
@@ -1864,9 +1864,7 @@ public class ReaderBasedJsonParser
 
     private String _parseName2(int startPtr, int hash, int endChar) throws IOException
     {
-        final int initLen = _inputPtr - startPtr;
-        _streamReadConstraints.validateNameLength(initLen);
-        _textBuffer.resetWithShared(_inputBuffer, startPtr, initLen);
+        _textBuffer.resetWithShared(_inputBuffer, startPtr, _inputPtr - startPtr);
 
         /* Output pointers; calls will also ensure that the buffer is
          * not shared and has room for at least one more char.
@@ -2130,9 +2128,7 @@ public class ReaderBasedJsonParser
 
     private String _handleOddName2(int startPtr, int hash, int[] codes) throws IOException
     {
-        final int initLen = _inputPtr - startPtr;
-        _streamReadConstraints.validateNameLength(initLen);
-        _textBuffer.resetWithShared(_inputBuffer, startPtr, initLen);
+        _textBuffer.resetWithShared(_inputBuffer, startPtr, _inputPtr - startPtr);
         char[] outBuf = _textBuffer.getCurrentSegment();
         int outPtr = _textBuffer.getCurrentSegmentSize();
         final int maxCode = codes.length;

--- a/src/main/java/com/fasterxml/jackson/core/json/UTF8StreamJsonParser.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/UTF8StreamJsonParser.java
@@ -2016,7 +2016,7 @@ public class UTF8StreamJsonParser
 
     private int[] growArrayWithNameLenCheck(int[] arr, int more) throws StreamConstraintsException {
         // the following check will fail if the array is already bigger than is allowed for names
-        _streamReadConstraints.validateNameLength(arr.length);
+        _streamReadConstraints.validateNameLength(arr.length << 2);
         return growArrayBy(_quadBuffer, more);
     }
 
@@ -2118,7 +2118,7 @@ public class UTF8StreamJsonParser
             }
             quads[qlen++] = _padLastQuad(currQuad, currQuadBytes);
         }
-        _streamReadConstraints.validateNameLength(qlen);
+        _streamReadConstraints.validateNameLength(qlen << 2);
         String name = _symbols.findName(quads, qlen);
         if (name == null) {
             name = addName(quads, qlen, currQuadBytes);
@@ -2199,7 +2199,7 @@ public class UTF8StreamJsonParser
             }
             quads[qlen++] = currQuad;
         }
-        _streamReadConstraints.validateNameLength(qlen);
+        _streamReadConstraints.validateNameLength(qlen << 2);
         String name = _symbols.findName(quads, qlen);
         if (name == null) {
             name = addName(quads, qlen, currQuadBytes);
@@ -2305,7 +2305,7 @@ public class UTF8StreamJsonParser
             }
             quads[qlen++] = _padLastQuad(currQuad, currQuadBytes);
         }
-        _streamReadConstraints.validateNameLength(qlen);
+        _streamReadConstraints.validateNameLength(qlen << 2);
         String name = _symbols.findName(quads, qlen);
         if (name == null) {
             name = addName(quads, qlen, currQuadBytes);
@@ -2370,7 +2370,7 @@ public class UTF8StreamJsonParser
             _quadBuffer = quads = growArrayWithNameLenCheck(quads, quads.length);
         }
         quads[qlen++] = _padLastQuad(lastQuad, lastQuadBytes);
-        _streamReadConstraints.validateNameLength(qlen);
+        _streamReadConstraints.validateNameLength(qlen << 2);
         String name = _symbols.findName(quads, qlen);
         if (name == null) {
             return addName(quads, qlen, lastQuadBytes);

--- a/src/main/java/com/fasterxml/jackson/core/json/UTF8StreamJsonParser.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/UTF8StreamJsonParser.java
@@ -1980,7 +1980,7 @@ public class UTF8StreamJsonParser
 
             // Nope, no end in sight. Need to grow quad array etc
             if (qlen >= _quadBuffer.length) {
-                _quadBuffer = growArrayBy(_quadBuffer, qlen);
+                _quadBuffer = growArrayWithNameLenCheck(_quadBuffer, qlen);
             }
             _quadBuffer[qlen++] = q;
             q = i;
@@ -2012,6 +2012,12 @@ public class UTF8StreamJsonParser
 
     private final String parseName(int q1, int ch, int lastQuadBytes) throws IOException {
         return parseEscapedName(_quadBuffer, 0, q1, ch, lastQuadBytes);
+    }
+
+    private int[] growArrayWithNameLenCheck(int[] arr, int more) throws StreamConstraintsException {
+        // the following check will fail if the array is already bigger than is allowed for names
+        _streamReadConstraints.validateNameLength(arr.length);
+        return growArrayBy(_quadBuffer, more);
     }
 
     private final String parseName(int q1, int q2, int ch, int lastQuadBytes) throws IOException {
@@ -2057,7 +2063,7 @@ public class UTF8StreamJsonParser
                     // Ok, we'll need room for first byte right away
                     if (currQuadBytes >= 4) {
                         if (qlen >= quads.length) {
-                            _quadBuffer = quads = growArrayBy(quads, quads.length);
+                            _quadBuffer = quads = growArrayWithNameLenCheck(quads, quads.length);
                         }
                         quads[qlen++] = currQuad;
                         currQuad = 0;
@@ -2073,7 +2079,7 @@ public class UTF8StreamJsonParser
                         // need room for middle byte?
                         if (currQuadBytes >= 4) {
                             if (qlen >= quads.length) {
-                                _quadBuffer = quads = growArrayBy(quads, quads.length);
+                                _quadBuffer = quads = growArrayWithNameLenCheck(quads, quads.length);
                             }
                             quads[qlen++] = currQuad;
                             currQuad = 0;
@@ -2092,7 +2098,7 @@ public class UTF8StreamJsonParser
                 currQuad = (currQuad << 8) | ch;
             } else {
                 if (qlen >= quads.length) {
-                    _quadBuffer = quads = growArrayBy(quads, quads.length);
+                    _quadBuffer = quads = growArrayWithNameLenCheck(quads, quads.length);
                 }
                 quads[qlen++] = currQuad;
                 currQuad = ch;
@@ -2108,10 +2114,11 @@ public class UTF8StreamJsonParser
 
         if (currQuadBytes > 0) {
             if (qlen >= quads.length) {
-                _quadBuffer = quads = growArrayBy(quads, quads.length);
+                _quadBuffer = quads = growArrayWithNameLenCheck(quads, quads.length);
             }
             quads[qlen++] = _padLastQuad(currQuad, currQuadBytes);
         }
+        _streamReadConstraints.validateNameLength(qlen);
         String name = _symbols.findName(quads, qlen);
         if (name == null) {
             name = addName(quads, qlen, currQuadBytes);
@@ -2168,7 +2175,7 @@ public class UTF8StreamJsonParser
                 currQuad = (currQuad << 8) | ch;
             } else {
                 if (qlen >= quads.length) {
-                    _quadBuffer = quads = growArrayBy(quads, quads.length);
+                    _quadBuffer = quads = growArrayWithNameLenCheck(quads, quads.length);
                 }
                 quads[qlen++] = currQuad;
                 currQuad = ch;
@@ -2188,10 +2195,11 @@ public class UTF8StreamJsonParser
 
         if (currQuadBytes > 0) {
             if (qlen >= quads.length) {
-                _quadBuffer = quads = growArrayBy(quads, quads.length);
+                _quadBuffer = quads = growArrayWithNameLenCheck(quads, quads.length);
             }
             quads[qlen++] = currQuad;
         }
+        _streamReadConstraints.validateNameLength(qlen);
         String name = _symbols.findName(quads, qlen);
         if (name == null) {
             name = addName(quads, qlen, currQuadBytes);
@@ -2242,7 +2250,7 @@ public class UTF8StreamJsonParser
                     // Ok, we'll need room for first byte right away
                     if (currQuadBytes >= 4) {
                         if (qlen >= quads.length) {
-                            _quadBuffer = quads = growArrayBy(quads, quads.length);
+                            _quadBuffer = quads = growArrayWithNameLenCheck(quads, quads.length);
                         }
                         quads[qlen++] = currQuad;
                         currQuad = 0;
@@ -2258,7 +2266,7 @@ public class UTF8StreamJsonParser
                         // need room for middle byte?
                         if (currQuadBytes >= 4) {
                             if (qlen >= quads.length) {
-                                _quadBuffer = quads = growArrayBy(quads, quads.length);
+                                _quadBuffer = quads = growArrayWithNameLenCheck(quads, quads.length);
                             }
                             quads[qlen++] = currQuad;
                             currQuad = 0;
@@ -2277,7 +2285,7 @@ public class UTF8StreamJsonParser
                 currQuad = (currQuad << 8) | ch;
             } else {
                 if (qlen >= quads.length) {
-                    _quadBuffer = quads = growArrayBy(quads, quads.length);
+                    _quadBuffer = quads = growArrayWithNameLenCheck(quads, quads.length);
                 }
                 quads[qlen++] = currQuad;
                 currQuad = ch;
@@ -2293,10 +2301,11 @@ public class UTF8StreamJsonParser
 
         if (currQuadBytes > 0) {
             if (qlen >= quads.length) {
-                _quadBuffer = quads = growArrayBy(quads, quads.length);
+                _quadBuffer = quads = growArrayWithNameLenCheck(quads, quads.length);
             }
             quads[qlen++] = _padLastQuad(currQuad, currQuadBytes);
         }
+        _streamReadConstraints.validateNameLength(qlen);
         String name = _symbols.findName(quads, qlen);
         if (name == null) {
             name = addName(quads, qlen, currQuadBytes);
@@ -2358,9 +2367,10 @@ public class UTF8StreamJsonParser
             throws JsonParseException, StreamConstraintsException
     {
         if (qlen >= quads.length) {
-            _quadBuffer = quads = growArrayBy(quads, quads.length);
+            _quadBuffer = quads = growArrayWithNameLenCheck(quads, quads.length);
         }
         quads[qlen++] = _padLastQuad(lastQuad, lastQuadBytes);
+        _streamReadConstraints.validateNameLength(qlen);
         String name = _symbols.findName(quads, qlen);
         if (name == null) {
             return addName(quads, qlen, lastQuadBytes);

--- a/src/main/java/com/fasterxml/jackson/core/json/UTF8StreamJsonParser.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/UTF8StreamJsonParser.java
@@ -2118,7 +2118,6 @@ public class UTF8StreamJsonParser
             }
             quads[qlen++] = _padLastQuad(currQuad, currQuadBytes);
         }
-        _streamReadConstraints.validateNameLength(qlen << 2);
         String name = _symbols.findName(quads, qlen);
         if (name == null) {
             name = addName(quads, qlen, currQuadBytes);
@@ -2199,7 +2198,6 @@ public class UTF8StreamJsonParser
             }
             quads[qlen++] = currQuad;
         }
-        _streamReadConstraints.validateNameLength(qlen << 2);
         String name = _symbols.findName(quads, qlen);
         if (name == null) {
             name = addName(quads, qlen, currQuadBytes);
@@ -2305,7 +2303,6 @@ public class UTF8StreamJsonParser
             }
             quads[qlen++] = _padLastQuad(currQuad, currQuadBytes);
         }
-        _streamReadConstraints.validateNameLength(qlen << 2);
         String name = _symbols.findName(quads, qlen);
         if (name == null) {
             name = addName(quads, qlen, currQuadBytes);
@@ -2370,7 +2367,6 @@ public class UTF8StreamJsonParser
             _quadBuffer = quads = growArrayWithNameLenCheck(quads, quads.length);
         }
         quads[qlen++] = _padLastQuad(lastQuad, lastQuadBytes);
-        _streamReadConstraints.validateNameLength(qlen << 2);
         String name = _symbols.findName(quads, qlen);
         if (name == null) {
             return addName(quads, qlen, lastQuadBytes);
@@ -2391,7 +2387,8 @@ public class UTF8StreamJsonParser
          * (as well as error reporting for unescaped control chars)
          */
         // 4 bytes per quad, except last one maybe less
-        int byteLen = (qlen << 2) - 4 + lastQuadBytes;
+        final int byteLen = (qlen << 2) - 4 + lastQuadBytes;
+        _streamReadConstraints.validateNameLength(byteLen);
 
         /* And last one is not correctly aligned (leading zero bytes instead
          * need to shift a bit, instead of trailing). Only need to shift it

--- a/src/main/java/com/fasterxml/jackson/core/json/async/NonBlockingJsonParserBase.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/async/NonBlockingJsonParserBase.java
@@ -696,7 +696,8 @@ public abstract class NonBlockingJsonParserBase
          * (as well as error reporting for unescaped control chars)
          */
         // 4 bytes per quad, except last one maybe less
-        int byteLen = (qlen << 2) - 4 + lastQuadBytes;
+        final int byteLen = (qlen << 2) - 4 + lastQuadBytes;
+        _streamReadConstraints.validateNameLength(byteLen);
 
         /* And last one is not correctly aligned (leading zero bytes instead
          * need to shift a bit, instead of trailing). Only need to shift it

--- a/src/main/java/com/fasterxml/jackson/core/json/async/NonBlockingUtf8JsonParserBase.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/async/NonBlockingUtf8JsonParserBase.java
@@ -2176,7 +2176,6 @@ public abstract class NonBlockingUtf8JsonParserBase
         } else if (qlen == 0) { // rare, but may happen
             return _fieldComplete("");
         }
-        _streamReadConstraints.validateNameLength(qlen << 2);
         String name = _symbols.findName(quads, qlen);
         if (name == null) {
             name = _addName(quads, qlen, currQuadBytes);
@@ -2275,7 +2274,6 @@ public abstract class NonBlockingUtf8JsonParserBase
             }
             quads[qlen++] = currQuad;
         }
-        _streamReadConstraints.validateNameLength(qlen << 2);
         String name = _symbols.findName(quads, qlen);
         if (name == null) {
             name = _addName(quads, qlen, currQuadBytes);
@@ -2373,7 +2371,6 @@ public abstract class NonBlockingUtf8JsonParserBase
         } else if (qlen == 0) { // rare case but possible
             return _fieldComplete("");
         }
-        _streamReadConstraints.validateNameLength(qlen << 2);
         String name = _symbols.findName(quads, qlen);
         if (name == null) {
             name = _addName(quads, qlen, currQuadBytes);

--- a/src/main/java/com/fasterxml/jackson/core/json/async/NonBlockingUtf8JsonParserBase.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/async/NonBlockingUtf8JsonParserBase.java
@@ -2176,7 +2176,7 @@ public abstract class NonBlockingUtf8JsonParserBase
         } else if (qlen == 0) { // rare, but may happen
             return _fieldComplete("");
         }
-        _streamReadConstraints.validateNameLength(qlen);
+        _streamReadConstraints.validateNameLength(qlen << 2);
         String name = _symbols.findName(quads, qlen);
         if (name == null) {
             name = _addName(quads, qlen, currQuadBytes);
@@ -2275,7 +2275,7 @@ public abstract class NonBlockingUtf8JsonParserBase
             }
             quads[qlen++] = currQuad;
         }
-        _streamReadConstraints.validateNameLength(qlen);
+        _streamReadConstraints.validateNameLength(qlen << 2);
         String name = _symbols.findName(quads, qlen);
         if (name == null) {
             name = _addName(quads, qlen, currQuadBytes);
@@ -2373,7 +2373,7 @@ public abstract class NonBlockingUtf8JsonParserBase
         } else if (qlen == 0) { // rare case but possible
             return _fieldComplete("");
         }
-        _streamReadConstraints.validateNameLength(qlen);
+        _streamReadConstraints.validateNameLength(qlen << 2);
         String name = _symbols.findName(quads, qlen);
         if (name == null) {
             name = _addName(quads, qlen, currQuadBytes);
@@ -2435,7 +2435,7 @@ public abstract class NonBlockingUtf8JsonParserBase
 
     private int[] growArrayWithNameLenCheck(int[] arr, int more) throws StreamConstraintsException {
         // the following check will fail if the array is already bigger than is allowed for names
-        _streamReadConstraints.validateNameLength(arr.length);
+        _streamReadConstraints.validateNameLength(arr.length << 2);
         return growArrayBy(_quadBuffer, more);
     }
 

--- a/src/main/java/com/fasterxml/jackson/core/json/async/NonBlockingUtf8JsonParserBase.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/async/NonBlockingUtf8JsonParserBase.java
@@ -2,6 +2,7 @@ package com.fasterxml.jackson.core.json.async;
 
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.core.exc.StreamConstraintsException;
 import com.fasterxml.jackson.core.io.CharTypes;
 import com.fasterxml.jackson.core.io.IOContext;
 import com.fasterxml.jackson.core.json.JsonReadFeature;
@@ -2096,7 +2097,7 @@ public abstract class NonBlockingUtf8JsonParserBase
                     continue;
                 }
                 if (qlen >= quads.length) {
-                    _quadBuffer = quads = growArrayBy(quads, quads.length);
+                    _quadBuffer = quads = growArrayWithNameLenCheck(quads, quads.length);
                 }
                 quads[qlen++] = currQuad;
                 currQuad = ch;
@@ -2129,7 +2130,7 @@ public abstract class NonBlockingUtf8JsonParserBase
             // 7-bit ASCII. Gets pretty messy. If this happens often, may
             // want to use different name canonicalization to avoid these hits.
             if (qlen >= quads.length) {
-                _quadBuffer = quads = growArrayBy(quads, quads.length);
+                _quadBuffer = quads = growArrayWithNameLenCheck(quads, quads.length);
             }
             if (ch > 127) {
                 // Ok, we'll need room for first byte right away
@@ -2169,12 +2170,13 @@ public abstract class NonBlockingUtf8JsonParserBase
 
         if (currQuadBytes > 0) {
             if (qlen >= quads.length) {
-                _quadBuffer = quads = growArrayBy(quads, quads.length);
+                _quadBuffer = quads = growArrayWithNameLenCheck(quads, quads.length);
             }
             quads[qlen++] = _padLastQuad(currQuad, currQuadBytes);
         } else if (qlen == 0) { // rare, but may happen
             return _fieldComplete("");
         }
+        _streamReadConstraints.validateNameLength(qlen);
         String name = _symbols.findName(quads, qlen);
         if (name == null) {
             name = _addName(quads, qlen, currQuadBytes);
@@ -2259,7 +2261,7 @@ public abstract class NonBlockingUtf8JsonParserBase
                 currQuad = (currQuad << 8) | ch;
             } else {
                 if (qlen >= quads.length) {
-                    _quadBuffer = quads = growArrayBy(quads, quads.length);
+                    _quadBuffer = quads = growArrayWithNameLenCheck(quads, quads.length);
                 }
                 quads[qlen++] = currQuad;
                 currQuad = ch;
@@ -2269,10 +2271,11 @@ public abstract class NonBlockingUtf8JsonParserBase
 
         if (currQuadBytes > 0) {
             if (qlen >= quads.length) {
-                _quadBuffer = quads = growArrayBy(quads, quads.length);
+                _quadBuffer = quads = growArrayWithNameLenCheck(quads, quads.length);
             }
             quads[qlen++] = currQuad;
         }
+        _streamReadConstraints.validateNameLength(qlen);
         String name = _symbols.findName(quads, qlen);
         if (name == null) {
             name = _addName(quads, qlen, currQuadBytes);
@@ -2319,7 +2322,7 @@ public abstract class NonBlockingUtf8JsonParserBase
                     // Ok, we'll need room for first byte right away
                     if (currQuadBytes >= 4) {
                         if (qlen >= quads.length) {
-                            _quadBuffer = quads = growArrayBy(quads, quads.length);
+                            _quadBuffer = quads = growArrayWithNameLenCheck(quads, quads.length);
                         }
                         quads[qlen++] = currQuad;
                         currQuad = 0;
@@ -2335,7 +2338,7 @@ public abstract class NonBlockingUtf8JsonParserBase
                         // need room for middle byte?
                         if (currQuadBytes >= 4) {
                             if (qlen >= quads.length) {
-                                _quadBuffer = quads = growArrayBy(quads, quads.length);
+                                _quadBuffer = quads = growArrayWithNameLenCheck(quads, quads.length);
                             }
                             quads[qlen++] = currQuad;
                             currQuad = 0;
@@ -2354,7 +2357,7 @@ public abstract class NonBlockingUtf8JsonParserBase
                 currQuad = (currQuad << 8) | ch;
             } else {
                 if (qlen >= quads.length) {
-                    _quadBuffer = quads = growArrayBy(quads, quads.length);
+                    _quadBuffer = quads = growArrayWithNameLenCheck(quads, quads.length);
                 }
                 quads[qlen++] = currQuad;
                 currQuad = ch;
@@ -2364,12 +2367,13 @@ public abstract class NonBlockingUtf8JsonParserBase
 
         if (currQuadBytes > 0) {
             if (qlen >= quads.length) {
-                _quadBuffer = quads = growArrayBy(quads, quads.length);
+                _quadBuffer = quads = growArrayWithNameLenCheck(quads, quads.length);
             }
             quads[qlen++] = _padLastQuad(currQuad, currQuadBytes);
         } else if (qlen == 0) { // rare case but possible
             return _fieldComplete("");
         }
+        _streamReadConstraints.validateNameLength(qlen);
         String name = _symbols.findName(quads, qlen);
         if (name == null) {
             name = _addName(quads, qlen, currQuadBytes);
@@ -2386,7 +2390,7 @@ public abstract class NonBlockingUtf8JsonParserBase
             return JsonToken.NOT_AVAILABLE;
         }
         if (_quadLength >= _quadBuffer.length) {
-            _quadBuffer = growArrayBy(_quadBuffer, 32);
+            _quadBuffer = growArrayWithNameLenCheck(_quadBuffer, 32);
         }
         int currQuad = _pending32;
         int currQuadBytes = _pendingBytes;
@@ -2427,6 +2431,12 @@ public abstract class NonBlockingUtf8JsonParserBase
             return _finishAposName(_quadLength, currQuad, currQuadBytes);
         }
         return _parseEscapedName(_quadLength, currQuad, currQuadBytes);
+    }
+
+    private int[] growArrayWithNameLenCheck(int[] arr, int more) throws StreamConstraintsException {
+        // the following check will fail if the array is already bigger than is allowed for names
+        _streamReadConstraints.validateNameLength(arr.length);
+        return growArrayBy(_quadBuffer, more);
     }
 
     private int _decodeSplitEscaped(int value, int bytesRead) throws IOException

--- a/src/main/java/com/fasterxml/jackson/core/sym/CharsToNameCanonicalizer.java
+++ b/src/main/java/com/fasterxml/jackson/core/sym/CharsToNameCanonicalizer.java
@@ -499,6 +499,7 @@ public final class CharsToNameCanonicalizer
         if (len < 1) { // empty Strings are simplest to handle up front
             return "";
         }
+        _streamReadConstraints.validateNameLength(len);
         if (!_canonicalize) { // [JACKSON-259]
             return new String(buffer, start, len);
         }

--- a/src/test/java/com/fasterxml/jackson/core/read/LargeNameReadTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/read/LargeNameReadTest.java
@@ -39,6 +39,24 @@ public class LargeNameReadTest extends BaseTest {
         }
     }
 
+    public void testReaderLargeNameWithSmallLimit() throws Exception
+    {
+        final String doc = generateJSON(1000);
+        final JsonFactory jsonFactory = JsonFactory.builder()
+                .streamReadConstraints(StreamReadConstraints.builder().maxNameLength(100).build())
+                .build();
+        try (JsonParser jp = createParserUsingReader(jsonFactory, doc)) {
+            JsonToken jsonToken;
+            while ((jsonToken = jp.nextToken()) != null) {
+                System.out.println(jsonToken);
+            }
+            fail("expected StreamConstraintsException");
+        } catch (StreamConstraintsException e) {
+            assertTrue("Unexpected exception message: " + e.getMessage(),
+                    e.getMessage().contains("Name value length"));
+        }
+    }
+
     private String generateJSON(final int nameLen) {
         final StringBuilder sb = new StringBuilder();
         sb.append("{\"");

--- a/src/test/java/com/fasterxml/jackson/core/read/LargeNameReadTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/read/LargeNameReadTest.java
@@ -1,15 +1,20 @@
 package com.fasterxml.jackson.core.read;
 
 import com.fasterxml.jackson.core.BaseTest;
+import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.core.StreamReadConstraints;
 
 public class LargeNameReadTest extends BaseTest {
 
     public void testLargeName() throws Exception
     {
         final String doc = generateJSON(1000);
-        try (JsonParser jp = createParserUsingStream(doc, "UTF-8")) {
+        final JsonFactory jsonFactory = JsonFactory.builder()
+                .streamReadConstraints(StreamReadConstraints.builder().maxNameLength(100).build())
+                .build();
+        try (JsonParser jp = createParserUsingStream(jsonFactory, doc, "UTF-8")) {
             JsonToken jsonToken;
             while ((jsonToken = jp.nextToken()) != null) {
 

--- a/src/test/java/com/fasterxml/jackson/core/read/LargeNameReadTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/read/LargeNameReadTest.java
@@ -5,10 +5,23 @@ import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.core.StreamReadConstraints;
+import com.fasterxml.jackson.core.exc.StreamConstraintsException;
 
 public class LargeNameReadTest extends BaseTest {
 
     public void testLargeName() throws Exception
+    {
+        final String doc = generateJSON(1000);
+        final JsonFactory jsonFactory = JsonFactory.builder().build();
+        try (JsonParser jp = createParserUsingStream(jsonFactory, doc, "UTF-8")) {
+            JsonToken jsonToken;
+            while ((jsonToken = jp.nextToken()) != null) {
+
+            }
+        }
+    }
+
+    public void testLargeNameWithSmallLimit() throws Exception
     {
         final String doc = generateJSON(1000);
         final JsonFactory jsonFactory = JsonFactory.builder()
@@ -19,6 +32,10 @@ public class LargeNameReadTest extends BaseTest {
             while ((jsonToken = jp.nextToken()) != null) {
 
             }
+            fail("expected StreamConstraintsException");
+        } catch (StreamConstraintsException e) {
+            assertTrue("Unexpected exception message: " + e.getMessage(),
+                    e.getMessage().contains("Name value length"));
         }
     }
 

--- a/src/test/java/com/fasterxml/jackson/core/read/LargeNameReadTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/read/LargeNameReadTest.java
@@ -1,0 +1,29 @@
+package com.fasterxml.jackson.core.read;
+
+import com.fasterxml.jackson.core.BaseTest;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+
+public class LargeNameReadTest extends BaseTest {
+
+    public void testLargeName() throws Exception
+    {
+        final String doc = generateJSON(1000);
+        try (JsonParser jp = createParserUsingStream(doc, "UTF-8")) {
+            JsonToken jsonToken;
+            while ((jsonToken = jp.nextToken()) != null) {
+
+            }
+        }
+    }
+
+    private String generateJSON(final int nameLen) {
+        final StringBuilder sb = new StringBuilder();
+        sb.append("{\"");
+        for (int i = 0; i < nameLen; i++) {
+            sb.append("a");
+        }
+        sb.append("\":\"value\"}");
+        return sb.toString();
+    }
+}


### PR DESCRIPTION
* so far just a POC that only works with the UTF8StreamJsonParser and possibly NonBlockingUtf8JsonParsers
* start with 50,000 char limit on names (as a default, that can be adjusted by users)
* if this approach is ok, the other JsonParser implementations can be given the equivalent checks
  * I have added some checks to the ReaderBasedJsonParser but we need more checks (while the name is being streamed)
* see https://github.com/FasterXML/jackson-core/issues/1047