### PR TITLE
Fix infinite loop due to integer overflow when reading large strings

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/json/UTF8StreamJsonParser.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/UTF8StreamJsonParser.java
@@ -2544,7 +2544,14 @@ public class UTF8StreamJsonParser
                     outBuf = _textBuffer.finishCurrentSegment();
                     outPtr = 0;
                 }
-                final int max = Math.min(_inputEnd, (ptr + (outBuf.length - outPtr)));
+
+                int max;
+                try {
+                    max = Math.min(_inputEnd, Math.addExact(ptr, outBuf.length - outPtr));
+                } catch (ArithmeticException ex) {
+                    max = Integer.MAX_VALUE;
+                }
+
                 while (ptr < max) {
                     c = inputBuffer[ptr++] & 0xFF;
                     if (codes[c] != 0) {

--- a/src/test/java/com/fasterxml/jackson/core/json/TestLargeString.java
+++ b/src/test/java/com/fasterxml/jackson/core/json/TestLargeString.java
@@ -1,0 +1,32 @@
+package com.fasterxml.jackson.core.json;
+
+import com.fasterxml.jackson.core.*;
+import net.bytebuddy.utility.RandomString;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class TestLargeString extends JUnit5TestBase {
+
+    @Test
+    void testLargeStringDeserialization() throws Exception
+    {
+        String largeString = RandomString.make(Integer.MAX_VALUE - 1024);
+        JsonFactory f = JsonFactory.builder()
+                .streamReadConstraints(StreamReadConstraints.builder()
+                        .maxStringLength(Integer.MAX_VALUE)
+                        .build())
+                .build();
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        JsonGenerator g = f.createGenerator(bytes);
+        g.writeString(largeString);
+        g.close();
+
+        JsonParser parser = f.createParser(bytes.toByteArray());
+        String parsedString = parser.nextTextValue();
+
+        assertEquals(largeString, parsedString);
+    }
+}


### PR DESCRIPTION
If the `StreamReadConstraints` are set to `Integer.MAX_VALUE`, reading a large string results in an infinite loop due to the value of `max` overflowing to a negative value. `while (ptr < max)` is always false so `break ascii_loop` is never reached.

This change uses `Math.addExact` to throw an `ArthimeticException` if an overflow were to occur and sets `max` to max integer, allowing the loop to break and large strings to be properly deserialized.

This can be reproduced like so, where the call to `nextTextValue` will trigger the infinite loop. After applying the patch, the code completes. I can add the test case somewhere (or put it in a new test class) however it requires a large JVM to run and I'm not sure the size of the JVMs used for testing.

```
    @Test
    void testLargeStringDeserialization() throws Exception {
        String largeString = RandomString.make(Integer.MAX_VALUE - 1024);
        JsonFactory f = JsonFactory.builder()
                .streamReadConstraints(StreamReadConstraints.builder()
                        .maxStringLength(Integer.MAX_VALUE)
                        .build())
                .build();
        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
        JsonGenerator g = f.createGenerator(bytes);
        g.writeString(largeString);
        g.close();

        JsonParser parser = f.createParser(bytes.toByteArray());
        String parsedString = parser.nextTextValue();

        assertEquals(largeString, parsedString);
    }
```