### PR TITLE
reuse in IOContext the BufferRecycler already contained in the ContentReference if any

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/JsonFactory.java
+++ b/src/main/java/com/fasterxml/jackson/core/JsonFactory.java
@@ -2185,8 +2185,12 @@ public class JsonFactory
         if (contentRef == null) {
             contentRef = ContentReference.unknown();
         }
+
+        BufferRecycler br = contentRef.getBufferRecycler();
+        boolean externalBufferRecycler = br != null;
         return new IOContext(_streamReadConstraints, _streamWriteConstraints, _errorReportConfiguration,
-                _getBufferRecycler(), contentRef, resourceManaged);
+                externalBufferRecycler ? br : _getBufferRecycler(), contentRef, resourceManaged)
+                .withExternalBufferRecycler(externalBufferRecycler);
     }
 
     /**

--- a/src/main/java/com/fasterxml/jackson/core/io/ContentReference.java
+++ b/src/main/java/com/fasterxml/jackson/core/io/ContentReference.java
@@ -7,6 +7,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 
 import com.fasterxml.jackson.core.ErrorReportConfiguration;
+import com.fasterxml.jackson.core.util.BufferRecycler;
+import com.fasterxml.jackson.core.util.BufferRecyclerOwner;
 
 /**
  * Abstraction that encloses information about content being processed --
@@ -20,7 +22,7 @@ import com.fasterxml.jackson.core.ErrorReportConfiguration;
  */
 public class ContentReference
     // sort of: we will read back as "UNKNOWN"
-    implements java.io.Serializable
+    implements java.io.Serializable, BufferRecyclerOwner
 {
     private static final long serialVersionUID = 1L;
 
@@ -481,5 +483,12 @@ public class ContentReference
     @Override
     public int hashCode() {
         return Objects.hashCode(_rawContent);
+    }
+
+    @Override
+    public BufferRecycler getBufferRecycler() {
+        return _rawContent instanceof BufferRecyclerOwner
+                ? ((BufferRecyclerOwner) _rawContent).getBufferRecycler()
+                : null;
     }
 }

--- a/src/main/java/com/fasterxml/jackson/core/io/IOContext.java
+++ b/src/main/java/com/fasterxml/jackson/core/io/IOContext.java
@@ -121,6 +121,8 @@ public class IOContext implements AutoCloseable
 
     private boolean _closed = false;
 
+    private boolean ownBufferRecycler = true;
+
     /*
     /**********************************************************************
     /* Life-cycle
@@ -464,8 +466,15 @@ public class IOContext implements AutoCloseable
     @Override
     public void close() {
         if (!_closed) {
-            _bufferRecycler.releaseToPool();
+            if (ownBufferRecycler) {
+                _bufferRecycler.releaseToPool();
+            }
             _closed = true;
         }
+    }
+
+    public IOContext withExternalBufferRecycler(boolean externalBufferRecycler) {
+        this.ownBufferRecycler = !externalBufferRecycler;
+        return this;
     }
 }

--- a/src/main/java/com/fasterxml/jackson/core/io/SegmentedStringWriter.java
+++ b/src/main/java/com/fasterxml/jackson/core/io/SegmentedStringWriter.java
@@ -3,6 +3,7 @@ package com.fasterxml.jackson.core.io;
 import java.io.*;
 
 import com.fasterxml.jackson.core.util.BufferRecycler;
+import com.fasterxml.jackson.core.util.BufferRecyclerOwner;
 import com.fasterxml.jackson.core.util.TextBuffer;
 
 /**
@@ -13,7 +14,7 @@ import com.fasterxml.jackson.core.util.TextBuffer;
  * if so, instance of this class can be given as the writer to
  * <code>JsonGenerator</code>.
  */
-public final class SegmentedStringWriter extends Writer {
+public final class SegmentedStringWriter extends Writer implements BufferRecyclerOwner {
     final private TextBuffer _buffer;
 
     public SegmentedStringWriter(BufferRecycler br) {
@@ -48,10 +49,12 @@ public final class SegmentedStringWriter extends Writer {
     }
 
     @Override
-    public void close() { } // NOP
+    public void flush() { } // NOP
 
     @Override
-    public void flush() { } // NOP
+    public void close() throws IOException {
+        BufferRecyclerOwner.super.close();
+    }
 
     @Override
     public void write(char[] cbuf) throws IOException {
@@ -76,6 +79,11 @@ public final class SegmentedStringWriter extends Writer {
     @Override
     public void write(String str, int off, int len) throws IOException {
         _buffer.append(str, off, len);
+    }
+
+    @Override
+    public BufferRecycler getBufferRecycler() {
+        return _buffer.getBufferRecycler();
     }
 
     /*

--- a/src/main/java/com/fasterxml/jackson/core/util/BufferRecyclerOwner.java
+++ b/src/main/java/com/fasterxml/jackson/core/util/BufferRecyclerOwner.java
@@ -1,0 +1,16 @@
+package com.fasterxml.jackson.core.util;
+
+import java.io.IOException;
+
+public interface BufferRecyclerOwner extends AutoCloseable {
+
+    BufferRecycler getBufferRecycler();
+
+    @Override
+    default void close() throws IOException {
+        BufferRecycler br = getBufferRecycler();
+        if (br != null) {
+            br.releaseToPool();
+        }
+    }
+}

--- a/src/main/java/com/fasterxml/jackson/core/util/ByteArrayBuilder.java
+++ b/src/main/java/com/fasterxml/jackson/core/util/ByteArrayBuilder.java
@@ -26,7 +26,7 @@ import java.util.*;
  * theoretically this builder can aggregate more content it will not be usable
  * as things are. Behavior may be improved if we solve the access problem.
  */
-public final class ByteArrayBuilder extends OutputStream
+public final class ByteArrayBuilder extends OutputStream implements BufferRecyclerOwner
 {
     public final static byte[] NO_BYTES = new byte[0];
 
@@ -79,6 +79,11 @@ public final class ByteArrayBuilder extends OutputStream
         if (!_pastBlocks.isEmpty()) {
             _pastBlocks.clear();
         }
+    }
+
+    @Override
+    public BufferRecycler getBufferRecycler() {
+        return _bufferRecycler;
     }
 
     /**
@@ -260,7 +265,6 @@ public final class ByteArrayBuilder extends OutputStream
         append(b);
     }
 
-    @Override public void close() { /* NOP */ }
     @Override public void flush() { /* NOP */ }
 
     /*

--- a/src/main/java/com/fasterxml/jackson/core/util/TextBuffer.java
+++ b/src/main/java/com/fasterxml/jackson/core/util/TextBuffer.java
@@ -25,7 +25,7 @@ import com.fasterxml.jackson.core.io.NumberInput;
  *    </li>
  * </ul>
  */
-public class TextBuffer
+public class TextBuffer implements BufferRecyclerOwner
 {
     final static char[] NO_CHARS = new char[0];
 
@@ -131,6 +131,11 @@ public class TextBuffer
         _currentSegment = initialSegment;
         _currentSize = initialSegment.length;
         _inputStart = -1;
+    }
+
+    @Override
+    public BufferRecycler getBufferRecycler() {
+        return _allocator;
     }
 
     /**


### PR DESCRIPTION
This is a tentative fix for the issue reported in https://github.com/FasterXML/jackson-databind/issues/4321

It tries to reuse the `BufferRecycler` already contained in the `ContentReference` (if any) also in the `IOContext`, instead of asking a new one from the pool regardless. In this case the `IOContext` is flagged for not being the owner of the `BufferRecycler`, so it won't attempt to mistakenly put it back into the pool when closed.