### PR TITLE
Part of #1260: write a manually run concurrency test to tease out problem with pool retention

### DIFF
--- a/src/test/java/perf/RecyclerPoolTest.java
+++ b/src/test/java/perf/RecyclerPoolTest.java
@@ -154,16 +154,15 @@ public class RecyclerPoolTest
         RecyclerPoolTest test = new RecyclerPoolTest(THREAD_COUNT);
         List<String> results = Arrays.asList(
             test.testPool(JsonFactory.builder()
-                    .recyclerPool(JsonRecyclerPools.newLockFreePool())
-                    .build(),
-                // Let's run this one twice as long
-                RUNTIME_SECS * 2),
-            test.testPool(JsonFactory.builder()
                     .recyclerPool(JsonRecyclerPools.newConcurrentDequePool())
                     .build(),
                 RUNTIME_SECS),
             test.testPool(JsonFactory.builder()
                     .recyclerPool(JsonRecyclerPools.newBoundedPool(THREAD_COUNT - 5))
+                    .build(),
+                RUNTIME_SECS),
+            test.testPool(JsonFactory.builder()
+                    .recyclerPool(JsonRecyclerPools.newLockFreePool())
                     .build(),
                 RUNTIME_SECS)
         );


### PR DESCRIPTION
So, `RecyclerPoolTest` under `src/test/java/perf/` runs through 3 pool implementations with N threads (like 100) over some amount of time (30 or 60 seconds), and checks pooled entry count (pool.pooledCount()); occasionally printing size.
Hope is that this will show abnormal behavior seen in production environments.