### PR TITLE
add tests for ints with 19 chars

### DIFF
--- a/src/test/java/com/fasterxml/jackson/core/read/NumberParsingTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/read/NumberParsingTest.java
@@ -454,11 +454,31 @@ class NumberParsingTest
         BigInteger biggie = new BigInteger(NUMBER_STR);
 
         for (int mode : ALL_MODES) {
-            try (JsonParser p = createParser(jsonFactory(), mode, NUMBER_STR +" ")) {
+            try (JsonParser p = createParser(jsonFactory(), mode, NUMBER_STR + " ")) {
                 assertToken(JsonToken.VALUE_NUMBER_INT, p.nextToken());
                 assertEquals(JsonParser.NumberType.BIG_INTEGER, p.getNumberType());
                 assertEquals(NUMBER_STR, p.getText());
                 assertEquals(biggie, p.getBigIntegerValue());
+            }
+        }
+    }
+
+    @Test
+    void intsWith19Chars() throws Exception
+    {
+        final String[] values = new String[] {
+            "9223372036854775808", "9999999999999999999"
+        };
+        for (String value : values) {
+            BigInteger biggie = new BigInteger(value);
+
+            for (int mode : ALL_MODES) {
+                try (JsonParser p = createParser(jsonFactory(), mode, value + " ")) {
+                    assertToken(JsonToken.VALUE_NUMBER_INT, p.nextToken());
+                    assertEquals(JsonParser.NumberType.BIG_INTEGER, p.getNumberType());
+                    assertEquals(biggie, p.getBigIntegerValue());
+                    assertEquals(value, p.getText());
+                }
             }
         }
     }


### PR DESCRIPTION
* based on https://github.com/plokhotnyuk/jsoniter-scala/issues/1195
* with int processing, it is common to count the chars and parse as a Long if the chars are <= 19 and BigInteger if above
* this approach can be risky because a few values may be at a little too big to parse as a long and you could get parse issues