### PR TITLE
remove old mentions of synchronization that no longer apply

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/sym/CharsToNameCanonicalizer.java
+++ b/src/main/java/com/fasterxml/jackson/core/sym/CharsToNameCanonicalizer.java
@@ -364,10 +364,9 @@ public final class CharsToNameCanonicalizer
      * read-only copy of parent's data, but when changes are needed, a
      * copy will be created.
      *<p>
-     * Note: while this method is synchronized, it is generally not
-     * safe to both use makeChild/mergeChild, AND to use instance
-     * actively. Instead, a separate 'root' instance should be used
-     * on which only makeChild/mergeChild are called, but instance itself
+     * Note: It is generally not safe to both use makeChild/mergeChild, AND to
+     * use instance actively. Instead, a separate 'root' instance should be
+     * used on which only makeChild/mergeChild are called, but instance itself
      * is not used as a symbol table.
      *
      * @return Actual canonicalizer instance that can be used by a parser

--- a/src/main/java/com/fasterxml/jackson/core/util/ThreadLocalBufferManager.java
+++ b/src/main/java/com/fasterxml/jackson/core/util/ThreadLocalBufferManager.java
@@ -95,8 +95,7 @@ class ThreadLocalBufferManager
 
     /**
      * Remove cleared (inactive) SoftRefs from our set. Gc may have cleared one or more,
-     * and made them inactive. We minimize contention by keeping synchronized sections short:
-     * the poll/remove methods
+     * and made them inactive.
      */
     private void removeSoftRefsClearedByGc() {
         SoftReference<?> clearedSoftRef;


### PR DESCRIPTION
these docs seem out of date - even before the recent PRs where I try to remove some synchronized blocks