### PR TITLE
fail if int overflow in _longNameOffset

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/sym/ByteQuadsCanonicalizer.java
+++ b/src/main/java/com/fasterxml/jackson/core/sym/ByteQuadsCanonicalizer.java
@@ -1120,10 +1120,10 @@ public final class ByteQuadsCanonicalizer
         final int newStart = start + qlen;
         if (newStart < 0) {
             throw new IllegalStateException(String.format(
-                    "Long name offset overflow; start=%s, qlen=%s", start, qlen));
+                    "Internal error: long name offset overflow; start=%s, qlen=%s", start, qlen));
         }
 
-        // note: at this point we must already be shared. But may not have enough space
+        // note: at this point we must already be unshared. But may not have enough space
         if (newStart > _hashArea.length) {
             // try to increment in reasonable chunks; at least space that we need
             int toAdd = newStart - _hashArea.length;
@@ -1264,9 +1264,8 @@ public final class ByteQuadsCanonicalizer
         final int newSize = oldSize + oldSize;
         final int oldEnd = _spilloverEnd;
 
-        /* 13-Mar-2010, tatu: Let's guard against OOME that could be caused by
-         *    large documents with unique (or mostly so) names
-         */
+        // 13-Mar-2010, tatu: Let's guard against OOME that could be caused by
+        //    large documents with unique (or mostly so) names
         if (newSize > MAX_T_SIZE) {
             nukeSymbols(true);
             return;

--- a/src/main/java/com/fasterxml/jackson/core/sym/ByteQuadsCanonicalizer.java
+++ b/src/main/java/com/fasterxml/jackson/core/sym/ByteQuadsCanonicalizer.java
@@ -1114,14 +1114,19 @@ public final class ByteQuadsCanonicalizer
         return false;
     }
 
-    private int _appendLongName(int[] quads, int qlen)
+    private int _appendLongName(final int[] quads, final int qlen)
     {
-        int start = _longNameOffset;
+        final int start = _longNameOffset;
+        final int newStart = start + qlen;
+        if (newStart < 0) {
+            throw new IllegalStateException(String.format(
+                    "Long name offset overflow; start=%s, qlen=%s", start, qlen));
+        }
 
         // note: at this point we must already be shared. But may not have enough space
-        if ((start + qlen) > _hashArea.length) {
+        if (newStart > _hashArea.length) {
             // try to increment in reasonable chunks; at least space that we need
-            int toAdd = (start + qlen) - _hashArea.length;
+            int toAdd = newStart - _hashArea.length;
             // but at least 1/8 of regular hash area size or 16kB (whichever smaller)
             int minAdd = Math.min(4096, _hashSize);
 
@@ -1129,7 +1134,7 @@ public final class ByteQuadsCanonicalizer
             _hashArea = Arrays.copyOf(_hashArea, newSize);
         }
         System.arraycopy(quads, 0, _hashArea, start, qlen);
-        _longNameOffset += qlen;
+        _longNameOffset = newStart;
         return start;
     }
 


### PR DESCRIPTION
* relates to #1289 
* the class relies on an array so can't handle the case where _longNameOffset ends up greater than Integer.MAX_VALUE
* I think it is helpful to fail with a readable exception - instead of array size exceptions
* It may or may not be useful to include details about how to disable canonicalisation

Only people who are seriously abusing JSON and creating names in their JSON that exceed 2 billion chars will hit this.