### PR TITLE
fix external pool pluggability

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/JsonFactory.java
+++ b/src/main/java/com/fasterxml/jackson/core/JsonFactory.java
@@ -2150,7 +2150,7 @@ public class JsonFactory
      */
     public BufferRecycler _getBufferRecycler()
     {
-        return _getBufferRecyclerPool().acquireBufferRecycler();
+        return _getBufferRecyclerPool()._internalAcquire();
     }
 
     /**

--- a/src/main/java/com/fasterxml/jackson/core/JsonFactory.java
+++ b/src/main/java/com/fasterxml/jackson/core/JsonFactory.java
@@ -2150,7 +2150,7 @@ public class JsonFactory
      */
     public BufferRecycler _getBufferRecycler()
     {
-        return _getBufferRecyclerPool()._internalAcquire();
+        return _getBufferRecyclerPool().acquireBufferRecycler();
     }
 
     /**

--- a/src/main/java/com/fasterxml/jackson/core/JsonFactory.java
+++ b/src/main/java/com/fasterxml/jackson/core/JsonFactory.java
@@ -2150,7 +2150,7 @@ public class JsonFactory
      */
     public BufferRecycler _getBufferRecycler()
     {
-        return _getBufferRecyclerPool().acquireBufferRecycler();
+        return _getBufferRecyclerPool().acquireAndLinkBufferRecycler();
     }
 
     /**

--- a/src/main/java/com/fasterxml/jackson/core/util/BufferRecyclerPool.java
+++ b/src/main/java/com/fasterxml/jackson/core/util/BufferRecyclerPool.java
@@ -59,7 +59,7 @@ public interface BufferRecyclerPool extends Serializable
      * Method for sub-classes to implement for actual acquire logic; called
      * by {@link #acquireAndLinkBufferRecycler()}.
      */
-    abstract BufferRecycler acquireBufferRecycler();
+    BufferRecycler acquireBufferRecycler();
 
     /**
      * Method that should be called when previously acquired (see {@link #acquireAndLinkBufferRecycler})

--- a/src/main/java/com/fasterxml/jackson/core/util/BufferRecyclerPool.java
+++ b/src/main/java/com/fasterxml/jackson/core/util/BufferRecyclerPool.java
@@ -56,6 +56,10 @@ public interface BufferRecyclerPool extends Serializable
      */
     void releaseBufferRecycler(BufferRecycler recycler);
 
+    default BufferRecycler _internalAcquire() {
+        return acquireBufferRecycler().withPool(this);
+    }
+
     /**
      * @return the default {@link BufferRecyclerPool} implementation
      *   which is the thread local based one:
@@ -134,6 +138,11 @@ public interface BufferRecyclerPool extends Serializable
         public void releaseBufferRecycler(BufferRecycler recycler) {
             ; // nothing to do, relies on ThreadLocal
         }
+
+        public BufferRecycler _internalAcquire() {
+            // since this pool doesn't do anything on release it doesn't need to be registered on the BufferRecycler
+            return acquireBufferRecycler();
+        }
     }
 
     /**
@@ -174,6 +183,11 @@ public interface BufferRecyclerPool extends Serializable
         @Override
         public void releaseBufferRecycler(BufferRecycler recycler) {
             ; // nothing to do, there is no underlying pool
+        }
+
+        public BufferRecycler _internalAcquire() {
+            // since this pool doesn't do anything on release it doesn't need to be registered on the BufferRecycler
+            return acquireBufferRecycler();
         }
     }
 
@@ -266,7 +280,7 @@ public interface BufferRecyclerPool extends Serializable
             if (bufferRecycler == null) {
                 bufferRecycler = new BufferRecycler();
             }
-            return bufferRecycler.withPool(this);
+            return bufferRecycler;
         }
 
         @Override
@@ -333,7 +347,7 @@ public interface BufferRecyclerPool extends Serializable
 
         @Override
         public BufferRecycler acquireBufferRecycler() {
-            return _getRecycler().withPool(this);
+            return _getRecycler();
         }
 
         private BufferRecycler _getRecycler() {
@@ -448,7 +462,7 @@ public interface BufferRecyclerPool extends Serializable
             if (bufferRecycler == null) {
                 bufferRecycler = new BufferRecycler();
             }
-            return bufferRecycler.withPool(this);
+            return bufferRecycler;
         }
 
         @Override

--- a/src/main/java/com/fasterxml/jackson/core/util/BufferRecyclerPool.java
+++ b/src/main/java/com/fasterxml/jackson/core/util/BufferRecyclerPool.java
@@ -75,7 +75,7 @@ public interface BufferRecyclerPool extends Serializable
      *   which is the thread local based one:
      *   basically alias to {@link #threadLocalPool()}).
      */
-    public static BufferRecyclerPool defaultPool() {
+    static BufferRecyclerPool defaultPool() {
         return threadLocalPool();
     }
 
@@ -83,7 +83,7 @@ public interface BufferRecyclerPool extends Serializable
      * @return Globally shared instance of {@link ThreadLocalPool}; same as calling
      *   {@link ThreadLocalPool#shared()}.
      */
-    public static BufferRecyclerPool threadLocalPool() {
+    static BufferRecyclerPool threadLocalPool() {
         return ThreadLocalPool.shared();
     }
 
@@ -91,7 +91,7 @@ public interface BufferRecyclerPool extends Serializable
      * @return Globally shared instance of {@link NonRecyclingPool}; same as calling
      *   {@link NonRecyclingPool#shared()}.
      */
-    public static BufferRecyclerPool nonRecyclingPool() {
+    static BufferRecyclerPool nonRecyclingPool() {
         return NonRecyclingPool.shared();
     }
 
@@ -112,7 +112,7 @@ public interface BufferRecyclerPool extends Serializable
      * Android), or on platforms where {@link java.lang.Thread}s are not
      * long-living or reused (like Project Loom).
      */
-    public class ThreadLocalPool implements BufferRecyclerPool
+    class ThreadLocalPool implements BufferRecyclerPool
     {
         private static final long serialVersionUID = 1L;
 
@@ -160,7 +160,7 @@ public interface BufferRecyclerPool extends Serializable
      * {@link BufferRecyclerPool} implementation that does not use
      * any pool but simply creates new instances when necessary.
      */
-    public class NonRecyclingPool implements BufferRecyclerPool
+    class NonRecyclingPool implements BufferRecyclerPool
     {
         private static final long serialVersionUID = 1L;
 
@@ -241,7 +241,7 @@ public interface BufferRecyclerPool extends Serializable
      *<p>
      * Pool is unbounded: see {@link BufferRecyclerPool} what this means.
      */
-    public class ConcurrentDequePool extends StatefulImplBase
+    class ConcurrentDequePool extends StatefulImplBase
     {
         private static final long serialVersionUID = 1L;
 
@@ -308,7 +308,7 @@ public interface BufferRecyclerPool extends Serializable
      * Pool is unbounded: see {@link BufferRecyclerPool} for
      * details on what this means.
      */
-    public class LockFreePool extends StatefulImplBase
+    class LockFreePool extends StatefulImplBase
     {
         private static final long serialVersionUID = 1L;
 
@@ -405,7 +405,7 @@ public interface BufferRecyclerPool extends Serializable
      * {@link BufferRecycler} instances than its size configuration:
      * the default size is {@link BoundedPool#DEFAULT_CAPACITY}.
      */
-    public class BoundedPool extends StatefulImplBase
+    class BoundedPool extends StatefulImplBase
     {
         private static final long serialVersionUID = 1L;
 

--- a/src/test/java/com/fasterxml/jackson/core/io/BufferRecyclerPoolTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/io/BufferRecyclerPoolTest.java
@@ -45,7 +45,7 @@ public class BufferRecyclerPoolTest extends BaseTest
 
         if (checkPooledResource) {
             // acquire the pooled BufferRecycler again and check if it is the same instance used before
-            BufferRecycler pooledBufferRecycler = pool._internalAcquire();
+            BufferRecycler pooledBufferRecycler = pool.acquireBufferRecycler();
             try {
                 assertSame(usedBufferRecycler, pooledBufferRecycler);
             } finally {
@@ -81,12 +81,13 @@ public class BufferRecyclerPoolTest extends BaseTest
     }
 
 
-    class TestPool implements BufferRecyclerPool {
-
+    @SuppressWarnings("serial")
+    class TestPool extends BufferRecyclerPool
+    {
         private BufferRecycler bufferRecycler;
 
         @Override
-        public BufferRecycler acquireBufferRecycler() {
+        public BufferRecycler _internalAcquire() {
             if (bufferRecycler != null) {
                 BufferRecycler tmp = bufferRecycler;
                 this.bufferRecycler = null;

--- a/src/test/java/com/fasterxml/jackson/core/io/BufferRecyclerPoolTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/io/BufferRecyclerPoolTest.java
@@ -45,7 +45,7 @@ public class BufferRecyclerPoolTest extends BaseTest
 
         if (checkPooledResource) {
             // acquire the pooled BufferRecycler again and check if it is the same instance used before
-            BufferRecycler pooledBufferRecycler = pool.acquireBufferRecycler();
+            BufferRecycler pooledBufferRecycler = pool.acquireAndLinkBufferRecycler();
             try {
                 assertSame(usedBufferRecycler, pooledBufferRecycler);
             } finally {
@@ -87,7 +87,7 @@ public class BufferRecyclerPoolTest extends BaseTest
         private BufferRecycler bufferRecycler;
 
         @Override
-        public BufferRecycler _internalAcquire() {
+        public BufferRecycler acquireBufferRecycler() {
             if (bufferRecycler != null) {
                 BufferRecycler tmp = bufferRecycler;
                 this.bufferRecycler = null;

--- a/src/test/java/com/fasterxml/jackson/core/io/BufferRecyclerPoolTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/io/BufferRecyclerPoolTest.java
@@ -82,7 +82,7 @@ public class BufferRecyclerPoolTest extends BaseTest
 
 
     @SuppressWarnings("serial")
-    class TestPool extends BufferRecyclerPool
+    class TestPool implements BufferRecyclerPool
     {
         private BufferRecycler bufferRecycler;
 


### PR DESCRIPTION
Trying to plug external pools from Quarkus I found that I made a terrible mistake so that external pools are never registered on the pooled `BufferRecycler` and then it never gets released to the pool. This pull request is intended to fix this bug.

@cowtowncoder @pjfanning Sorry about this, but please try to give it the highest possible priority. Let me know if you have any question.

/cc @franz1981