### PR TITLE
Fix #1340 by adding missing "provides" in `module-info.java`

### DIFF
--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -45,6 +45,8 @@ a pure JSON library.
   of Tokens allowed per document#
 #1331: Update to FastDoubleParser v1.0.1 to fix `BigDecimal` decoding proble
  (fixed by @pjfanning)
+#1340: Missing `JsonFactory` "provides" SPI with JPMS in `jackson-core` module
+ (contributed by @sdyura)
 
 2.17.2 (05-Jul-2024)
 

--- a/src/moditect/module-info.java
+++ b/src/moditect/module-info.java
@@ -21,6 +21,7 @@ module com.fasterxml.jackson.core {
     // 03-Oct-2019, tatu: [core#567] Add self-use to avoid warnings
     uses com.fasterxml.jackson.core.ObjectCodec;
 
+    // 25-Sep-2024: [core#1340] Need to explicitly add even in base
     provides com.fasterxml.jackson.core.JsonFactory with
-            com.fasterxml.jackson.core.JsonFactory;
+        com.fasterxml.jackson.core.JsonFactory;
 }


### PR DESCRIPTION
(Fixes #1340)

if we have a src/main/resources/META-INF/services/com.fasterxml.jackson.core.JsonFactory
this works in projects that have no module-info.java, but if a project does have module-info.java
then we need to also add the java modules way of provides

this fixes `ServiceLoader<JsonFactory> sl = ServiceLoader.load(JsonFactory.class);` not working (returning empty)
for projects that have a module-info.java