### PR TITLE
track JsonFactory in CharsToNameCanonicalizer

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/JsonFactory.java
+++ b/src/main/java/com/fasterxml/jackson/core/JsonFactory.java
@@ -221,7 +221,7 @@ public class JsonFactory
      * It should not be linked back to the original blueprint, to
      * avoid contents from leaking between factories.
      */
-    protected final transient CharsToNameCanonicalizer _rootCharSymbols = CharsToNameCanonicalizer.createRoot();
+    protected final transient CharsToNameCanonicalizer _rootCharSymbols = CharsToNameCanonicalizer.createRoot(this);
 
     /**
      * Alternative to the basic symbol table, some stream-based


### PR DESCRIPTION
* not yet making a change for ByteQuadsCanonicalizer
* based on https://github.com/FasterXML/jackson-core/pull/1078#issuecomment-1688978066
* I don't really understand the subtleties in CharsToNameCanonicalizer. In #1078, I am already validating the length before I call findSymbol on the CharsToNameCanonicalizer so I don't know what benefit there is to also checking in CharsToNameCanonicalizer. The changes in ReaderBasedJsonParser in 1078 are incomplete because waiting until the CharsToNameCanonicalizer findSymbol call is very late. We may already have wasted a lot of processing time by that stage.