### PR TITLE
Set dependabot for grouped updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Related to #1103.

As suggested in the linked issue, this PR configures dependabot to update all GitHub Actions at once instead of sending individual PRs for each Action.