### PR TITLE
Make `JsonGenerator::writeTypePrefix` method to not make a `WRAPPER_ARRAY` when `typeIdDef.id == null`

### DIFF
--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -456,3 +456,8 @@ Jared Stehler (@jaredstehler)
 Zhanghao (@zhangOranges)
  * Contributed #1305: Make helper methods of `WriterBasedJsonGenerator` non-final to allow overriding
   (2.18.0)
+
+Eduard Gomoliako (@Gems)
+ * Contributed #1356: Make `JsonGenerator::writeTypePrefix` method to not write a
+  `WRAPPER_ARRAY` when `typeIdDef.id == null`
+  (2.19.0)

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -17,6 +17,9 @@ a pure JSON library.
 2.19.0 (not yet released)
 
 #1328: Optimize handling of `JsonPointer.head()`
+#1356: Make `JsonGenerator::writeTypePrefix` method to not write a
+  `WRAPPER_ARRAY` when `typeIdDef.id == null`
+ (contributed by Eduard G)
 
 2.18.1 (28-Oct-2024)
 

--- a/src/main/java/com/fasterxml/jackson/core/JsonGenerator.java
+++ b/src/main/java/com/fasterxml/jackson/core/JsonGenerator.java
@@ -10,6 +10,7 @@ import java.math.BigInteger;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.Objects;
 
 import com.fasterxml.jackson.core.JsonParser.NumberType;
 import com.fasterxml.jackson.core.exc.StreamWriteException;
@@ -1978,12 +1979,13 @@ public abstract class JsonGenerator
         } else {
             // No native type id; write wrappers
             // Normally we only support String type ids (non-String reserved for native type ids)
-            String idStr = (id instanceof String) ? (String) id : String.valueOf(id);
+            String idStr = (id instanceof String) ? (String) id : Objects.toString(id, null);
             typeIdDef.wrapperWritten = true;
 
             Inclusion incl = typeIdDef.include;
             // first: can not output "as property" if value not Object; if so, must do "as array"
             if ((valueShape != JsonToken.START_OBJECT)
+                    && idStr != null 
                     && incl.requiresObjectContext()) {
                 typeIdDef.include = incl = WritableTypeId.Inclusion.WRAPPER_ARRAY;
             }


### PR DESCRIPTION
This PR addresses [GitHub issue #4772](https://github.com/FasterXML/jackson-databind/issues/4772).

**Summary**

In certain cases where `@JsonTypeInfo` is used with `JsonTypeInfo.Id.DEDUCTION`, `typeDef.id` may resolve to `null`. For example, in the [referenced issue](https://github.com/FasterXML/jackson-databind/issues/4772), this occurs with a class based on the `Collection` interface, resulting in `typeDef.id` being `null`.

**Change Details**

This update modifies the `sonGenerator::writeTypePrefix` method so that it doesn’t generate a wrapping array with a `"null"` key for classes with a `null` `typeDef.id`. The current behavior, which includes an unnecessary wrapping array labeled by `"null"`, can be misleading. By skipping this wrapper, we aim to make the serialization output more intuitive and aligned with user expectations.

**Rationale**

The previous behavior of adding a wrapping array with a "null" key was confusing and did not provide meaningful value to users. Removing it simplifies the output and makes the serialization format clearer, especially in cases involving classes based on generic interfaces like `Collection`.

**Impact**

This change will make the output format more predictable and consistent, especially for users employing `@JsonTypeInfo` with `JsonTypeInfo.Id.DEDUCTION`. Existing tests and validation tools should ensure that this change does not disrupt compatibility with existing deserialization setups.