### PR TITLE
Change parsing error message to mention `-INF`

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/base/ParserBase.java
+++ b/src/main/java/com/fasterxml/jackson/core/base/ParserBase.java
@@ -1410,7 +1410,7 @@ public abstract class ParserBase extends ParserMinimalBase
     @SuppressWarnings("deprecation")
     protected String _validJsonValueList() throws IOException {
         if (isEnabled(Feature.ALLOW_NON_NUMERIC_NUMBERS)) {
-            return "(JSON String, Number (or 'NaN'/'INF'/'+INF'), Array, Object or token 'null', 'true' or 'false')";
+            return "(JSON String, Number (or 'NaN'/'+INF'/'-INF'), Array, Object or token 'null', 'true' or 'false')";
         }
         return "(JSON String, Number, Array, Object or token 'null', 'true' or 'false')";
     }


### PR DESCRIPTION
-INF is allowed.

The code is unclear about whether 'INF' is allowed. '+INF' seems to be tested and seems to work but 'INF' seems to be documented but I'm not sure if it works.