### PR TITLE
support IOContext closing in GeneratorBase

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/base/GeneratorBase.java
+++ b/src/main/java/com/fasterxml/jackson/core/base/GeneratorBase.java
@@ -129,6 +129,7 @@ public abstract class GeneratorBase extends JsonGenerator
     }
 
     // @since 2.16
+    @SuppressWarnings("deprecation")
     protected GeneratorBase(int features, ObjectCodec codec, IOContext ioContext, JsonWriteContext jsonWriteContext) {
         super();
         _features = features;

--- a/src/main/java/com/fasterxml/jackson/core/base/GeneratorBase.java
+++ b/src/main/java/com/fasterxml/jackson/core/base/GeneratorBase.java
@@ -133,6 +133,7 @@ public abstract class GeneratorBase extends JsonGenerator
         super();
         _features = features;
         _objectCodec = codec;
+        _ioContext = ioContext;
         _writeContext = jsonWriteContext;
         _cfgNumbersAsStrings = Feature.WRITE_NUMBERS_AS_STRINGS.enabledIn(features);
     }
@@ -430,8 +431,10 @@ public abstract class GeneratorBase extends JsonGenerator
     @Override public abstract void flush() throws IOException;
     @Override public void close() throws IOException {
         if (!_closed) {
+            if (_ioContext != null) {
+                _ioContext.close();
+            }
             _closed = true;
-            _ioContext.close();
         }
     }
     @Override public boolean isClosed() { return _closed; }

--- a/src/main/java/com/fasterxml/jackson/core/base/GeneratorBase.java
+++ b/src/main/java/com/fasterxml/jackson/core/base/GeneratorBase.java
@@ -70,7 +70,8 @@ public abstract class GeneratorBase extends JsonGenerator
      */
     protected int _features;
 
-    protected IOContext _ioContext;
+    // since 2.16
+    protected final IOContext _ioContext;
 
     /**
      * Flag set to indicate that implicit conversion from number

--- a/src/main/java/com/fasterxml/jackson/core/json/JsonGeneratorImpl.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/JsonGeneratorImpl.java
@@ -120,14 +120,6 @@ public abstract class JsonGeneratorImpl extends GeneratorBase
     /**********************************************************
      */
 
-    @Override
-    public void close() throws IOException {
-        if (!isClosed()) {
-            super.close();
-            _ioContext.close();
-        }
-    }
-
     @SuppressWarnings("deprecation")
     public JsonGeneratorImpl(IOContext ctxt, int features, ObjectCodec codec)
     {

--- a/src/main/java/com/fasterxml/jackson/core/json/JsonGeneratorImpl.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/JsonGeneratorImpl.java
@@ -45,8 +45,6 @@ public abstract class JsonGeneratorImpl extends GeneratorBase
     /**********************************************************
      */
 
-    protected final IOContext _ioContext;
-
     /**
      * @since 2.16
      */
@@ -123,8 +121,7 @@ public abstract class JsonGeneratorImpl extends GeneratorBase
     @SuppressWarnings("deprecation")
     public JsonGeneratorImpl(IOContext ctxt, int features, ObjectCodec codec)
     {
-        super(features, codec);
-        _ioContext = ctxt;
+        super(features, codec, ctxt);
         _streamWriteConstraints = ctxt.streamWriteConstraints();
         if (Feature.ESCAPE_NON_ASCII.enabledIn(features)) {
             // inlined `setHighestNonEscapedChar()`

--- a/src/test/java/com/fasterxml/jackson/core/io/BufferRecyclerPoolTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/io/BufferRecyclerPoolTest.java
@@ -12,28 +12,28 @@ import java.io.OutputStream;
 
 public class BufferRecyclerPoolTest extends BaseTest
 {
-    public void testNoOp() {
+    public void testNoOp() throws IOException {
         // no-op pool doesn't actually pool anything, so avoid checking it
         checkBufferRecyclerPoolImpl(BufferRecyclerPool.NonRecyclingPool.shared(), false);
     }
 
-    public void testThreadLocal() {
+    public void testThreadLocal() throws IOException {
         checkBufferRecyclerPoolImpl(BufferRecyclerPool.ThreadLocalPool.shared(), true);
     }
 
-    public void testLockFree() {
+    public void testLockFree() throws IOException {
         checkBufferRecyclerPoolImpl(BufferRecyclerPool.LockFreePool.nonShared(), true);
     }
 
-    public void testConcurrentDequeue() {
+    public void testConcurrentDequeue() throws IOException {
         checkBufferRecyclerPoolImpl(BufferRecyclerPool.ConcurrentDequePool.nonShared(), true);
     }
 
-    public void testBounded() {
+    public void testBounded() throws IOException {
         checkBufferRecyclerPoolImpl(BufferRecyclerPool.BoundedPool.nonShared(1), true);
     }
 
-    private void checkBufferRecyclerPoolImpl(BufferRecyclerPool pool, boolean checkPooledResource) {
+    private void checkBufferRecyclerPoolImpl(BufferRecyclerPool pool, boolean checkPooledResource) throws IOException {
         JsonFactory jsonFactory = JsonFactory.builder()
                 .bufferRecyclerPool(pool)
                 .build();
@@ -50,14 +50,12 @@ public class BufferRecyclerPoolTest extends BaseTest
         }
     }
 
-    protected final BufferRecycler write(Object value, JsonFactory jsonFactory, int expectedSize) {
+    private BufferRecycler write(Object value, JsonFactory jsonFactory, int expectedSize) throws IOException {
         BufferRecycler bufferRecycler;
         NopOutputStream out = new NopOutputStream();
         try (JsonGenerator gen = jsonFactory.createGenerator(out)) {
             bufferRecycler = ((JsonGeneratorImpl) gen).ioContext()._bufferRecycler;
             gen.writeObject(value);
-        } catch (IOException e) {
-            throw new RuntimeException(e);
         }
         assertEquals(expectedSize, out.size);
         return bufferRecycler;

--- a/src/test/java/com/fasterxml/jackson/core/io/BufferRecyclerPoolTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/io/BufferRecyclerPoolTest.java
@@ -12,28 +12,28 @@ import java.io.OutputStream;
 
 public class BufferRecyclerPoolTest extends BaseTest
 {
-    public void testNoOp() throws IOException {
+    public void testNoOp() throws Exception {
         // no-op pool doesn't actually pool anything, so avoid checking it
         checkBufferRecyclerPoolImpl(BufferRecyclerPool.NonRecyclingPool.shared(), false);
     }
 
-    public void testThreadLocal() throws IOException {
+    public void testThreadLocal() throws Exception {
         checkBufferRecyclerPoolImpl(BufferRecyclerPool.ThreadLocalPool.shared(), true);
     }
 
-    public void testLockFree() throws IOException {
+    public void testLockFree() throws Exception {
         checkBufferRecyclerPoolImpl(BufferRecyclerPool.LockFreePool.nonShared(), true);
     }
 
-    public void testConcurrentDequeue() throws IOException {
+    public void testConcurrentDequeue() throws Exception {
         checkBufferRecyclerPoolImpl(BufferRecyclerPool.ConcurrentDequePool.nonShared(), true);
     }
 
-    public void testBounded() throws IOException {
+    public void testBounded() throws Exception {
         checkBufferRecyclerPoolImpl(BufferRecyclerPool.BoundedPool.nonShared(1), true);
     }
 
-    private void checkBufferRecyclerPoolImpl(BufferRecyclerPool pool, boolean checkPooledResource) throws IOException {
+    private void checkBufferRecyclerPoolImpl(BufferRecyclerPool pool, boolean checkPooledResource) throws Exception {
         JsonFactory jsonFactory = JsonFactory.builder()
                 .bufferRecyclerPool(pool)
                 .build();
@@ -50,7 +50,7 @@ public class BufferRecyclerPoolTest extends BaseTest
         }
     }
 
-    private BufferRecycler write(Object value, JsonFactory jsonFactory, int expectedSize) throws IOException {
+    private BufferRecycler write(Object value, JsonFactory jsonFactory, int expectedSize) throws Exception {
         BufferRecycler bufferRecycler;
         NopOutputStream out = new NopOutputStream();
         try (JsonGenerator gen = jsonFactory.createGenerator(out)) {
@@ -61,10 +61,10 @@ public class BufferRecyclerPoolTest extends BaseTest
         return bufferRecycler;
     }
 
-    public class NopOutputStream extends OutputStream {
+    private static class NopOutputStream extends OutputStream {
         protected int size = 0;
 
-        public NopOutputStream() { }
+        NopOutputStream() { }
 
         @Override
         public void write(int b) throws IOException { ++size; }


### PR DESCRIPTION
JsonGeneratorImpl closes the IOContext now (part of the BufferRecycler changes in v2.16).
Unfortunately, there are generators in other Jackson modules that now need to close the IOContext (eg TomlGenerator). It would be easier if GeneratorBase was changed and then classes like TomlGenerator could be updated to notify GeneratorBase about their IOContext and let GeneratorBase do closing.

ParserBase has the IOContext close in it so it is pretty strange not to support it in GeneratorBase.

wdyt @cowtowncoder @mariofusco  ?