### PR TITLE
Fix `JsonParser.isNaN()` to be stable, only indicate explicit NaN values; not ones due to coercion

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/JsonParser.java
+++ b/src/main/java/com/fasterxml/jackson/core/JsonParser.java
@@ -12,6 +12,7 @@ import java.util.Iterator;
 
 import com.fasterxml.jackson.core.async.NonBlockingInputFeeder;
 import com.fasterxml.jackson.core.exc.InputCoercionException;
+import com.fasterxml.jackson.core.json.JsonReadFeature;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.core.util.JacksonFeatureSet;
 import com.fasterxml.jackson.core.util.RequestPayload;
@@ -1397,16 +1398,21 @@ public abstract class JsonParser
     public boolean isExpectedNumberIntToken() { return currentToken() == JsonToken.VALUE_NUMBER_INT; }
 
     /**
-     * Access for checking whether current token is a numeric value token, but
-     * one that is of "not-a-number" (NaN) variety (including both "NaN" AND
-     * positive/negative infinity!): not supported by all formats,
-     * but often supported for {@link JsonToken#VALUE_NUMBER_FLOAT}.
-     * NOTE: roughly equivalent to calling <code>!Double.isFinite()</code>
-     * on value you would get from calling {@link #getDoubleValue()}.
+     * Access for checking whether current token is a special
+     * "not-a-number" (NaN) token (including both "NaN" AND
+     * positive/negative infinity!). These values are not supported by all formats:
+     * JSON, for example, only supports them if
+     * {@link JsonReadFeature#ALLOW_NON_NUMERIC_NUMBERS} is enabled.
+     *<p>
+     * NOTE: in case where numeric value is outside range of requested type --
+     * most notably {@link java.lang.Float} or {@link java.lang.Double} -- and
+     * decoding results effectively in a NaN value, this method DOES NOT return
+     * {@code true}: only explicit incoming markers do.
+     * This is because value could still be accessed as a valid {@link BigDecimal}.
      *
-     * @return {@code True} if the current token is of type {@link JsonToken#VALUE_NUMBER_FLOAT}
-     *   but represents a "Not a Number"; {@code false} for other tokens and regular
-     *   floating-point numbers
+     * @return {@code True} if the current token is reported as {@link JsonToken#VALUE_NUMBER_FLOAT}
+     *   and represents a "Not a Number" value; {@code false} for other tokens and regular
+     *   floating-point numbers.
      *
      * @throws IOException for low-level read issues, or
      *   {@link JsonParseException} for decoding problems

--- a/src/test/java/com/fasterxml/jackson/core/read/NonStandardNumberParsingTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/read/NonStandardNumberParsingTest.java
@@ -58,21 +58,25 @@ public class NonStandardNumberParsingTest
         }
     }
 
+    /**
+     * Test for checking that Overflow for Double value does not lead
+     * to bogus NaN information.
+     */
     public void testLargeDecimal() throws Exception {
-        final String value = "7976931348623157e309";
+        final String biggerThanDouble = "7976931348623157e309";
         for (int mode : ALL_MODES) {
-            try (JsonParser p = createParser(mode, " " + value + " ")) {
+            try (JsonParser p = createParser(mode, " " + biggerThanDouble + " ")) {
                 assertEquals(JsonToken.VALUE_NUMBER_FLOAT, p.nextToken());
-                assertEquals(new BigDecimal(value), p.getDecimalValue());
+                assertEquals(new BigDecimal(biggerThanDouble), p.getDecimalValue());
                 assertFalse(p.isNaN());
                 assertEquals(Double.POSITIVE_INFINITY, p.getValueAsDouble());
-                // PJF: we might want to fix the isNaN check to not be affected by us reading the value as a double
-                assertTrue(p.isNaN());
+                // 01-Dec-2023, tatu: [core#1137] NaN only from explicit value
+                assertFalse(p.isNaN());
             }
         }
     }
 
-    //JSON does not allow numbers to have f or d suffixes
+    // JSON does not allow numbers to have f or d suffixes
     public void testFloatMarker() throws Exception {
         for (int mode : ALL_MODES) {
             try (JsonParser p = createParser(mode, " -0.123f ")) {


### PR DESCRIPTION
First part of fixes related to problems with number Overflow/Underflow for `Double` leading to problems with `BigDecimal` access. Second part of solution will be #1149.