### PR TITLE
use the sharedLockFreePool as default pool instead of allocating a new one

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/util/JsonRecyclerPools.java
+++ b/src/main/java/com/fasterxml/jackson/core/util/JsonRecyclerPools.java
@@ -20,13 +20,13 @@ public final class JsonRecyclerPools
     /**
      * Method to call to get the default recycler pool instance:
      * as of Jackson 2.17 this is same as calling
-     * {@link #newLockFreePool()}; earlier 
+     * {@link #sharedLockFreePool()}; earlier
      *
      * @return the default {@link RecyclerPool} implementation to use
      *   if no specific implementation desired.
      */
     public static RecyclerPool<BufferRecycler> defaultPool() {
-        return newLockFreePool();
+        return sharedLockFreePool();
     }
 
     /**


### PR DESCRIPTION
At the moment jackson allocates a new pool every time the default pool is asked. I believe it would be more correct to always reuse the shared one also because the (useless?) creation of a new one is not only causing [this issue in quarkus](https://github.com/quarkusio/quarkus/pull/39739), but even worse is very likely the main cause of the performance problem reported [here](https://github.com/FasterXML/jackson-module-scala/issues/672). 