### PR TITLE
use fastdoubleparser 1.0.90

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -299,7 +299,7 @@ com.fasterxml.jackson.core.*;version=${project.version}
     <dependency>
       <groupId>ch.randelshofer</groupId>
       <artifactId>fastdoubleparser</artifactId>
-      <version>1.0.1</version>
+      <version>1.0.90</version>
     </dependency>
     <!-- Test dependencies -->
     <dependency>


### PR DESCRIPTION
an issue in ZIng JVM - and possibly other JVMs

https://github.com/wrandelshofer/FastDoubleParser/releases/tag/v1.0.90

It does seem like a bug in the JVM but seems best to use the workaround