### PR TITLE
InternCache - remove synchronized

### DIFF
--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -16,6 +16,10 @@ a pure JSON library.
 
 2.18.0 (not yet released)
 
+#1251: `InternCache` replace synchronized with `ReentrantLock` - the cache
+  size limit is no longer strictly enforced for performance reasons but
+  we should never go far about the limit
+ (contributed by @pjfanning)
 #1252: `ThreadLocalBufferManager` replace synchronized with `ReentrantLock`
  (contributed by @pjfanning)
 

--- a/src/main/java/com/fasterxml/jackson/core/util/InternCache.java
+++ b/src/main/java/com/fasterxml/jackson/core/util/InternCache.java
@@ -1,6 +1,7 @@
 package com.fasterxml.jackson.core.util;
 
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * Singleton class that adds a simple first-level cache in front of
@@ -29,7 +30,7 @@ public final class InternCache
      * cases where multiple threads might try to concurrently
      * flush the map.
      */
-    private final Object lock = new Object();
+    private final ReentrantLock lock = new ReentrantLock();
 
     public InternCache() { this(MAX_ENTRIES, 0.8f, 4); }
 
@@ -51,10 +52,13 @@ public final class InternCache
              * storage gives close enough answer to real one here; and we are
              * more concerned with flooding than starvation.
              */
-            synchronized (lock) {
+            lock.lock();
+            try {
                 if (size() >= MAX_ENTRIES) {
                     clear();
                 }
+            } finally {
+                lock.unlock();
             }
         }
         result = input.intern();


### PR DESCRIPTION
If we are going all-in on ReentrantLocks - I would still like to do each change its own PR so that each change gets looked at on its own merits.