### PR TITLE
move pool reference from BufferRecycler to IOContext

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/JsonFactory.java
+++ b/src/main/java/com/fasterxml/jackson/core/JsonFactory.java
@@ -2184,7 +2184,7 @@ public class JsonFactory
             contentRef = ContentReference.unknown();
         }
         return new IOContext(_streamReadConstraints, _streamWriteConstraints, _errorReportConfiguration,
-                _getBufferRecycler(), contentRef, resourceManaged);
+                _getBufferRecycler(), _getBufferRecyclerPool(), contentRef, resourceManaged);
     }
 
     /**
@@ -2200,7 +2200,7 @@ public class JsonFactory
     @Deprecated // @since 2.13
     protected IOContext _createContext(Object rawContentRef, boolean resourceManaged) {
         return new IOContext(_streamReadConstraints, _streamWriteConstraints, _errorReportConfiguration,
-                _getBufferRecycler(),
+                _getBufferRecycler(), _getBufferRecyclerPool(),
                 _createContentReference(rawContentRef),
                 resourceManaged);
     }
@@ -2219,7 +2219,7 @@ public class JsonFactory
         // [jackson-core#479]: allow recycling for non-blocking parser again
         // now that access is thread-safe
         return new IOContext(_streamReadConstraints, _streamWriteConstraints, _errorReportConfiguration,
-                _getBufferRecycler(),
+                _getBufferRecycler(), _getBufferRecyclerPool(),
                 _createContentReference(srcRef),
                 false);
     }

--- a/src/main/java/com/fasterxml/jackson/core/JsonFactory.java
+++ b/src/main/java/com/fasterxml/jackson/core/JsonFactory.java
@@ -2141,25 +2141,12 @@ public class JsonFactory
      */
 
     /**
-     * Method used by factory to create buffer recycler instances
-     * for parsers and generators.
-     *<p>
-     * Note: only public to give access for {@code ObjectMapper}
-     *
-     * @return Buffer recycler instance to use
-     */
-    public BufferRecycler _getBufferRecycler()
-    {
-        return _getBufferRecyclerPool().acquireBufferRecycler();
-    }
-
-    /**
      * Accessor for getting access to {@link BufferRecyclerPool} for getting
      * {@link BufferRecycler} instance to use.
      *
      * @since 2.16
      */
-    public BufferRecyclerPool _getBufferRecyclerPool() {
+    private BufferRecyclerPool _getBufferRecyclerPool() {
         // 23-Apr-2015, tatu: Let's allow disabling of buffer recycling
         //   scheme, for cases where it is considered harmful (possibly
         //   on Android, for example)
@@ -2183,8 +2170,9 @@ public class JsonFactory
         if (contentRef == null) {
             contentRef = ContentReference.unknown();
         }
+        BufferRecyclerPool pool = _getBufferRecyclerPool();
         return new IOContext(_streamReadConstraints, _streamWriteConstraints, _errorReportConfiguration,
-                _getBufferRecycler(), _getBufferRecyclerPool(), contentRef, resourceManaged);
+                pool.acquireBufferRecycler(), pool, contentRef, resourceManaged);
     }
 
     /**
@@ -2199,8 +2187,9 @@ public class JsonFactory
      */
     @Deprecated // @since 2.13
     protected IOContext _createContext(Object rawContentRef, boolean resourceManaged) {
+        BufferRecyclerPool pool = _getBufferRecyclerPool();
         return new IOContext(_streamReadConstraints, _streamWriteConstraints, _errorReportConfiguration,
-                _getBufferRecycler(), _getBufferRecyclerPool(),
+                pool.acquireBufferRecycler(), pool,
                 _createContentReference(rawContentRef),
                 resourceManaged);
     }
@@ -2218,8 +2207,9 @@ public class JsonFactory
     protected IOContext _createNonBlockingContext(Object srcRef) {
         // [jackson-core#479]: allow recycling for non-blocking parser again
         // now that access is thread-safe
+        BufferRecyclerPool pool = _getBufferRecyclerPool();
         return new IOContext(_streamReadConstraints, _streamWriteConstraints, _errorReportConfiguration,
-                _getBufferRecycler(), _getBufferRecyclerPool(),
+                pool.acquireBufferRecycler(), pool,
                 _createContentReference(srcRef),
                 false);
     }

--- a/src/main/java/com/fasterxml/jackson/core/util/BufferRecycler.java
+++ b/src/main/java/com/fasterxml/jackson/core/util/BufferRecycler.java
@@ -86,8 +86,6 @@ public class BufferRecycler
     // Note: changed from simple array in 2.10:
     protected final AtomicReferenceArray<char[]> _charBuffers;
 
-    private BufferRecyclerPool _pool;
-
     /*
     /**********************************************************
     /* Construction
@@ -197,34 +195,11 @@ public class BufferRecycler
     protected char[] calloc(int size) { return new char[size]; }
 
     /**
-     * Method called by owner of this recycler instance, to provide reference to
-     * {@link BufferRecyclerPool} into which instance is to be released (if any)
+     * Method called when owner of this recycler no longer wishes use it.
      *
      * @since 2.16
      */
-    BufferRecycler withPool(BufferRecyclerPool pool) {
-        if (this._pool != null) {
-            throw new IllegalStateException("BufferRecycler already linked to pool: "+pool);
-        }
-        // assign to pool to which this BufferRecycler belongs in order to release it
-        // to the same pool when the work will be completed
-        _pool = Objects.requireNonNull(pool);
-        return this;
-    }
-
-    /**
-     * Method called when owner of this recycler no longer wishes use it; this should
-     * return it to pool passed via {@code withPool()} (if any).
-     *
-     * @since 2.16
-     */
-    public void release() {
-        if (_pool != null) {
-            BufferRecyclerPool tmpPool = _pool;
-            // nullify the reference to the pool in order to avoid the risk of releasing
-            // the same BufferRecycler more than once, thus compromising the pool integrity
-            _pool = null;
-            tmpPool.releaseBufferRecycler(this);
-        }
+    public void release(BufferRecyclerPool pool) {
+        pool.releaseBufferRecycler(this);
     }
 }

--- a/src/main/java/com/fasterxml/jackson/core/util/BufferRecyclerPool.java
+++ b/src/main/java/com/fasterxml/jackson/core/util/BufferRecyclerPool.java
@@ -266,7 +266,7 @@ public interface BufferRecyclerPool extends Serializable
             if (bufferRecycler == null) {
                 bufferRecycler = new BufferRecycler();
             }
-            return bufferRecycler.withPool(this);
+            return bufferRecycler;
         }
 
         @Override
@@ -333,7 +333,7 @@ public interface BufferRecyclerPool extends Serializable
 
         @Override
         public BufferRecycler acquireBufferRecycler() {
-            return _getRecycler().withPool(this);
+            return _getRecycler();
         }
 
         private BufferRecycler _getRecycler() {
@@ -448,7 +448,7 @@ public interface BufferRecyclerPool extends Serializable
             if (bufferRecycler == null) {
                 bufferRecycler = new BufferRecycler();
             }
-            return bufferRecycler.withPool(this);
+            return bufferRecycler;
         }
 
         @Override

--- a/src/test/java/com/fasterxml/jackson/core/io/TestIOContext.java
+++ b/src/test/java/com/fasterxml/jackson/core/io/TestIOContext.java
@@ -13,7 +13,7 @@ public class TestIOContext
         IOContext ctxt = new IOContext(StreamReadConstraints.defaults(),
                 StreamWriteConstraints.defaults(),
                 ErrorReportConfiguration.defaults(),
-                new BufferRecycler(),
+                new BufferRecycler(), null,
                 ContentReference.rawReference("N/A"), true);
 
         /* I/O Read buffer */

--- a/src/test/java/com/fasterxml/jackson/core/testsupport/TestSupport.java
+++ b/src/test/java/com/fasterxml/jackson/core/testsupport/TestSupport.java
@@ -45,6 +45,6 @@ public class TestSupport
             StreamWriteConstraints swc,
             ErrorReportConfiguration erc) {
         return new IOContext(src, swc, erc,
-                new BufferRecycler(), ContentReference.unknown(), false);
+                new BufferRecycler(), null, ContentReference.unknown(), false);
     }
 }

--- a/src/test/java/com/fasterxml/jackson/core/util/ReadConstrainedTextBufferTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/util/ReadConstrainedTextBufferTest.java
@@ -64,7 +64,7 @@ class ReadConstrainedTextBufferTest {
                 constraints,
                 StreamWriteConstraints.defaults(),
                 ErrorReportConfiguration.defaults(),
-                new BufferRecycler(),
+                new BufferRecycler(), null,
                 ContentReference.rawReference("N/A"), true);
     }
 }

--- a/src/test/java/com/fasterxml/jackson/core/write/WriterBasedJsonGeneratorTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/write/WriterBasedJsonGeneratorTest.java
@@ -49,7 +49,7 @@ public class WriterBasedJsonGeneratorTest extends BaseTest
         return new IOContext(StreamReadConstraints.defaults(),
                 swc,
                 ErrorReportConfiguration.defaults(),
-                new BufferRecycler(),
+                new BufferRecycler(), null,
                 ContentReference.unknown(), true);
     }
 }


### PR DESCRIPTION
This is an alternative solution for the problem reported and tentatively fixed [here](https://github.com/FasterXML/jackson-core/pull/1106). 

This time I moved the pool reference from the `BufferRecycler` to the `IOContext` instance. In this way I got rid of that `withPool` method and now it's `IOContext` responsibility to pass to the `BufferRecycler` the instance of the pool to which it has to be eventually released. 

This solution has the advantage of exposing a much cleaner API, but the drawback of moving the pool reference away from its own `BufferRecycler`. I think that this is fine as long as the `BufferRecycler` is always exclusively used by the `IOContext` and there aren't other classes that reference it either now or in future.

@cowtowncoder @pjfanning Please let me know if this solution is more acceptable than the one that I proposed yesterday (I believe so).