### PR TITLE
Allow configuring `DefaultPrettyPrinter` separators for empty Arrays and Objects

### DIFF
--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -415,3 +415,8 @@ Robert Elliot (@Mahoney)
   (2.17.0)
  * Reported #1168: `JsonPointer.append(JsonPointer.tail())` includes the original pointer
   (2.16.1)
+
+Guillaume Lecroc (@gulecroc)
+ * Contributed #1179: Allow configuring `DefaultPrettyPrinter` separators for empty
+   Arrays and Objects
+  (2.17.0)

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -22,6 +22,9 @@ a pure JSON library.
  (contributed by @pjfanning)
 #1169: `ArrayIndexOutOfBoundsException` for specific invalid content,
   with Reader-based parser
+#1179: Allow configuring `DefaultPrettyPrinter` separators for empty
+  Arrays and Objects
+ (contributed by Guillaume L)
 
 2.16.2 (not yet released)
 

--- a/src/main/java/com/fasterxml/jackson/core/util/DefaultPrettyPrinter.java
+++ b/src/main/java/com/fasterxml/jackson/core/util/DefaultPrettyPrinter.java
@@ -111,9 +111,19 @@ public class DefaultPrettyPrinter
     protected String _objectEntrySeparator;
 
     /**
+     * @since 2.17
+     */
+    protected String _objectEmptySeparator;
+
+    /**
      * @since 2.16
      */
     protected String _arrayValueSeparator;
+
+    /**
+     * @since 2.17
+     */
+    protected String _arrayEmptySeparator;
     
     /*
     /**********************************************************
@@ -167,7 +177,9 @@ public class DefaultPrettyPrinter
         _separators = base._separators;
         _objectFieldValueSeparatorWithSpaces = base._objectFieldValueSeparatorWithSpaces;
         _objectEntrySeparator = base._objectEntrySeparator;
+        _objectEmptySeparator = base._objectEmptySeparator;
         _arrayValueSeparator = base._arrayValueSeparator;
+        _arrayEmptySeparator = base._arrayEmptySeparator;
 
         _rootSeparator = rootSeparator;
     }
@@ -183,7 +195,9 @@ public class DefaultPrettyPrinter
         _objectFieldValueSeparatorWithSpaces = separators.getObjectFieldValueSpacing().apply(
                 separators.getObjectFieldValueSeparator());
         _objectEntrySeparator = separators.getObjectEntrySpacing().apply(separators.getObjectEntrySeparator());
+        _objectEmptySeparator = separators.getObjectEmptySeparator();
         _arrayValueSeparator = separators.getArrayValueSpacing().apply(separators.getArrayValueSeparator());
+        _arrayEmptySeparator = separators.getArrayEmptySeparator();
     }
     
     /**
@@ -202,7 +216,9 @@ public class DefaultPrettyPrinter
         _separators = base._separators;
         _objectFieldValueSeparatorWithSpaces = base._objectFieldValueSeparatorWithSpaces;
         _objectEntrySeparator = base._objectEntrySeparator;
+        _objectEmptySeparator = base._objectEmptySeparator;
         _arrayValueSeparator = base._arrayValueSeparator;
+        _arrayEmptySeparator = base._arrayEmptySeparator;
     }
 
     /**
@@ -328,7 +344,9 @@ public class DefaultPrettyPrinter
         result._objectFieldValueSeparatorWithSpaces = separators.getObjectFieldValueSpacing().apply(
                 separators.getObjectFieldValueSeparator());
         result._objectEntrySeparator = separators.getObjectEntrySpacing().apply(separators.getObjectEntrySeparator());
+        result._objectEmptySeparator = separators.getObjectEmptySeparator();
         result._arrayValueSeparator = separators.getArrayValueSpacing().apply(separators.getArrayValueSeparator());
+        result._arrayEmptySeparator = separators.getArrayEmptySeparator();
 
         return result;
     }
@@ -417,7 +435,7 @@ public class DefaultPrettyPrinter
         if (nrOfEntries > 0) {
             _objectIndenter.writeIndentation(g, _nesting);
         } else {
-            g.writeRaw(' ');
+            g.writeRaw(_objectEmptySeparator);
         }
         g.writeRaw('}');
     }
@@ -461,7 +479,7 @@ public class DefaultPrettyPrinter
         if (nrOfValues > 0) {
             _arrayIndenter.writeIndentation(g, _nesting);
         } else {
-            g.writeRaw(' ');
+            g.writeRaw(_arrayEmptySeparator);
         }
         g.writeRaw(']');
     }

--- a/src/main/java/com/fasterxml/jackson/core/util/DefaultPrettyPrinter.java
+++ b/src/main/java/com/fasterxml/jackson/core/util/DefaultPrettyPrinter.java
@@ -111,6 +111,8 @@ public class DefaultPrettyPrinter
     protected String _objectEntrySeparator;
 
     /**
+     * String to use for empty Object. One space by default : { }
+     * 
      * @since 2.17
      */
     protected String _objectEmptySeparator;
@@ -121,6 +123,8 @@ public class DefaultPrettyPrinter
     protected String _arrayValueSeparator;
 
     /**
+     * String to use for empty Array. One space by default : [ ]
+     * 
      * @since 2.17
      */
     protected String _arrayEmptySeparator;

--- a/src/main/java/com/fasterxml/jackson/core/util/DefaultPrettyPrinter.java
+++ b/src/main/java/com/fasterxml/jackson/core/util/DefaultPrettyPrinter.java
@@ -111,7 +111,8 @@ public class DefaultPrettyPrinter
     protected String _objectEntrySeparator;
 
     /**
-     * String to use for empty Object. One space by default : { }
+     * String to use in empty Object to separate start and end markers.
+     * Default is single space, resulting in output of {@code { }}.
      * 
      * @since 2.17
      */
@@ -123,7 +124,8 @@ public class DefaultPrettyPrinter
     protected String _arrayValueSeparator;
 
     /**
-     * String to use for empty Array. One space by default : [ ]
+     * String to use in empty Array to separate start and end markers.
+     * Default is single space, resulting in output of {@code [ ]}.
      * 
      * @since 2.17
      */
@@ -149,7 +151,7 @@ public class DefaultPrettyPrinter
      * @param rootSeparator String to use as root value separator
      * @deprecated in 2.16. Use the Separators API instead.
      */
-    @Deprecated
+    @Deprecated // since 2.16
     public DefaultPrettyPrinter(String rootSeparator) {
         this((rootSeparator == null) ? null : new SerializedString(rootSeparator));
     }
@@ -161,7 +163,7 @@ public class DefaultPrettyPrinter
      * @param rootSeparator String to use as root value separator
      * @deprecated in 2.16. Use the Separators API instead.
      */
-    @Deprecated
+    @Deprecated // since 2.16
     public DefaultPrettyPrinter(SerializableString rootSeparator) {
         this(DEFAULT_SEPARATORS.withRootSeparator(rootSeparator.getValue()));
     }
@@ -169,7 +171,7 @@ public class DefaultPrettyPrinter
     /**
      * @deprecated in 2.16. Use the Separators API instead.
      */
-    @Deprecated
+    @Deprecated // since 2.16
     public DefaultPrettyPrinter(DefaultPrettyPrinter base,
             SerializableString rootSeparator)
     {
@@ -228,7 +230,7 @@ public class DefaultPrettyPrinter
     /**
      * @deprecated in 2.16. Use the Separators API instead.
      */
-    @Deprecated
+    @Deprecated // since 2.16
     public DefaultPrettyPrinter withRootSeparator(SerializableString rootSeparator)
     {
         if (_rootSeparator == rootSeparator ||
@@ -248,7 +250,7 @@ public class DefaultPrettyPrinter
      * @since 2.6
      * @deprecated in 2.16. Use the Separators API instead.
      */
-    @Deprecated
+    @Deprecated // since 2.16
     public DefaultPrettyPrinter withRootSeparator(String rootSeparator) {
         return withRootSeparator((rootSeparator == null) ? null : new SerializedString(rootSeparator));
     }
@@ -298,7 +300,7 @@ public class DefaultPrettyPrinter
      * @since 2.3
      * @deprecated in 2.16. Use the Separators API instead.
      */
-    @Deprecated
+    @Deprecated // since 2.16
     public DefaultPrettyPrinter withSpacesInObjectEntries() {
         return _withSpaces(true);
     }
@@ -314,7 +316,7 @@ public class DefaultPrettyPrinter
      * @since 2.3
      * @deprecated in 2.16. Use the Separators API instead.
      */
-    @Deprecated
+    @Deprecated // since 2.16
     public DefaultPrettyPrinter withoutSpacesInObjectEntries() {
         return _withSpaces(false);
     }

--- a/src/main/java/com/fasterxml/jackson/core/util/Separators.java
+++ b/src/main/java/com/fasterxml/jackson/core/util/Separators.java
@@ -25,11 +25,15 @@ public class Separators implements Serializable
     public final static String DEFAULT_ROOT_VALUE_SEPARATOR = " ";
 
     /**
+     * String to use in empty Object. One space by default : { }
+     * 
      * @since 2.17
      */
     public final static String DEFAULT_OBJECT_EMPTY_SEPARATOR = " ";
 
     /**
+     * String to use in empty Array. One space by default : [ ]
+     * 
      * @since 2.17
      */
     public final static String DEFAULT_ARRAY_EMPTY_SEPARATOR = " ";

--- a/src/main/java/com/fasterxml/jackson/core/util/Separators.java
+++ b/src/main/java/com/fasterxml/jackson/core/util/Separators.java
@@ -86,6 +86,10 @@ public class Separators implements Serializable
         return new Separators();
     }
 
+    /**
+     * Constructor for creating an instance with default settings for all
+     * separators.
+     */
     public Separators() {
         this(':', ',', ',');
     }
@@ -112,7 +116,7 @@ public class Separators implements Serializable
      *
      * @deprecated Since 2.17 use new canonical constructor
      */
-    @Deprecated // since 2.16
+    @Deprecated // since 2.17
     public Separators(
             String rootSeparator,
             char objectFieldValueSeparator,
@@ -128,8 +132,9 @@ public class Separators implements Serializable
     }
 
     /**
-     * Create an instance with the specified separator characters and spaces around those characters.
-     * 
+     * Canonical constructor for creating an instance with the specified separator
+     * characters and spaces around those characters.
+     *
      * @since 2.17
      */
     public Separators(

--- a/src/main/java/com/fasterxml/jackson/core/util/Separators.java
+++ b/src/main/java/com/fasterxml/jackson/core/util/Separators.java
@@ -1,6 +1,7 @@
 package com.fasterxml.jackson.core.util;
 
 import java.io.Serializable;
+import java.util.Objects;
 
 /**
  * Value class used with some {@link com.fasterxml.jackson.core.PrettyPrinter}
@@ -22,6 +23,16 @@ public class Separators implements Serializable
      * @since 2.16
      */
     public final static String DEFAULT_ROOT_VALUE_SEPARATOR = " ";
+
+    /**
+     * @since 2.17
+     */
+    public final static String DEFAULT_OBJECT_EMPTY_SEPARATOR = " ";
+
+    /**
+     * @since 2.17
+     */
+    public final static String DEFAULT_ARRAY_EMPTY_SEPARATOR = " ";
 
     /**
      * Define the spacing around elements like commas and colons.
@@ -59,8 +70,10 @@ public class Separators implements Serializable
     private final Spacing objectFieldValueSpacing;
     private final char objectEntrySeparator;
     private final Spacing objectEntrySpacing;
+    private final String objectEmptySeparator;
     private final char arrayValueSeparator;
     private final Spacing arrayValueSpacing;
+    private final String arrayEmptySeparator;
     private final String rootSeparator;
 
     public static Separators createDefaultInstance() {
@@ -82,8 +95,8 @@ public class Separators implements Serializable
     ) {
         this(DEFAULT_ROOT_VALUE_SEPARATOR,
                 objectFieldValueSeparator, Spacing.BOTH,
-                objectEntrySeparator, Spacing.NONE,
-                arrayValueSeparator, Spacing.NONE);
+                objectEntrySeparator, Spacing.NONE, DEFAULT_OBJECT_EMPTY_SEPARATOR,
+                arrayValueSeparator, Spacing.NONE, DEFAULT_ARRAY_EMPTY_SEPARATOR);
     }
 
     /**
@@ -97,26 +110,30 @@ public class Separators implements Serializable
             Spacing objectFieldValueSpacing,
             char objectEntrySeparator,
             Spacing objectEntrySpacing,
+            String objectEmptySeparator,
             char arrayValueSeparator,
-            Spacing arrayValueSpacing
+            Spacing arrayValueSpacing,
+            String arrayEmptySeparator
     ) {
         this.rootSeparator = rootSeparator;
         this.objectFieldValueSeparator = objectFieldValueSeparator;
         this.objectFieldValueSpacing = objectFieldValueSpacing;
         this.objectEntrySeparator = objectEntrySeparator;
         this.objectEntrySpacing = objectEntrySpacing;
+        this.objectEmptySeparator = objectEmptySeparator;
         this.arrayValueSeparator = arrayValueSeparator;
         this.arrayValueSpacing = arrayValueSpacing;
+        this.arrayEmptySeparator = arrayEmptySeparator;
     }
 
     public Separators withRootSeparator(String sep) {
         return (rootSeparator.equals(sep)) ? this
-                : new Separators(sep, objectFieldValueSeparator, objectFieldValueSpacing, objectEntrySeparator, objectEntrySpacing, arrayValueSeparator, arrayValueSpacing);
+                : new Separators(sep, objectFieldValueSeparator, objectFieldValueSpacing, objectEntrySeparator, objectEntrySpacing, objectEmptySeparator, arrayValueSeparator, arrayValueSpacing, arrayEmptySeparator);
     }
     
     public Separators withObjectFieldValueSeparator(char sep) {
         return (objectFieldValueSeparator == sep) ? this
-                : new Separators(rootSeparator, sep, objectFieldValueSpacing, objectEntrySeparator, objectEntrySpacing, arrayValueSeparator, arrayValueSpacing);
+                : new Separators(rootSeparator, sep, objectFieldValueSpacing, objectEntrySeparator, objectEntrySpacing, objectEmptySeparator, arrayValueSeparator, arrayValueSpacing, arrayEmptySeparator);
     }
 
     /**
@@ -126,12 +143,12 @@ public class Separators implements Serializable
      */
     public Separators withObjectFieldValueSpacing(Spacing spacing) {
         return (objectFieldValueSpacing == spacing) ? this
-                : new Separators(rootSeparator, objectFieldValueSeparator, spacing, objectEntrySeparator, objectEntrySpacing, arrayValueSeparator, arrayValueSpacing);
+                : new Separators(rootSeparator, objectFieldValueSeparator, spacing, objectEntrySeparator, objectEntrySpacing, objectEmptySeparator, arrayValueSeparator, arrayValueSpacing, arrayEmptySeparator);
     }
     
     public Separators withObjectEntrySeparator(char sep) {
         return (objectEntrySeparator == sep) ? this
-                : new Separators(rootSeparator, objectFieldValueSeparator, objectFieldValueSpacing, sep, objectEntrySpacing, arrayValueSeparator, arrayValueSpacing);
+                : new Separators(rootSeparator, objectFieldValueSeparator, objectFieldValueSpacing, sep, objectEntrySpacing, objectEmptySeparator, arrayValueSeparator, arrayValueSpacing, arrayEmptySeparator);
     }
     
     /**
@@ -141,12 +158,22 @@ public class Separators implements Serializable
      */
     public Separators withObjectEntrySpacing(Spacing spacing) {
         return (objectEntrySpacing == spacing) ? this
-                : new Separators(rootSeparator, objectFieldValueSeparator, objectFieldValueSpacing, objectEntrySeparator, spacing, arrayValueSeparator, arrayValueSpacing);
+                : new Separators(rootSeparator, objectFieldValueSeparator, objectFieldValueSpacing, objectEntrySeparator, spacing, objectEmptySeparator, arrayValueSeparator, arrayValueSpacing, arrayEmptySeparator);
+    }
+
+    /**
+     * @return This instance (for call chaining)
+     *
+     * @since 2.17
+     */
+    public Separators withObjectEmptySeparator(String sep) {
+        return (Objects.equals(arrayEmptySeparator, sep)) ? this
+                : new Separators(rootSeparator, objectFieldValueSeparator, objectFieldValueSpacing, objectEntrySeparator, objectEntrySpacing, sep, arrayValueSeparator, arrayValueSpacing, arrayEmptySeparator);
     }
 
     public Separators withArrayValueSeparator(char sep) {
         return (arrayValueSeparator == sep) ? this
-                : new Separators(rootSeparator, objectFieldValueSeparator, objectFieldValueSpacing, objectEntrySeparator, objectEntrySpacing, sep, arrayValueSpacing);
+                : new Separators(rootSeparator, objectFieldValueSeparator, objectFieldValueSpacing, objectEntrySeparator, objectEntrySpacing, objectEmptySeparator, sep, arrayValueSpacing, arrayEmptySeparator);
     }
 
     /**
@@ -156,7 +183,17 @@ public class Separators implements Serializable
      */
     public Separators withArrayValueSpacing(Spacing spacing) {
         return (arrayValueSpacing == spacing) ? this
-                : new Separators(rootSeparator, objectFieldValueSeparator, objectFieldValueSpacing, objectEntrySeparator, objectEntrySpacing, arrayValueSeparator, spacing);
+                : new Separators(rootSeparator, objectFieldValueSeparator, objectFieldValueSpacing, objectEntrySeparator, objectEntrySpacing, objectEmptySeparator, arrayValueSeparator, spacing, arrayEmptySeparator);
+    }
+
+    /**
+     * @return This instance (for call chaining)
+     *
+     * @since 2.17
+     */
+    public Separators withArrayEmptySeparator(String sep) {
+        return (Objects.equals(arrayEmptySeparator, sep)) ? this
+                : new Separators(rootSeparator, objectFieldValueSeparator, objectFieldValueSpacing, objectEntrySeparator, objectEntrySpacing, objectEmptySeparator, arrayValueSeparator, arrayValueSpacing, sep);
     }
 
     /**
@@ -193,6 +230,15 @@ public class Separators implements Serializable
     public Spacing getObjectEntrySpacing() {
         return objectEntrySpacing;
     }
+
+    /**
+     * @return String to use in empty Object
+     * 
+     * @since 2.17
+     */
+    public String getObjectEmptySeparator() {
+        return objectEmptySeparator;
+    }
     
     public char getArrayValueSeparator() {
         return arrayValueSeparator;
@@ -205,5 +251,14 @@ public class Separators implements Serializable
      */
     public Spacing getArrayValueSpacing() {
         return arrayValueSpacing;
+    }
+
+    /**
+     * @return String to use in empty Array
+     * 
+     * @since 2.17
+     */
+    public String getArrayEmptySeparator() {
+        return arrayEmptySeparator;
     }
 }

--- a/src/main/java/com/fasterxml/jackson/core/util/Separators.java
+++ b/src/main/java/com/fasterxml/jackson/core/util/Separators.java
@@ -25,14 +25,16 @@ public class Separators implements Serializable
     public final static String DEFAULT_ROOT_VALUE_SEPARATOR = " ";
 
     /**
-     * String to use in empty Object. One space by default : { }
+     * String to use in empty Object to separate start and end markers.
+     * Default is single space, resulting in output of {@code { }}.
      * 
      * @since 2.17
      */
     public final static String DEFAULT_OBJECT_EMPTY_SEPARATOR = " ";
 
     /**
-     * String to use in empty Array. One space by default : [ ]
+     * String to use in empty Array to separate start and end markers.
+     * Default is single space, resulting in output of {@code [ ]}.
      * 
      * @since 2.17
      */
@@ -107,6 +109,28 @@ public class Separators implements Serializable
      * Create an instance with the specified separator characters and spaces around those characters.
      * 
      * @since 2.16
+     *
+     * @deprecated Since 2.17 use new canonical constructor
+     */
+    @Deprecated // since 2.16
+    public Separators(
+            String rootSeparator,
+            char objectFieldValueSeparator,
+            Spacing objectFieldValueSpacing,
+            char objectEntrySeparator,
+            Spacing objectEntrySpacing,
+            char arrayValueSeparator,
+            Spacing arrayValueSpacing
+    ) {
+        this(rootSeparator, objectFieldValueSeparator, objectFieldValueSpacing,
+                objectEntrySeparator, objectEntrySpacing, DEFAULT_OBJECT_EMPTY_SEPARATOR,
+                arrayValueSeparator, arrayValueSpacing, DEFAULT_ARRAY_EMPTY_SEPARATOR);
+    }
+
+    /**
+     * Create an instance with the specified separator characters and spaces around those characters.
+     * 
+     * @since 2.17
      */
     public Separators(
             String rootSeparator,
@@ -171,7 +195,7 @@ public class Separators implements Serializable
      * @since 2.17
      */
     public Separators withObjectEmptySeparator(String sep) {
-        return (Objects.equals(arrayEmptySeparator, sep)) ? this
+        return Objects.equals(arrayEmptySeparator, sep) ? this
                 : new Separators(rootSeparator, objectFieldValueSeparator, objectFieldValueSpacing, objectEntrySeparator, objectEntrySpacing, sep, arrayValueSeparator, arrayValueSpacing, arrayEmptySeparator);
     }
 
@@ -196,7 +220,7 @@ public class Separators implements Serializable
      * @since 2.17
      */
     public Separators withArrayEmptySeparator(String sep) {
-        return (Objects.equals(arrayEmptySeparator, sep)) ? this
+        return Objects.equals(arrayEmptySeparator, sep) ? this
                 : new Separators(rootSeparator, objectFieldValueSeparator, objectFieldValueSpacing, objectEntrySeparator, objectEntrySpacing, objectEmptySeparator, arrayValueSeparator, arrayValueSpacing, sep);
     }
 

--- a/src/test/java/com/fasterxml/jackson/core/util/TestDefaultPrettyPrinter.java
+++ b/src/test/java/com/fasterxml/jackson/core/util/TestDefaultPrettyPrinter.java
@@ -233,6 +233,92 @@ public class TestDefaultPrettyPrinter extends BaseTest
         assertEquals("1[2]{\"a\":3}", _printTestData(pp, false, writeTestData));
     }
 
+    public void testObjectEmptySeparatorDefault() throws IOException
+    {
+        Separators separators = new Separators()
+            .withRootSeparator(null)
+            .withObjectFieldValueSpacing(Spacing.NONE);
+        DefaultPrettyPrinter pp = new DefaultPrettyPrinter()
+                .withSeparators(separators)
+                .withArrayIndenter(null)
+                .withObjectIndenter(null);
+
+        ThrowingConsumer<JsonGenerator> writeTestData = gen -> {
+            gen.writeStartObject();
+            gen.writeFieldName("objectEmptySeparatorDefault");
+            gen.writeStartObject();
+            gen.writeEndObject();
+            gen.writeEndObject();
+        };
+        
+        assertEquals("{\"objectEmptySeparatorDefault\":{ }}", _printTestData(pp, false, writeTestData));
+    }
+
+    public void testObjectEmptySeparatorCustom() throws IOException
+    {
+        Separators separators = new Separators()
+            .withRootSeparator(null)
+            .withObjectFieldValueSpacing(Spacing.NONE)
+            .withObjectEmptySeparator("    ");
+        DefaultPrettyPrinter pp = new DefaultPrettyPrinter()
+                .withSeparators(separators)
+                .withArrayIndenter(null)
+                .withObjectIndenter(null);
+
+        ThrowingConsumer<JsonGenerator> writeTestData = gen -> {
+            gen.writeStartObject();
+            gen.writeFieldName("objectEmptySeparatorCustom");
+            gen.writeStartObject();
+            gen.writeEndObject();
+            gen.writeEndObject();
+        };
+        
+        assertEquals("{\"objectEmptySeparatorCustom\":{    }}", _printTestData(pp, false, writeTestData));
+    }
+
+    public void testArrayEmptySeparatorDefault() throws IOException
+    {
+        Separators separators = new Separators()
+            .withRootSeparator(null)
+            .withObjectFieldValueSpacing(Spacing.NONE);
+        DefaultPrettyPrinter pp = new DefaultPrettyPrinter()
+                .withSeparators(separators)
+                .withArrayIndenter(null)
+                .withObjectIndenter(null);
+
+        ThrowingConsumer<JsonGenerator> writeTestData = gen -> {
+            gen.writeStartObject();
+            gen.writeFieldName("arrayEmptySeparatorDefault");
+            gen.writeStartArray();
+            gen.writeEndArray();
+            gen.writeEndObject();
+        };
+        
+        assertEquals("{\"arrayEmptySeparatorDefault\":[ ]}", _printTestData(pp, false, writeTestData));
+    }
+
+    public void testArrayEmptySeparatorCustom() throws IOException
+    {
+        Separators separators = new Separators()
+            .withRootSeparator(null)
+            .withObjectFieldValueSpacing(Spacing.NONE)
+            .withArrayEmptySeparator("    ");
+        DefaultPrettyPrinter pp = new DefaultPrettyPrinter()
+                .withSeparators(separators)
+                .withArrayIndenter(null)
+                .withObjectIndenter(null);
+
+        ThrowingConsumer<JsonGenerator> writeTestData = gen -> {
+            gen.writeStartObject();
+            gen.writeFieldName("arrayEmptySeparatorCustom");
+            gen.writeStartArray();
+            gen.writeEndArray();
+            gen.writeEndObject();
+        };
+        
+        assertEquals("{\"arrayEmptySeparatorCustom\":[    ]}", _printTestData(pp, false, writeTestData));
+    }
+
     private String _printTestData(PrettyPrinter pp, boolean useBytes) throws IOException
     {
         return _printTestData(pp, useBytes, gen -> {


### PR DESCRIPTION
Fix for https://github.com/FasterXML/jackson-core/issues/1128