### PR TITLE
Call the right filterFinishArray/Object from FilteringParserDelegate

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/filter/FilteringParserDelegate.java
+++ b/src/main/java/com/fasterxml/jackson/core/filter/FilteringParserDelegate.java
@@ -403,7 +403,11 @@ public class FilteringParserDelegate extends JsonParserDelegate
                 boolean returnEnd = _headContext.isStartHandled();
                 f = _headContext.getFilter();
                 if ((f != null) && (f != TokenFilter.INCLUDE_ALL)) {
-                    f.filterFinishArray();
+                    if (t.id() == JsonTokenId.ID_END_ARRAY) {
+                        f.filterFinishArray();
+                    } else {
+                        f.filterFinishObject();
+                    }
                 }
                 _headContext = _headContext.getParent();
                 _itemFilter = _headContext.getFilter();


### PR DESCRIPTION
Hi,

While I was tackling https://groups.google.com/g/jackson-user/c/bLZTjjjXZ28 , I found that `filterFinishObject` is not called properly under some condition. `filterFinishArray` is called against `"}"` instead of `filterFinishObject`.

The first commit is a new test to confirm this behavior (the added test should fail before the second commit), and the second commit fixes the issue.

----

I created this pull request against `2.15` because https://github.com/FasterXML/jackson/blob/master/CONTRIBUTING.md says :

> Most bug-fix Pull Requests should be made against the current stable branch,

(but "the current stable branch" may be now `2.15`, not `2.14`?)

Please tell me if another branch should be the base.

----

I have not signed/sent the CLA yet. I'll do it in a couple of days.