### PR TITLE
Faster division by 1000

### DIFF
--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -426,3 +426,7 @@ Guillaume Lecroc (@gulecroc)
  * Contributed #1179: Allow configuring `DefaultPrettyPrinter` separators for empty
    Arrays and Objects
   (2.17.0)
+
+Antonin Janec (@xtonic)
+ * Contributed #1203: Faster division by 1000
+  (2.17.0)

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -35,6 +35,8 @@ a pure JSON library.
  (suggested by @kkkkkhhhh)
 #1195: Use `BufferRecycler` provided by output (`OutputStream`, `Writer`) object if available
  (contributed by Mario F)
+#1203: Faster division by 1000
+ (contributed by @xtonik)
 
 2.16.2 (not yet released)
 

--- a/src/main/java/com/fasterxml/jackson/core/io/NumberOutput.java
+++ b/src/main/java/com/fasterxml/jackson/core/io/NumberOutput.java
@@ -245,6 +245,12 @@ public final class NumberOutput
         return _outputFullBillion((int) v, b, off);
     }
 
+    /**
+     * Optimized code for integer division by 1000; typically 50% higher
+     * throughput for calculation
+     *
+     * @since 2.17
+     */
     static int divBy1000(int number) {
         return (int) (number * 274_877_907L >>> 38);
     }

--- a/src/main/java/com/fasterxml/jackson/core/io/NumberOutput.java
+++ b/src/main/java/com/fasterxml/jackson/core/io/NumberOutput.java
@@ -246,7 +246,7 @@ public final class NumberOutput
     }
 
     static int divBy1000(int number) {
-        return (int) (number * 274877907L >>> 38);
+        return (int) (number * 274_877_907L >>> 38);
     }
 
     /*

--- a/src/main/java/com/fasterxml/jackson/core/io/NumberOutput.java
+++ b/src/main/java/com/fasterxml/jackson/core/io/NumberOutput.java
@@ -85,7 +85,7 @@ public final class NumberOutput
                 }
                 return _leading3(v, b, off);
             }
-            int thousands = v / 1000;
+            int thousands = divBy1000(v);
             v -= (thousands * 1000); // == value % 1000
             off = _leading3(thousands, b, off);
             off = _full3(v, b, off);
@@ -107,10 +107,10 @@ public final class NumberOutput
             }
             return _outputFullBillion(v, b, off);
         }
-        int newValue = v / 1000;
+        int newValue = divBy1000(v);
         int ones = (v - (newValue * 1000)); // == value % 1000
         v = newValue;
-        newValue /= 1000;
+        newValue = divBy1000(newValue);
         int thousands = (v - (newValue * 1000));
 
         off = _leading3(newValue, b, off);
@@ -136,7 +136,7 @@ public final class NumberOutput
                     off = _leading3(v, b, off);
                 }
             } else {
-                int thousands = v / 1000;
+                int thousands = divBy1000(v);
                 v -= (thousands * 1000); // == value % 1000
                 off = _leading3(thousands, b, off);
                 off = _full3(v, b, off);
@@ -153,10 +153,10 @@ public final class NumberOutput
             }
             return _outputFullBillion(v, b, off);
         }
-        int newValue = v / 1000;
+        int newValue = divBy1000(v);
         int ones = (v - (newValue * 1000)); // == value % 1000
         v = newValue;
-        newValue /= 1000;
+        newValue = divBy1000(newValue);
         int thousands = (v - (newValue * 1000));
         off = _leading3(newValue, b, off);
         off = _full3(thousands, b, off);
@@ -243,6 +243,10 @@ public final class NumberOutput
             off = _outputFullBillion((int) upper, b, off);
         }
         return _outputFullBillion((int) v, b, off);
+    }
+
+    static int divBy1000(int number) {
+        return (int) (number * 274877907L >>> 38);
     }
 
     /*
@@ -359,13 +363,13 @@ public final class NumberOutput
             if (v < 1000) {
                 return _leading3(v, b, off);
             }
-            int thousands = v / 1000;
+            int thousands = divBy1000(v);
             int ones = v - (thousands * 1000); // == value % 1000
             return _outputUptoMillion(b, off, thousands, ones);
         }
-        int thousands = v / 1000;
+        int thousands = divBy1000(v);
         int ones = (v - (thousands * 1000)); // == value % 1000
-        int millions = thousands / 1000;
+        int millions = divBy1000(thousands);
         thousands -= (millions * 1000);
 
         off = _leading3(millions, b, off);
@@ -385,9 +389,9 @@ public final class NumberOutput
 
     private static int _outputFullBillion(int v, char[] b, int off)
     {
-        int thousands = v / 1000;
+        int thousands = divBy1000(v);
         int ones = (v - (thousands * 1000)); // == value % 1000
-        int millions = thousands / 1000;
+        int millions = divBy1000(thousands);
 
         int enc = TRIPLET_TO_CHARS[millions];
         b[off++] = (char) (enc >> 16);
@@ -414,13 +418,13 @@ public final class NumberOutput
             if (v < 1000) {
                 return _leading3(v, b, off);
             }
-            int thousands = v / 1000;
+            int thousands = divBy1000(v);
             int ones = v - (thousands * 1000); // == value % 1000
             return _outputUptoMillion(b, off, thousands, ones);
         }
-        int thousands = v / 1000;
+        int thousands = divBy1000(v);
         int ones = (v - (thousands * 1000)); // == value % 1000
-        int millions = thousands / 1000;
+        int millions = divBy1000(thousands);
         thousands -= (millions * 1000);
 
         off = _leading3(millions, b, off);
@@ -440,9 +444,9 @@ public final class NumberOutput
 
     private static int _outputFullBillion(int v, byte[] b, int off)
     {
-        int thousands = v / 1000;
+        int thousands = divBy1000(v);
         int ones = (v - (thousands * 1000)); // == value % 1000
-        int millions = thousands / 1000;
+        int millions = divBy1000(thousands);
         thousands -= (millions * 1000);
 
         int enc = TRIPLET_TO_CHARS[millions];

--- a/src/main/java/com/fasterxml/jackson/core/sym/ByteQuadsCanonicalizer.java
+++ b/src/main/java/com/fasterxml/jackson/core/sym/ByteQuadsCanonicalizer.java
@@ -1096,6 +1096,7 @@ public final class ByteQuadsCanonicalizer
         return offset;
     }
 
+    // @since 2.17
     static int multiplyByFourFifths(int number) {
         return (int) (number * 3_435_973_837L >>> 32);
     }
@@ -1106,7 +1107,7 @@ public final class ByteQuadsCanonicalizer
         if (_count > (_hashSize >> 1)) { // over 50%
             int spillCount = (_spilloverEnd - _spilloverStart()) >> 2;
             if ((spillCount > (1 + _count >> 7))
-                    || (_count > (multiplyByFourFifths(_hashSize)))) {
+                    || (_count > multiplyByFourFifths(_hashSize))) {
                 return true;
             }
         }

--- a/src/main/java/com/fasterxml/jackson/core/sym/ByteQuadsCanonicalizer.java
+++ b/src/main/java/com/fasterxml/jackson/core/sym/ByteQuadsCanonicalizer.java
@@ -1096,13 +1096,17 @@ public final class ByteQuadsCanonicalizer
         return offset;
     }
 
+    static int multiplyByFourFifths(int number) {
+        return (int) (number * 1_717_986_919L >>> 33);
+    }
+
     // Helper method for checking if we should simply rehash() before add
     private boolean _checkNeedForRehash() {
         // Yes if above 80%, or above 50% AND have ~1% spill-overs
         if (_count > (_hashSize >> 1)) { // over 50%
             int spillCount = (_spilloverEnd - _spilloverStart()) >> 2;
             if ((spillCount > (1 + _count >> 7))
-                    || (_count > (_hashSize * 0.80))) {
+                    || (_count > (multiplyByFourFifths(_hashSize)))) {
                 return true;
             }
         }

--- a/src/main/java/com/fasterxml/jackson/core/sym/ByteQuadsCanonicalizer.java
+++ b/src/main/java/com/fasterxml/jackson/core/sym/ByteQuadsCanonicalizer.java
@@ -1097,7 +1097,7 @@ public final class ByteQuadsCanonicalizer
     }
 
     static int multiplyByFourFifths(int number) {
-        return (int) (number * 1_717_986_919L >>> 33);
+        return (int) (number * 3_435_973_837L >>> 32);
     }
 
     // Helper method for checking if we should simply rehash() before add

--- a/src/test/java/com/fasterxml/jackson/core/io/NumberOutputTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/io/NumberOutputTest.java
@@ -1,0 +1,16 @@
+package com.fasterxml.jackson.core.io;
+
+import com.fasterxml.jackson.core.BaseTest;
+import org.junit.Ignore;
+
+public class NumberOutputTest extends BaseTest {
+    @Ignore
+    public void testDivBy1000() {
+        for (long i = 0; i <= Integer.MAX_VALUE; i++) {
+            int number = (int) i;
+            int expected = number / 1000;
+            int actual = NumberOutput.divBy1000(number);
+            assertEquals(expected, actual, number);
+        }
+    }
+}

--- a/src/test/java/com/fasterxml/jackson/core/io/NumberOutputTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/io/NumberOutputTest.java
@@ -5,13 +5,39 @@ import org.junit.Test;
 
 import static org.junit.Assert.fail;
 
-public class NumberOutputTest {
+public class NumberOutputTest
+{
+    @Test
+    public void testDivBy1000Small()
+    {
+        for (int number = 0; number <= 999_999; ++number) {
+            int expected = number / 1000;
+            int actual = NumberOutput.divBy1000(number);
+            if (expected != actual) { // only construct String if fail
+                fail("With "+number+" should get "+expected+", got: "+actual);
+            }
+        }
+    }
+
+    @Test
+    public void testDivBy1000Sampled()
+    {
+        for (int number = 1_000_000; number > 0; number += 7) {
+            int expected = number / 1000;
+            int actual = NumberOutput.divBy1000(number);
+            if (expected != actual) { // only construct String if fail
+                fail("With "+number+" should get "+expected+", got: "+actual);
+            }
+        }
+    }
+
+    // And then full range, not included in CI since code shouldn't change;
+    // but has been run to verify full range manually
     @Test
     // Comment out for manual testing:
     @Ignore
-    public void testDivBy1000() {
-        for (int i = 0; i <= Integer.MAX_VALUE; i++) {
-            int number = (int) i;
+    public void testDivBy1000FullRange() {
+        for (int number = 0; number <= Integer.MAX_VALUE; ++number) {
             int expected = number / 1000;
             int actual = NumberOutput.divBy1000(number);
             if (expected != actual) { // only construct String if fail

--- a/src/test/java/com/fasterxml/jackson/core/io/NumberOutputTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/io/NumberOutputTest.java
@@ -1,9 +1,9 @@
 package com.fasterxml.jackson.core.io;
 
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class NumberOutputTest
 {
@@ -35,7 +35,7 @@ public class NumberOutputTest
     // but has been run to verify full range manually
     @Test
     // Comment out for manual testing:
-    @Ignore
+    @Disabled
     public void testDivBy1000FullRange() {
         for (int number = 0; number <= Integer.MAX_VALUE; ++number) {
             int expected = number / 1000;

--- a/src/test/java/com/fasterxml/jackson/core/io/NumberOutputTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/io/NumberOutputTest.java
@@ -3,17 +3,20 @@ package com.fasterxml.jackson.core.io;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 public class NumberOutputTest {
     @Test
+    // Comment out for manual testing:
     @Ignore
     public void testDivBy1000() {
-        for (long i = 0; i <= Integer.MAX_VALUE; i++) {
+        for (int i = 0; i <= Integer.MAX_VALUE; i++) {
             int number = (int) i;
             int expected = number / 1000;
             int actual = NumberOutput.divBy1000(number);
-            assertEquals("input=" + number, expected, actual);
+            if (expected != actual) { // only construct String if fail
+                fail("With "+number+" should get "+expected+", got: "+actual);
+            }
         }
     }
 }

--- a/src/test/java/com/fasterxml/jackson/core/io/NumberOutputTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/io/NumberOutputTest.java
@@ -1,16 +1,19 @@
 package com.fasterxml.jackson.core.io;
 
-import com.fasterxml.jackson.core.BaseTest;
 import org.junit.Ignore;
+import org.junit.Test;
 
-public class NumberOutputTest extends BaseTest {
+import static org.junit.Assert.assertEquals;
+
+public class NumberOutputTest {
+    @Test
     @Ignore
     public void testDivBy1000() {
         for (long i = 0; i <= Integer.MAX_VALUE; i++) {
             int number = (int) i;
             int expected = number / 1000;
             int actual = NumberOutput.divBy1000(number);
-            assertEquals(expected, actual, number);
+            assertEquals("input=" + number, expected, actual);
         }
     }
 }

--- a/src/test/java/com/fasterxml/jackson/core/sym/ByteQuadsCanonicalizerTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/sym/ByteQuadsCanonicalizerTest.java
@@ -1,0 +1,16 @@
+package com.fasterxml.jackson.core.sym;
+
+import com.fasterxml.jackson.core.BaseTest;
+import org.junit.Ignore;
+
+public class ByteQuadsCanonicalizerTest extends BaseTest {
+    @Ignore
+    public void testMultiplyByFourFifths() {
+        for (long i = 0; i <= Integer.MAX_VALUE; i++) {
+            int number = (int) i;
+            int expected = (int) (number * 0.80);
+            int actual = ByteQuadsCanonicalizer.multiplyByFourFifths(number);
+            assertEquals(expected, actual, number);
+        }
+    }
+}

--- a/src/test/java/com/fasterxml/jackson/core/sym/ByteQuadsCanonicalizerTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/sym/ByteQuadsCanonicalizerTest.java
@@ -1,16 +1,19 @@
 package com.fasterxml.jackson.core.sym;
 
-import com.fasterxml.jackson.core.BaseTest;
 import org.junit.Ignore;
+import org.junit.Test;
 
-public class ByteQuadsCanonicalizerTest extends BaseTest {
+import static org.junit.Assert.assertEquals;
+
+public class ByteQuadsCanonicalizerTest {
+    @Test
     @Ignore
     public void testMultiplyByFourFifths() {
         for (long i = 0; i <= Integer.MAX_VALUE; i++) {
             int number = (int) i;
             int expected = (int) (number * 0.80);
             int actual = ByteQuadsCanonicalizer.multiplyByFourFifths(number);
-            assertEquals(expected, actual, number);
+            assertEquals("input=" + number, expected, actual);
         }
     }
 }


### PR DESCRIPTION
**Division by 1000** was replaced with more performant custom method using multiply and add. I suppose that this tiny method will be inlined, otherwise the code must be copied to places where is called.

Another similar simple optimization was also done - **multiplication of int by constant `0.80`** in integer (exactly in `long`) domain.

The validity is **verified by attached tests**. They are provided as a comparison to original implementation and thus they don't need to be executed again and again, so they are marked as a ignored not to cause running tests slowly - on my PC they take around 10 s.

**No behavior changes were done, performance improvement only.**