### PR TITLE
Make `ByteSourceJsonBootstrapper` use `StringReader` for < 8KiB byte[] inputs

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/json/ByteSourceJsonBootstrapper.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/ByteSourceJsonBootstrapper.java
@@ -234,7 +234,7 @@ public final class ByteSourceJsonBootstrapper
 
                 if (in == null) {
                     int length = _inputEnd - _inputPtr;
-                    if (length <= STRING_READER_BYTE_ARRAY_LENGTH_LIMIT && length >= 0) {
+                    if (length <= STRING_READER_BYTE_ARRAY_LENGTH_LIMIT) {
                         // [jackson-core#488] Avoid overhead of heap ByteBuffer allocated by InputStreamReader
                         // when processing small inputs up to 8KiB.
                         return new StringReader(new String(_inputBuffer, _inputPtr, length, enc.getJavaName()));

--- a/src/main/java/com/fasterxml/jackson/core/json/ByteSourceJsonBootstrapper.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/ByteSourceJsonBootstrapper.java
@@ -22,6 +22,9 @@ public final class ByteSourceJsonBootstrapper
     public final static byte UTF8_BOM_2 = (byte) 0xBB;
     public final static byte UTF8_BOM_3 = (byte) 0xBF;
 
+    // [jackson-core#488] Limit in bytes for input byte array length to use StringReader instead of InputStreamReader
+    private static final int STRING_READER_BYTE_ARRAY_LENGTH_LIMIT = 8192;
+
     /*
     /**********************************************************
     /* Configuration
@@ -231,7 +234,7 @@ public final class ByteSourceJsonBootstrapper
 
                 if (in == null) {
                     int length = _inputEnd - _inputPtr;
-                    if (length >= 0 && length <= 8192) {
+                    if (length <= STRING_READER_BYTE_ARRAY_LENGTH_LIMIT && length >= 0) {
                         // [jackson-core#488] Avoid overhead of heap ByteBuffer allocated by InputStreamReader
                         // when processing small inputs up to 8KiB.
                         return new StringReader(new String(_inputBuffer, _inputPtr, length, enc.getJavaName()));

--- a/src/main/java/com/fasterxml/jackson/core/json/ByteSourceJsonBootstrapper.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/ByteSourceJsonBootstrapper.java
@@ -230,6 +230,12 @@ public final class ByteSourceJsonBootstrapper
                 InputStream in = _in;
 
                 if (in == null) {
+                    int length = _inputEnd - _inputPtr;
+                    if (length >= 0 && length <= 8192) {
+                        // [jackson-core#488] Avoid overhead of heap ByteBuffer allocated by InputStreamReader
+                        // when processing small inputs up to 8KiB.
+                        return new StringReader(new String(_inputBuffer, _inputPtr, length, enc.getJavaName()));
+                    }
                     in = new ByteArrayInputStream(_inputBuffer, _inputPtr, _inputEnd);
                 } else {
                     /* Also, if we have any read but unused input (usually true),


### PR DESCRIPTION
From @carterkozak https://github.com/FasterXML/jackson-core/pull/1079#discussion_r1290512114 this is an alternative implementation draft to address https://github.com/FasterXML/jackson-core/issues/593 (and https://github.com/FasterXML/jackson-core/pull/995#issuecomment-1668292432 ) when deserializing from a `byte[]` as the `InputStreamReader` code path triggers an 8KiB `HeapByteBuffer` allocation for `StreamDecoder` regardless of input byte array length. This allocation significantly penalizes smaller `byte[]` sources.

![image](https://github.com/FasterXML/jackson-core/assets/54594/1dbb3e30-aa60-471b-a622-bc9601415750)

The approach here converts `byte[]` inputs smaller thank 8KiB to a `String` and processed via `StringReader`. This should avoid unnecessary 8KiB heap byte buffer allocation and leverage OpenJDK's continued charset decoding improvements (e.g. https://cl4es.github.io/2021/02/23/Faster-Charset-Decoding.html ).

Initial benchmarks from https://github.com/FasterXML/jackson-benchmarks/pull/9 show `StringReader` providing performance equivalent to `ByteArrayInputStream` source in worst case, and anywhere from ~2x to ~10x speedup in best case.