### PR TITLE
fix ignored maxDocLen in deprecated StreamReadConstraints constructor

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/StreamReadConstraints.java
+++ b/src/main/java/com/fasterxml/jackson/core/StreamReadConstraints.java
@@ -140,7 +140,7 @@ public class StreamReadConstraints
          * The length is in input units of the input source, that is, in
          * {@code byte}s or {@code char}s.
          *
-         * @param maxDocLen the maximum allowed document if positive number above 0; otherwise
+         * @param maxDocLen the maximum allowed document length if positive number above 0; otherwise
          *   ({@code 0} or negative number) means "unlimited".
          *
          * @return this builder
@@ -256,7 +256,7 @@ public class StreamReadConstraints
     @Deprecated // since 2.16
     protected StreamReadConstraints(final int maxNestingDepth, final long maxDocLen,
             final int maxNumLen, final int maxStringLen) {
-        this(maxNestingDepth, DEFAULT_MAX_DOC_LEN,
+        this(maxNestingDepth, maxDocLen,
                 maxNumLen, maxStringLen, DEFAULT_MAX_NAME_LEN);
     }
 


### PR DESCRIPTION
really just tidy up - this constructor is not likely used by anyone