### PR TITLE
Fix #1378: rename `JsonParser.getText()` as `.getString()` (JSTEP-6)

### DIFF
--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -48,6 +48,7 @@ JSON library.
 #1269: Change `JsonFactory.builder()` configuration of `RecyclerPool` to avoid
   allocation default implementation (in 3.0)
 #1364: JSTEP-6: rename `JsonLocation` as `TokenStreamLocation`
+#1378: Rename `JsonParser.getText()` as `.getString()` [JSTEP-6]
 - Rename `JsonGenerator.Feature.AUTO_CLOSE_JSON_CONTENT` as `AUTO_CLOSE_CONTENT`
 - Add `TreeCodec.nullNode()`, `TreeNode.isNull()` methods
 - Change the way `JsonLocation.NA` is included in exception messages

--- a/src/main/java/tools/jackson/core/JsonGenerator.java
+++ b/src/main/java/tools/jackson/core/JsonGenerator.java
@@ -2210,7 +2210,7 @@ public abstract class JsonGenerator
     protected void _copyCurrentStringValue(JsonParser p) throws JacksonException
     {
         if (p.hasStringCharacters()) {
-            writeString(p.getTextCharacters(), p.getTextOffset(), p.getTextLength());
+            writeString(p.getStringCharacters(), p.getStringOffset(), p.getStringLength());
         } else {
             writeString(p.getString());
         }

--- a/src/main/java/tools/jackson/core/JsonGenerator.java
+++ b/src/main/java/tools/jackson/core/JsonGenerator.java
@@ -2209,7 +2209,7 @@ public abstract class JsonGenerator
      */
     protected void _copyCurrentStringValue(JsonParser p) throws JacksonException
     {
-        if (p.hasTextCharacters()) {
+        if (p.hasStringCharacters()) {
             writeString(p.getTextCharacters(), p.getTextOffset(), p.getTextLength());
         } else {
             writeString(p.getText());

--- a/src/main/java/tools/jackson/core/JsonGenerator.java
+++ b/src/main/java/tools/jackson/core/JsonGenerator.java
@@ -2212,7 +2212,7 @@ public abstract class JsonGenerator
         if (p.hasStringCharacters()) {
             writeString(p.getTextCharacters(), p.getTextOffset(), p.getTextLength());
         } else {
-            writeString(p.getText());
+            writeString(p.getString());
         }
     }
 

--- a/src/main/java/tools/jackson/core/JsonParser.java
+++ b/src/main/java/tools/jackson/core/JsonParser.java
@@ -467,7 +467,7 @@ public abstract class JsonParser
      * so that even if lazy processing is enabled, the whole contents are
      * read for possible retrieval. This is usually used to ensure that
      * the token end location is available, as well as token contents
-     * (similar to what calling, say {@link #getTextCharacters()}, would
+     * (similar to what calling, say {@link #getStringCharacters()}, would
      * achieve).
      *<p>
      * Note that for many dataformat implementations this method
@@ -570,7 +570,7 @@ public abstract class JsonParser
      * otherwise returns null.
      * It is functionally equivalent to:
      *<pre>
-     *  return (nextToken() == JsonToken.VALUE_STRING) ? getText() : null;
+     *  return (nextToken() == JsonToken.VALUE_STRING) ? getString() : null;
      *</pre>
      * but may be faster for parser to process, and can therefore be used if caller
      * expects to get a String value next from input.
@@ -839,7 +839,7 @@ public abstract class JsonParser
 
     /*
     /**********************************************************************
-    /* Public API, access to token information, text
+    /* Public API, access to token information, Strings
     /**********************************************************************
      */
 
@@ -871,9 +871,9 @@ public abstract class JsonParser
     /**
      * Method to read the textual representation of the current token in chunks and
      * pass it to the given Writer.
-     * Conceptually same as calling:
+     * Functionally same as calling:
      *<pre>
-     *  writer.write(parser.getText());
+     *  writer.write(parser.getString());
      *</pre>
      * but should typically be more efficient as longer content does need to
      * be combined into a single <code>String</code> to return, and write
@@ -881,7 +881,7 @@ public abstract class JsonParser
      *<p>
      * NOTE: String value <b>will</b> still be buffered (usually
      * using {@link TextBuffer}) and <b>will</b> be accessible with
-     * other {@code getText()} calls (that is, it will not be consumed).
+     * other {@code getString()} calls (that is, it will not be consumed).
      * So this accessor only avoids construction of {@link java.lang.String}
      * compared to plain {@link #getString()} method.
      *<p>
@@ -904,11 +904,11 @@ public abstract class JsonParser
      * Note, however, that:
      *<ul>
      * <li>String contents are not guaranteed to start at
-     *   index 0 (rather, call {@link #getTextOffset}) to
+     *   index 0 (rather, call {@link #getStringOffset}) to
      *   know the actual offset
      *  </li>
      * <li>Length of string contents may be less than the
-     *  length of returned buffer: call {@link #getTextLength}
+     *  length of returned buffer: call {@link #getStringLength}
      *  for actual length of returned content.
      *  </li>
      * </ul>
@@ -927,33 +927,33 @@ public abstract class JsonParser
      * @throws JacksonIOException for low-level read issues
      * @throws tools.jackson.core.exc.StreamReadException for decoding problems
      */
-    public abstract char[] getTextCharacters() throws JacksonException;
+    public abstract char[] getStringCharacters() throws JacksonException;
 
     /**
-     * Accessor used with {@link #getTextCharacters}, to know length
+     * Accessor used with {@link #getStringCharacters}, to know length
      * of String stored in returned buffer.
      *
      * @return Number of characters within buffer returned
-     *   by {@link #getTextCharacters} that are part of
+     *   by {@link #getStringCharacters} that are part of
      *   textual content of the current token.
      *
      * @throws JacksonIOException for low-level read issues
      * @throws tools.jackson.core.exc.StreamReadException for decoding problems
      */
-    public abstract int getTextLength() throws JacksonException;
+    public abstract int getStringLength() throws JacksonException;
 
     /**
-     * Accessor used with {@link #getTextCharacters}, to know offset
+     * Accessor used with {@link #getStringCharacters}, to know offset
      * of the first text content character within buffer.
      *
      * @return Offset of the first character within buffer returned
-     *   by {@link #getTextCharacters} that is part of
+     *   by {@link #getStringCharacters} that is part of
      *   textual content of the current token.
      *
      * @throws JacksonIOException for low-level read issues
      * @throws tools.jackson.core.exc.StreamReadException for decoding problems
      */
-    public abstract int getTextOffset() throws JacksonException;
+    public abstract int getStringOffset() throws JacksonException;
 
     /**
      * Method that can be used to determine whether calling of
@@ -962,14 +962,20 @@ public abstract class JsonParser
      * points to (compared to {@link #getString()}).
      *
      * @return True if parser currently has character array that can
-     *   be efficiently returned via {@link #getTextCharacters}; false
+     *   be efficiently returned via {@link #getStringCharacters}; false
      *   means that it may or may not exist
      */
     public abstract boolean hasStringCharacters();
 
+    /*
+    /**********************************************************************
+    /* Deprecated Public API String access methods (deprecated in 3.0)
+    /**********************************************************************
+     */
+    
     /**
-     * Deprecated alias for {@link #getString()}: MAY be removed in a 3.x version
-     * past 3.0; only included to help initial migration.
+     * Deprecated alias for {@link #getString()}:
+     * MAY be removed in a 3.x version past 3.0; only included to help initial migration.
      *
      * @deprecated since 3.0 use {@link #getString()} instead.
      */
@@ -977,7 +983,40 @@ public abstract class JsonParser
     public String getText() throws JacksonException {
         return getString();
     }
-    
+
+    /**
+     * Deprecated alias for {@link #getStringCharacters()}:
+     * MAY be removed in a 3.x version past 3.0; only included to help initial migration.
+     *
+     * @deprecated since 3.0 use {@link #getStringCharacters()} instead.
+     */
+    @Deprecated // since 3.0
+    public char[] getTextCharacters() throws JacksonException {
+        return getStringCharacters();
+    }
+
+    /**
+     * Deprecated alias for {@link #getStringLength()}:
+     * MAY be removed in a 3.x version past 3.0; only included to help initial migration.
+     *
+     * @deprecated since 3.0 use {@link #getStringLength()} instead.
+     */
+    @Deprecated // since 3.0
+    public int getTextLength() throws JacksonException {
+        return getStringLength();
+    }
+
+    /**
+     * Deprecated alias for {@link #getStringOffset()}:
+     * MAY be removed in a 3.x version past 3.0; only included to help initial migration.
+     *
+     * @deprecated since 3.0 use {@link #getStringOffset()} instead.
+     */
+    @Deprecated // since 3.0
+    public int getTextOffset() throws JacksonException {
+        return getStringOffset();
+    }
+
     /*
     /**********************************************************************
     /* Public API, access to token information, numeric

--- a/src/main/java/tools/jackson/core/JsonParser.java
+++ b/src/main/java/tools/jackson/core/JsonParser.java
@@ -955,22 +955,15 @@ public abstract class JsonParser
 
     /**
      * Method that can be used to determine whether calling of
-     * {@link #getTextCharacters} would be the most efficient
-     * way to access textual content for the event parser currently
-     * points to.
-     *<p>
-     * Default implementation simply returns false since only actual
-     * implementation class has knowledge of its internal buffering
-     * state.
-     * Implementations are strongly encouraged to properly override
-     * this method, to allow efficient copying of content by other
-     * code.
+     * {@link #getStringCharacters} would be the most efficient
+     * way to access String value for the event parser currently
+     * points to (compared to {@link #getText}).
      *
      * @return True if parser currently has character array that can
      *   be efficiently returned via {@link #getTextCharacters}; false
      *   means that it may or may not exist
      */
-    public abstract boolean hasTextCharacters();
+    public abstract boolean hasStringCharacters();
 
     /*
     /**********************************************************************

--- a/src/main/java/tools/jackson/core/JsonParser.java
+++ b/src/main/java/tools/jackson/core/JsonParser.java
@@ -581,7 +581,7 @@ public abstract class JsonParser
      * @throws JacksonIOException for low-level read issues
      * @throws tools.jackson.core.exc.StreamReadException for decoding problems
      */
-    public String nextTextValue() throws JacksonException {
+    public String nextStringValue() throws JacksonException {
         return (nextToken() == JsonToken.VALUE_STRING) ? getText() : null;
     }
 

--- a/src/main/java/tools/jackson/core/JsonParser.java
+++ b/src/main/java/tools/jackson/core/JsonParser.java
@@ -575,7 +575,7 @@ public abstract class JsonParser
      * but may be faster for parser to process, and can therefore be used if caller
      * expects to get a String value next from input.
      *
-     * @return Text value of the {@code JsonToken.VALUE_STRING} token parser advanced
+     * @return String value of {@code JsonToken.VALUE_STRING} token parser advanced
      *   to; or {@code null} if next token is of some other type
      *
      * @throws JacksonIOException for low-level read issues
@@ -879,20 +879,20 @@ public abstract class JsonParser
      * be combined into a single <code>String</code> to return, and write
      * can occur directly from intermediate buffers Jackson uses.
      *<p>
-     * NOTE: textual content <b>will</b> still be buffered (usually
+     * NOTE: String value <b>will</b> still be buffered (usually
      * using {@link TextBuffer}) and <b>will</b> be accessible with
      * other {@code getText()} calls (that is, it will not be consumed).
      * So this accessor only avoids construction of {@link java.lang.String}
      * compared to plain {@link #getText()} method.
      *
-     * @param writer Writer to write textual content to
+     * @param writer Writer to write String value to
      *
      * @return The number of characters written to the Writer
      *
      * @throws JacksonIOException for low-level read issues, or failed write using {@link Writer}
      * @throws tools.jackson.core.exc.StreamReadException for decoding problems
      */
-    public abstract int getText(Writer writer) throws JacksonException;
+    public abstract int getString(Writer writer) throws JacksonException;
 
     /**
      * Method similar to {@link #getText}, but that will return

--- a/src/main/java/tools/jackson/core/JsonParser.java
+++ b/src/main/java/tools/jackson/core/JsonParser.java
@@ -582,7 +582,7 @@ public abstract class JsonParser
      * @throws tools.jackson.core.exc.StreamReadException for decoding problems
      */
     public String nextStringValue() throws JacksonException {
-        return (nextToken() == JsonToken.VALUE_STRING) ? getText() : null;
+        return (nextToken() == JsonToken.VALUE_STRING) ? getString() : null;
     }
 
     /**
@@ -846,7 +846,7 @@ public abstract class JsonParser
     /**
      * Method that can be called to get the name associated with
      * the current token: for {@link JsonToken#PROPERTY_NAME}s it will
-     * be the same as what {@link #getText} returns;
+     * be the same as what {@link #getString()} returns;
      * for Object property values it will be the preceding property name;
      * and for others (array element, root-level values) null.
      *
@@ -866,7 +866,7 @@ public abstract class JsonParser
      * @throws JacksonIOException for low-level read issues
      * @throws tools.jackson.core.exc.StreamReadException for decoding problems
      */
-    public abstract String getText() throws JacksonException;
+    public abstract String getString() throws JacksonException;
 
     /**
      * Method to read the textual representation of the current token in chunks and
@@ -883,7 +883,9 @@ public abstract class JsonParser
      * using {@link TextBuffer}) and <b>will</b> be accessible with
      * other {@code getText()} calls (that is, it will not be consumed).
      * So this accessor only avoids construction of {@link java.lang.String}
-     * compared to plain {@link #getText()} method.
+     * compared to plain {@link #getString()} method.
+     *<p>
+     * NOTE: In Jackson 2.x this method was called {@code getString(Writer)}.
      *
      * @param writer Writer to write String value to
      *
@@ -895,7 +897,7 @@ public abstract class JsonParser
     public abstract int getString(Writer writer) throws JacksonException;
 
     /**
-     * Method similar to {@link #getText}, but that will return
+     * Method similar to {@link #getString()}, but that will return
      * underlying (unmodifiable) character array that contains
      * textual value, instead of constructing a String object
      * to contain this information.
@@ -915,7 +917,7 @@ public abstract class JsonParser
      * character array in any way -- doing so may corrupt
      * current parser state and render parser instance useless.
      *<p>
-     * The only reason to call this method (over {@link #getText})
+     * The only reason to call this method (over {@link #getString()})
      * is to avoid construction of a String object (which
      * will make a copy of contents).
      *
@@ -957,7 +959,7 @@ public abstract class JsonParser
      * Method that can be used to determine whether calling of
      * {@link #getStringCharacters} would be the most efficient
      * way to access String value for the event parser currently
-     * points to (compared to {@link #getText}).
+     * points to (compared to {@link #getString()}).
      *
      * @return True if parser currently has character array that can
      *   be efficiently returned via {@link #getTextCharacters}; false
@@ -965,6 +967,17 @@ public abstract class JsonParser
      */
     public abstract boolean hasStringCharacters();
 
+    /**
+     * Deprecated alias for {@link #getString()}: MAY be removed in a 3.x version
+     * past 3.0; only included to help initial migration.
+     *
+     * @deprecated since 3.0 use {@link #getString()} instead.
+     */
+    @Deprecated // since 3.0
+    public String getText() throws JacksonException {
+        return getString();
+    }
+    
     /*
     /**********************************************************************
     /* Public API, access to token information, numeric
@@ -1255,7 +1268,7 @@ public abstract class JsonParser
      * may not be accessible using other methods after the call)
      * base64-encoded binary data
      * included in the current textual JSON value.
-     * It works similar to getting String value via {@link #getText}
+     * It works similar to getting String value via {@link #getString()}
      * and decoding result (except for decoding part),
      * but should be significantly more performant.
      *<p>

--- a/src/main/java/tools/jackson/core/base/ParserBase.java
+++ b/src/main/java/tools/jackson/core/base/ParserBase.java
@@ -305,7 +305,7 @@ public abstract class ParserBase extends ParserMinimalBase
                 _reportError("Current token (%s) not VALUE_EMBEDDED_OBJECT or VALUE_STRING, can not access as binary", _currToken);
             }
             ByteArrayBuilder builder = _getByteArrayBuilder();
-            _decodeBase64(getText(), builder, variant);
+            _decodeBase64(getString(), builder, variant);
             _binaryValue = builder.toByteArray();
         }
         return _binaryValue;
@@ -721,7 +721,7 @@ public abstract class ParserBase extends ParserMinimalBase
             // Let's verify its lossless conversion by simple roundtrip
             int result = (int) _numberLong;
             if (result != _numberLong) {
-                _reportOverflowInt(getText(), currentToken());
+                _reportOverflowInt(getString(), currentToken());
             }
             _numberInt = result;
         } else if ((_numTypesValid & NR_BIGINT) != 0) {
@@ -884,7 +884,7 @@ public abstract class ParserBase extends ParserMinimalBase
         if ((_numTypesValid & NR_DOUBLE) != 0) {
             // Let's actually parse from String representation, to avoid
             // rounding errors that non-decimal floating operations could incur
-            final String numStr = _numberString == null ? getText() : _numberString;
+            final String numStr = _numberString == null ? getString() : _numberString;
             _numberBigDecimal = NumberInput.parseBigDecimal(
                     numStr,
                     isEnabled(StreamReadFeature.USE_FAST_BIG_NUMBER_PARSER));

--- a/src/main/java/tools/jackson/core/base/ParserBase.java
+++ b/src/main/java/tools/jackson/core/base/ParserBase.java
@@ -292,7 +292,7 @@ public abstract class ParserBase extends ParserMinimalBase
      */
 
     @Override
-    public boolean hasTextCharacters() {
+    public boolean hasStringCharacters() {
         return false;
     }
 

--- a/src/main/java/tools/jackson/core/base/ParserMinimalBase.java
+++ b/src/main/java/tools/jackson/core/base/ParserMinimalBase.java
@@ -528,7 +528,7 @@ public abstract class ParserMinimalBase extends JsonParser
 //    @Override public abstract int getTextOffset();
 
     @Override
-    public int getText(Writer writer) throws JacksonException
+    public int getString(Writer writer) throws JacksonException
     {
         String str = getText();
         if (str == null) {

--- a/src/main/java/tools/jackson/core/base/ParserMinimalBase.java
+++ b/src/main/java/tools/jackson/core/base/ParserMinimalBase.java
@@ -530,7 +530,7 @@ public abstract class ParserMinimalBase extends JsonParser
     @Override
     public int getString(Writer writer) throws JacksonException
     {
-        String str = getText();
+        String str = getString();
         if (str == null) {
             return 0;
         }
@@ -573,7 +573,7 @@ public abstract class ParserMinimalBase extends JsonParser
         // Let's actually allow range of [-128, 255] instead of just signed range of [-128, 127]
         // since "unsigned" usage quite common for bytes (but Java may use signed range, too)
         if (value < MIN_BYTE_I || value > MAX_BYTE_I) {
-            _reportOverflowByte(getText(), currentToken());
+            _reportOverflowByte(getString(), currentToken());
         }
         return (byte) value;
     }
@@ -583,7 +583,7 @@ public abstract class ParserMinimalBase extends JsonParser
     {
         int value = getIntValue();
         if (value < MIN_SHORT_I || value > MAX_SHORT_I) {
-            _reportOverflowShort(getText(), currentToken());
+            _reportOverflowShort(getString(), currentToken());
         }
         return (short) value;
     }
@@ -631,7 +631,7 @@ public abstract class ParserMinimalBase extends JsonParser
         if (t != null) {
             switch (t.id()) {
             case ID_STRING:
-                String str = getText().trim();
+                String str = getString().trim();
                 if ("true".equals(str)) {
                     return true;
                 }
@@ -682,7 +682,7 @@ public abstract class ParserMinimalBase extends JsonParser
         if (t != null) {
             switch (t.id()) {
             case ID_STRING:
-                String str = getText();
+                String str = getString();
                 if (_hasTextualNull(str)) {
                     return 0;
                 }
@@ -723,7 +723,7 @@ public abstract class ParserMinimalBase extends JsonParser
         if (t != null) {
             switch (t.id()) {
             case ID_STRING:
-                String str = getText();
+                String str = getString();
                 if (_hasTextualNull(str)) {
                     return 0L;
                 }
@@ -750,7 +750,7 @@ public abstract class ParserMinimalBase extends JsonParser
         if (t != null) {
             switch (t.id()) {
             case ID_STRING:
-                String str = getText();
+                String str = getString();
                 if (_hasTextualNull(str)) {
                     return 0L;
                 }
@@ -783,7 +783,7 @@ public abstract class ParserMinimalBase extends JsonParser
     @Override
     public String getValueAsString(String defaultValue) {
         if (_currToken == JsonToken.VALUE_STRING) {
-            return getText();
+            return getString();
         }
         if (_currToken == JsonToken.PROPERTY_NAME) {
             return currentName();
@@ -791,7 +791,7 @@ public abstract class ParserMinimalBase extends JsonParser
         if (_currToken == null || _currToken == JsonToken.VALUE_NULL || !_currToken.isScalarValue()) {
             return defaultValue;
         }
-        return getText();
+        return getString();
     }
 
     /*
@@ -915,7 +915,7 @@ public abstract class ParserMinimalBase extends JsonParser
      * @throws InputCoercionException Exception that describes problem with number range validity
      */
     protected void _reportOverflowInt() throws InputCoercionException {
-        _reportOverflowInt(getText());
+        _reportOverflowInt(getString());
     }
 
     protected void _reportOverflowInt(String numDesc) throws InputCoercionException {
@@ -937,7 +937,7 @@ public abstract class ParserMinimalBase extends JsonParser
      * @throws InputCoercionException Exception that describes problem with number range validity
      */
     protected void _reportOverflowLong() throws InputCoercionException {
-        _reportOverflowLong(getText());
+        _reportOverflowLong(getString());
     }
 
     protected void _reportOverflowLong(String numDesc) throws InputCoercionException {

--- a/src/main/java/tools/jackson/core/filter/FilteringParserDelegate.java
+++ b/src/main/java/tools/jackson/core/filter/FilteringParserDelegate.java
@@ -904,11 +904,11 @@ public class FilteringParserDelegate extends JsonParserDelegate
     // 19-Jul-2021, tatu: Cannot quite just delegate these methods due to oddity
     //   of property name token, which may be buffered.
 
-    @Override public String getText() throws JacksonException {
+    @Override public String getString() throws JacksonException {
         if (_currToken == JsonToken.PROPERTY_NAME) {
             return currentName();
         }
-        return delegate.getText();
+        return delegate.getString();
     }
 
     @Override public boolean hasStringCharacters() {

--- a/src/main/java/tools/jackson/core/filter/FilteringParserDelegate.java
+++ b/src/main/java/tools/jackson/core/filter/FilteringParserDelegate.java
@@ -911,11 +911,11 @@ public class FilteringParserDelegate extends JsonParserDelegate
         return delegate.getText();
     }
 
-    @Override public boolean hasTextCharacters() {
+    @Override public boolean hasStringCharacters() {
         if (_currToken == JsonToken.PROPERTY_NAME) {
             return false;
         }
-        return delegate.hasTextCharacters();
+        return delegate.hasStringCharacters();
     }
 
     @Override public char[] getTextCharacters() throws JacksonException {

--- a/src/main/java/tools/jackson/core/filter/FilteringParserDelegate.java
+++ b/src/main/java/tools/jackson/core/filter/FilteringParserDelegate.java
@@ -918,26 +918,26 @@ public class FilteringParserDelegate extends JsonParserDelegate
         return delegate.hasStringCharacters();
     }
 
-    @Override public char[] getTextCharacters() throws JacksonException {
+    @Override public char[] getStringCharacters() throws JacksonException {
         // Not optimal but is correct, unlike delegating (as underlying stream
         // may point to something else due to buffering)
         if (_currToken == JsonToken.PROPERTY_NAME) {
             return currentName().toCharArray();
         }
-        return delegate.getTextCharacters();
+        return delegate.getStringCharacters();
     }
 
-    @Override public int getTextLength() throws JacksonException {
+    @Override public int getStringLength() throws JacksonException {
         if (_currToken == JsonToken.PROPERTY_NAME) {
             return currentName().length();
         }
-        return delegate.getTextLength();
+        return delegate.getStringLength();
     }
-    @Override public int getTextOffset() throws JacksonException {
+    @Override public int getStringOffset() throws JacksonException {
         if (_currToken == JsonToken.PROPERTY_NAME) {
             return 0;
         }
-        return delegate.getTextOffset();
+        return delegate.getStringOffset();
     }
 
     @Override public String getValueAsString() throws JacksonException {

--- a/src/main/java/tools/jackson/core/json/JsonParserBase.java
+++ b/src/main/java/tools/jackson/core/json/JsonParserBase.java
@@ -132,7 +132,7 @@ public abstract class JsonParserBase
     }
 
     @Override
-    public boolean hasTextCharacters() {
+    public boolean hasStringCharacters() {
         if (_currToken == JsonToken.VALUE_STRING) { return true; } // usually true
         if (_currToken == JsonToken.PROPERTY_NAME) { return _nameCopied; }
         return false;

--- a/src/main/java/tools/jackson/core/json/JsonReadFeature.java
+++ b/src/main/java/tools/jackson/core/json/JsonReadFeature.java
@@ -99,7 +99,7 @@ public enum JsonReadFeature
      * JSON integral numbers to start with additional (ignorable)
      * zeroes (like: {@code 000001}). If enabled, no exception is thrown, and extra
      * nulls are silently ignored (and not included in textual representation
-     * exposed via {@link JsonParser#getText}).
+     * exposed via {@link JsonParser#getString()}).
      *<p>
      * Since JSON specification does not allow leading zeroes,
      * this is a non-standard feature, and as such disabled by default.

--- a/src/main/java/tools/jackson/core/json/ReaderBasedJsonParser.java
+++ b/src/main/java/tools/jackson/core/json/ReaderBasedJsonParser.java
@@ -307,7 +307,7 @@ public class ReaderBasedJsonParser
     }
 
     @Override
-    public int getText(Writer writer) throws JacksonException
+    public int getString(Writer writer) throws JacksonException
     {
         final JsonToken t = _currToken;
 

--- a/src/main/java/tools/jackson/core/json/ReaderBasedJsonParser.java
+++ b/src/main/java/tools/jackson/core/json/ReaderBasedJsonParser.java
@@ -294,7 +294,7 @@ public class ReaderBasedJsonParser
      * see {@link tools.jackson.core.StreamReadConstraints.Builder#maxStringLength(int)}
      */
     @Override
-    public final String getText() throws JacksonException
+    public final String getString() throws JacksonException
     {
         if (_currToken == JsonToken.VALUE_STRING) {
             if (_tokenIncomplete) {
@@ -482,7 +482,7 @@ public class ReaderBasedJsonParser
             if (_binaryValue == null) {
                 @SuppressWarnings("resource")
                 ByteArrayBuilder builder = _getByteArrayBuilder();
-                _decodeBase64(getText(), builder, b64variant);
+                _decodeBase64(getString(), builder, b64variant);
                 _binaryValue = builder.toByteArray();
             }
         }
@@ -1223,7 +1223,7 @@ public class ReaderBasedJsonParser
             return null;
         }
         // !!! TODO: optimize this case as well
-        return (nextToken() == JsonToken.VALUE_STRING) ? getText() : null;
+        return (nextToken() == JsonToken.VALUE_STRING) ? getString() : null;
     }
 
     // note: identical to one in Utf8StreamParser

--- a/src/main/java/tools/jackson/core/json/ReaderBasedJsonParser.java
+++ b/src/main/java/tools/jackson/core/json/ReaderBasedJsonParser.java
@@ -1201,7 +1201,7 @@ public class ReaderBasedJsonParser
     }
     // note: identical to one in UTF8StreamJsonParser
     @Override
-    public final String nextTextValue() throws JacksonException
+    public final String nextStringValue() throws JacksonException
     {
         if (_currToken == JsonToken.PROPERTY_NAME) { // mostly copied from '_nextAfterName'
             _nameCopied = false;

--- a/src/main/java/tools/jackson/core/json/ReaderBasedJsonParser.java
+++ b/src/main/java/tools/jackson/core/json/ReaderBasedJsonParser.java
@@ -390,7 +390,7 @@ public class ReaderBasedJsonParser
     }
 
     @Override
-    public final char[] getTextCharacters() throws JacksonException
+    public final char[] getStringCharacters() throws JacksonException
     {
         if (_currToken != null) { // null only before/after document
             switch (_currToken.id()) {
@@ -413,7 +413,7 @@ public class ReaderBasedJsonParser
     }
 
     @Override
-    public final int getTextLength() throws JacksonException
+    public final int getStringLength() throws JacksonException
     {
         if (_currToken != null) { // null only before/after document
             switch (_currToken.id()) {
@@ -436,7 +436,7 @@ public class ReaderBasedJsonParser
     }
 
     @Override
-    public final int getTextOffset() throws JacksonException
+    public final int getStringOffset() throws JacksonException
     {
         // Most have offset of 0, only some may have other values:
         if (_currToken != null) {

--- a/src/main/java/tools/jackson/core/json/UTF8DataInputJsonParser.java
+++ b/src/main/java/tools/jackson/core/json/UTF8DataInputJsonParser.java
@@ -169,7 +169,7 @@ public class UTF8DataInputJsonParser
     }
 
     @Override
-    public int getText(Writer writer) throws JacksonException
+    public int getString(Writer writer) throws JacksonException
     {
         JsonToken t = _currToken;
         try {

--- a/src/main/java/tools/jackson/core/json/UTF8DataInputJsonParser.java
+++ b/src/main/java/tools/jackson/core/json/UTF8DataInputJsonParser.java
@@ -290,7 +290,7 @@ public class UTF8DataInputJsonParser
     }
 
     @Override
-    public char[] getTextCharacters() throws JacksonException
+    public char[] getStringCharacters() throws JacksonException
     {
         if (_currToken != null) { // null only before/after document
             switch (_currToken.id()) {
@@ -315,7 +315,7 @@ public class UTF8DataInputJsonParser
     }
 
     @Override
-    public int getTextLength() throws JacksonException
+    public int getStringLength() throws JacksonException
     {
         if (_currToken == JsonToken.VALUE_STRING) {
             if (_tokenIncomplete) {
@@ -337,7 +337,7 @@ public class UTF8DataInputJsonParser
     }
 
     @Override
-    public int getTextOffset() throws JacksonException
+    public int getStringOffset() throws JacksonException
     {
         // Most have offset of 0, only some may have other values:
         if (_currToken != null) {

--- a/src/main/java/tools/jackson/core/json/UTF8DataInputJsonParser.java
+++ b/src/main/java/tools/jackson/core/json/UTF8DataInputJsonParser.java
@@ -870,7 +870,7 @@ public class UTF8DataInputJsonParser
     }
 
     @Override
-    public String nextTextValue() throws JacksonException
+    public String nextStringValue() throws JacksonException
     {
         // two distinct cases; either got name and we know next type, or 'other'
         if (_currToken == JsonToken.PROPERTY_NAME) { // mostly copied from '_nextAfterName'

--- a/src/main/java/tools/jackson/core/json/UTF8DataInputJsonParser.java
+++ b/src/main/java/tools/jackson/core/json/UTF8DataInputJsonParser.java
@@ -156,7 +156,7 @@ public class UTF8DataInputJsonParser
      */
 
     @Override
-    public String getText() throws JacksonException
+    public String getString() throws JacksonException
     {
         if (_currToken == JsonToken.VALUE_STRING) {
             if (_tokenIncomplete) {
@@ -384,7 +384,7 @@ public class UTF8DataInputJsonParser
             if (_binaryValue == null) {
                 @SuppressWarnings("resource")
                 ByteArrayBuilder builder = _getByteArrayBuilder();
-                _decodeBase64(getText(), builder, b64variant);
+                _decodeBase64(getString(), builder, b64variant);
                 _binaryValue = builder.toByteArray();
             }
         }
@@ -892,7 +892,7 @@ public class UTF8DataInputJsonParser
             }
             return null;
         }
-        return (nextToken() == JsonToken.VALUE_STRING) ? getText() : null;
+        return (nextToken() == JsonToken.VALUE_STRING) ? getString() : null;
     }
 
     @Override

--- a/src/main/java/tools/jackson/core/json/UTF8StreamJsonParser.java
+++ b/src/main/java/tools/jackson/core/json/UTF8StreamJsonParser.java
@@ -1631,7 +1631,7 @@ public class UTF8StreamJsonParser
      */
 
     @Override
-    public String nextTextValue() throws JacksonException
+    public String nextStringValue() throws JacksonException
     {
         // two distinct cases; either got name and we know next type, or 'other'
         if (_currToken == JsonToken.PROPERTY_NAME) { // mostly copied from '_nextAfterName'

--- a/src/main/java/tools/jackson/core/json/UTF8StreamJsonParser.java
+++ b/src/main/java/tools/jackson/core/json/UTF8StreamJsonParser.java
@@ -417,7 +417,7 @@ public class UTF8StreamJsonParser
     }
 
     @Override
-    public char[] getTextCharacters() throws JacksonException
+    public char[] getStringCharacters() throws JacksonException
     {
         if (_currToken != null) { // null only before/after document
             switch (_currToken.id()) {
@@ -442,7 +442,7 @@ public class UTF8StreamJsonParser
     }
 
     @Override
-    public int getTextLength() throws JacksonException
+    public int getStringLength() throws JacksonException
     {
         if (_currToken != null) { // null only before/after document
             switch (_currToken.id()) {
@@ -467,7 +467,7 @@ public class UTF8StreamJsonParser
     }
 
     @Override
-    public int getTextOffset() throws JacksonException
+    public int getStringOffset() throws JacksonException
     {
         // Most have offset of 0, only some may have other values:
         if (_currToken != null) {

--- a/src/main/java/tools/jackson/core/json/UTF8StreamJsonParser.java
+++ b/src/main/java/tools/jackson/core/json/UTF8StreamJsonParser.java
@@ -293,7 +293,7 @@ public class UTF8StreamJsonParser
     }
 
     @Override
-    public int getText(Writer writer) throws JacksonException
+    public int getString(Writer writer) throws JacksonException
     {
         try {
             JsonToken t = _currToken;

--- a/src/main/java/tools/jackson/core/json/UTF8StreamJsonParser.java
+++ b/src/main/java/tools/jackson/core/json/UTF8StreamJsonParser.java
@@ -280,7 +280,7 @@ public class UTF8StreamJsonParser
      */
 
     @Override
-    public String getText() throws JacksonException
+    public String getString() throws JacksonException
     {
         if (_currToken == JsonToken.VALUE_STRING) {
             if (_tokenIncomplete) {
@@ -509,7 +509,7 @@ public class UTF8StreamJsonParser
             if (_binaryValue == null) {
                 @SuppressWarnings("resource")
                 ByteArrayBuilder builder = _getByteArrayBuilder();
-                _decodeBase64(getText(), builder, b64variant);
+                _decodeBase64(getString(), builder, b64variant);
                 _binaryValue = builder.toByteArray();
             }
         }
@@ -1654,7 +1654,7 @@ public class UTF8StreamJsonParser
             return null;
         }
         // !!! TODO: optimize this case as well
-        return (nextToken() == JsonToken.VALUE_STRING) ? getText() : null;
+        return (nextToken() == JsonToken.VALUE_STRING) ? getString() : null;
     }
 
     @Override

--- a/src/main/java/tools/jackson/core/json/async/NonBlockingJsonParserBase.java
+++ b/src/main/java/tools/jackson/core/json/async/NonBlockingJsonParserBase.java
@@ -455,7 +455,7 @@ public abstract class NonBlockingJsonParserBase
     }
 
     @Override
-    public char[] getTextCharacters() throws JacksonException
+    public char[] getStringCharacters() throws JacksonException
     {
         if (_currToken != null) { // null only before/after document
             switch (_currToken.id()) {
@@ -476,7 +476,7 @@ public abstract class NonBlockingJsonParserBase
     }
 
     @Override
-    public int getTextLength() throws JacksonException
+    public int getStringLength() throws JacksonException
     {
         if (_currToken != null) { // null only before/after document
             switch (_currToken.id()) {
@@ -497,7 +497,7 @@ public abstract class NonBlockingJsonParserBase
     }
 
     @Override
-    public int getTextOffset() throws JacksonException
+    public int getStringOffset() throws JacksonException
     {
         // Most have offset of 0, only some may have other values:
         if (_currToken != null) {

--- a/src/main/java/tools/jackson/core/json/async/NonBlockingJsonParserBase.java
+++ b/src/main/java/tools/jackson/core/json/async/NonBlockingJsonParserBase.java
@@ -370,7 +370,7 @@ public abstract class NonBlockingJsonParserBase
      * see {@link tools.jackson.core.StreamReadConstraints.Builder#maxStringLength(int)}
      */
     @Override
-    public String getText() throws JacksonException
+    public String getString() throws JacksonException
     {
         if (_currToken == JsonToken.VALUE_STRING) {
             return _textBuffer.contentsAsString();
@@ -531,7 +531,7 @@ public abstract class NonBlockingJsonParserBase
         if (_binaryValue == null) {
             @SuppressWarnings("resource")
             ByteArrayBuilder builder = _getByteArrayBuilder();
-            _decodeBase64(getText(), builder, b64variant);
+            _decodeBase64(getString(), builder, b64variant);
             _binaryValue = builder.toByteArray();
         }
         return _binaryValue;

--- a/src/main/java/tools/jackson/core/json/async/NonBlockingJsonParserBase.java
+++ b/src/main/java/tools/jackson/core/json/async/NonBlockingJsonParserBase.java
@@ -399,7 +399,7 @@ public abstract class NonBlockingJsonParserBase
     }
 
     @Override // since 2.8
-    public int getText(Writer writer) throws JacksonException
+    public int getString(Writer writer) throws JacksonException
     {
         JsonToken t = _currToken;
         try {

--- a/src/main/java/tools/jackson/core/json/async/NonBlockingJsonParserBase.java
+++ b/src/main/java/tools/jackson/core/json/async/NonBlockingJsonParserBase.java
@@ -312,7 +312,7 @@ public abstract class NonBlockingJsonParserBase
      */
 
     @Override
-    public boolean hasTextCharacters()
+    public boolean hasStringCharacters()
     {
         if (_currToken == JsonToken.VALUE_STRING) {
             // yes; is or can be made available efficiently as char[]

--- a/src/main/java/tools/jackson/core/util/JsonParserDelegate.java
+++ b/src/main/java/tools/jackson/core/util/JsonParserDelegate.java
@@ -173,7 +173,7 @@ public class JsonParserDelegate extends JsonParser
     /**********************************************************************
      */
 
-    @Override public String getText() throws JacksonException { return delegate.getText();  }
+    @Override public String getString() throws JacksonException { return delegate.getString();  }
     @Override public boolean hasStringCharacters() { return delegate.hasStringCharacters(); }
     @Override public char[] getTextCharacters() throws JacksonException { return delegate.getTextCharacters(); }
     @Override public int getTextLength() throws JacksonException { return delegate.getTextLength(); }

--- a/src/main/java/tools/jackson/core/util/JsonParserDelegate.java
+++ b/src/main/java/tools/jackson/core/util/JsonParserDelegate.java
@@ -178,7 +178,7 @@ public class JsonParserDelegate extends JsonParser
     @Override public char[] getTextCharacters() throws JacksonException { return delegate.getTextCharacters(); }
     @Override public int getTextLength() throws JacksonException { return delegate.getTextLength(); }
     @Override public int getTextOffset() throws JacksonException { return delegate.getTextOffset(); }
-    @Override public int getText(Writer writer) throws JacksonException { return delegate.getText(writer);  }
+    @Override public int getString(Writer writer) throws JacksonException { return delegate.getString(writer);  }
 
     /*
     /**********************************************************************

--- a/src/main/java/tools/jackson/core/util/JsonParserDelegate.java
+++ b/src/main/java/tools/jackson/core/util/JsonParserDelegate.java
@@ -174,7 +174,7 @@ public class JsonParserDelegate extends JsonParser
      */
 
     @Override public String getText() throws JacksonException { return delegate.getText();  }
-    @Override public boolean hasTextCharacters() { return delegate.hasTextCharacters(); }
+    @Override public boolean hasStringCharacters() { return delegate.hasStringCharacters(); }
     @Override public char[] getTextCharacters() throws JacksonException { return delegate.getTextCharacters(); }
     @Override public int getTextLength() throws JacksonException { return delegate.getTextLength(); }
     @Override public int getTextOffset() throws JacksonException { return delegate.getTextOffset(); }

--- a/src/main/java/tools/jackson/core/util/JsonParserDelegate.java
+++ b/src/main/java/tools/jackson/core/util/JsonParserDelegate.java
@@ -175,9 +175,9 @@ public class JsonParserDelegate extends JsonParser
 
     @Override public String getString() throws JacksonException { return delegate.getString();  }
     @Override public boolean hasStringCharacters() { return delegate.hasStringCharacters(); }
-    @Override public char[] getTextCharacters() throws JacksonException { return delegate.getTextCharacters(); }
-    @Override public int getTextLength() throws JacksonException { return delegate.getTextLength(); }
-    @Override public int getTextOffset() throws JacksonException { return delegate.getTextOffset(); }
+    @Override public char[] getStringCharacters() throws JacksonException { return delegate.getStringCharacters(); }
+    @Override public int getStringLength() throws JacksonException { return delegate.getStringLength(); }
+    @Override public int getStringOffset() throws JacksonException { return delegate.getStringOffset(); }
     @Override public int getString(Writer writer) throws JacksonException { return delegate.getString(writer);  }
 
     /*

--- a/src/test/java/perf/ManualIntRead.java
+++ b/src/test/java/perf/ManualIntRead.java
@@ -60,7 +60,7 @@ public class ManualIntRead extends ManualPerfTestBase
         while ((t = p.nextToken()) != null) {
             // force decoding/reading of scalar values too (booleans are fine, nulls too)
             if (t == JsonToken.VALUE_STRING) {
-                p.getText();
+                p.getString();
             } else if (t == JsonToken.VALUE_NUMBER_INT) {
                 p.getIntValue();
             }

--- a/src/test/java/perf/ManualReadPerfWithMedia.java
+++ b/src/test/java/perf/ManualReadPerfWithMedia.java
@@ -72,7 +72,7 @@ public class ManualReadPerfWithMedia extends ManualPerfTestBase
         while ((t = p.nextToken()) != null) {
             // force decoding/reading of scalar values too (booleans are fine, nulls too)
             if (t == JsonToken.VALUE_STRING) {
-                p.getText();
+                p.getString();
             } else if (t == JsonToken.VALUE_NUMBER_INT) {
                 p.getLongValue();
             }

--- a/src/test/java/perf/ManualSmallTokenRead.java
+++ b/src/test/java/perf/ManualSmallTokenRead.java
@@ -60,7 +60,7 @@ public class ManualSmallTokenRead extends ManualPerfTestBase
         while ((t = p.nextToken()) != null) {
             // force decoding/reading of scalar values too (booleans are fine, nulls too)
             if (t == JsonToken.VALUE_STRING) {
-                p.getText();
+                p.getString();
             } else if (t == JsonToken.VALUE_NUMBER_INT) {
                 p.getLongValue();
             }

--- a/src/test/java/tools/jackson/core/JUnit5TestBase.java
+++ b/src/test/java/tools/jackson/core/JUnit5TestBase.java
@@ -307,7 +307,7 @@ public class JUnit5TestBase
         int actLen = p.getTextLength();
         char[] ch = p.getTextCharacters();
         String str2 = new String(ch, p.getTextOffset(), actLen);
-        String str = p.getText();
+        String str = p.getString();
 
         if (str.length() !=  actLen) {
             fail("Internal problem (p.token == "+p.currentToken()+"): p.getText().length() ['"+str+"'] == "+str.length()+"; p.getTextLength() == "+actLen);

--- a/src/test/java/tools/jackson/core/JUnit5TestBase.java
+++ b/src/test/java/tools/jackson/core/JUnit5TestBase.java
@@ -304,9 +304,9 @@ public class JUnit5TestBase
     public static String getAndVerifyText(JsonParser p)
     {
         // Ok, let's verify other accessors
-        int actLen = p.getTextLength();
-        char[] ch = p.getTextCharacters();
-        String str2 = new String(ch, p.getTextOffset(), actLen);
+        int actLen = p.getStringLength();
+        char[] ch = p.getStringCharacters();
+        String str2 = new String(ch, p.getStringOffset(), actLen);
         String str = p.getString();
 
         if (str.length() !=  actLen) {

--- a/src/test/java/tools/jackson/core/base64/Base64BinaryParsingTest.java
+++ b/src/test/java/tools/jackson/core/base64/Base64BinaryParsingTest.java
@@ -192,7 +192,7 @@ class Base64BinaryParsingTest
         // second, access String first
         p = createParser(JSON_F, mode, doc);
         assertToken(JsonToken.VALUE_STRING, p.nextToken());
-        /*String str =*/ p.getText();
+        /*String str =*/ p.getString();
         try {
             /*byte[] b =*/ p.getBinaryValue(Base64Variants.MIME);
             fail("Should not pass");
@@ -250,7 +250,7 @@ class Base64BinaryParsingTest
 
                 // minor twist: for even-length values, force access as String first:
                 if ((len & 1) == 0) {
-                    assertNotNull(p.getText());
+                    assertNotNull(p.getString());
                 }
 
                 byte[] data = null;

--- a/src/test/java/tools/jackson/core/base64/Base64GenerationTest.java
+++ b/src/test/java/tools/jackson/core/base64/Base64GenerationTest.java
@@ -173,7 +173,7 @@ class Base64GenerationTest
                 break;
             }
             assertEquals(JsonToken.VALUE_STRING, jp.nextToken());
-            String actualValue = jp.getText();
+            String actualValue = jp.getString();
             jp.close();
             assertEquals(WIKIPEDIA_BASE64_ENCODED, actualValue);
         }

--- a/src/test/java/tools/jackson/core/filter/BasicParserFilteringTest.java
+++ b/src/test/java/tools/jackson/core/filter/BasicParserFilteringTest.java
@@ -667,7 +667,7 @@ class BasicParserFilteringTest extends JUnit5TestBase
 
         assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
         assertEquals("value", p.currentName());
-        assertEquals("value", p.getText());
+        assertEquals("value", p.getString());
 
         assertToken(JsonToken.VALUE_NUMBER_INT, p.nextToken());
         assertEquals(JsonToken.VALUE_NUMBER_INT, p.currentToken());

--- a/src/test/java/tools/jackson/core/filter/ParserFiltering700Test.java
+++ b/src/test/java/tools/jackson/core/filter/ParserFiltering700Test.java
@@ -48,7 +48,7 @@ class ParserFiltering700Test extends JUnit5TestBase
         assertEquals("value", p.currentName());
         // 19-Jul-2021, tatu: while not ideal, existing contract is that "getText()"
         //    ought to return property name as well...
-        assertEquals("value", p.getText());
+        assertEquals("value", p.getString());
 
         assertToken(JsonToken.VALUE_NUMBER_INT, p.nextToken());
         assertEquals(12, p.getIntValue());
@@ -77,12 +77,12 @@ class ParserFiltering700Test extends JUnit5TestBase
         assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
         assertEquals("value", p.currentName());
         // as earlier, this needs to hold true too
-        assertEquals("value", p.getText());
+        assertEquals("value", p.getString());
 
         assertToken(JsonToken.START_OBJECT, p.nextToken());
         assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
         assertEquals("a", p.currentName());
-        assertEquals("a", p.getText());
+        assertEquals("a", p.getString());
         assertToken(JsonToken.VALUE_NUMBER_INT, p.nextToken());
         assertEquals(12, p.getIntValue());
         assertEquals(JsonToken.END_OBJECT, p.nextToken());
@@ -119,11 +119,11 @@ class ParserFiltering700Test extends JUnit5TestBase
         if (useNextName) {
             assertEquals("value", p.nextName());
             // as earlier, this needs to hold true too
-            assertEquals("value", p.getText());
+            assertEquals("value", p.getString());
             assertToken(JsonToken.START_OBJECT, p.nextToken());
             assertTrue(p.isExpectedStartObjectToken());
             assertEquals("a", p.nextName());
-            assertEquals("a", p.getText());
+            assertEquals("a", p.getString());
             assertToken(JsonToken.VALUE_NUMBER_INT, p.nextToken());
             assertEquals(99, p.getIntValue());
             assertNull(p.nextName());
@@ -131,12 +131,12 @@ class ParserFiltering700Test extends JUnit5TestBase
         } else {
             assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
             assertEquals("value", p.currentName());
-            assertEquals("value", p.getText());
+            assertEquals("value", p.getString());
             assertToken(JsonToken.START_OBJECT, p.nextToken());
             assertTrue(p.isExpectedStartObjectToken());
             assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
             assertEquals("a", p.currentName());
-            assertEquals("a", p.getText());
+            assertEquals("a", p.getString());
             assertToken(JsonToken.VALUE_NUMBER_INT, p.nextToken());
             assertEquals(99, p.getIntValue());
             assertEquals(JsonToken.END_OBJECT, p.nextToken());

--- a/src/test/java/tools/jackson/core/fuzz/Fuzz32208UTF32ParseTest.java
+++ b/src/test/java/tools/jackson/core/fuzz/Fuzz32208UTF32ParseTest.java
@@ -28,7 +28,7 @@ class Fuzz32208UTF32ParseTest extends JUnit5TestBase
         JsonParser p = f.createParser(ObjectReadContext.empty(), DOC);
         try {
             assertToken(JsonToken.VALUE_STRING, p.nextToken());
-            String text = p.getText();
+            String text = p.getString();
             fail("Should not have passed; got text with length of: "+text.length());
         } catch (JacksonIOException e) {
             verifyException(e, "Invalid UTF-32 character ");

--- a/src/test/java/tools/jackson/core/fuzz/Fuzz34435ParseTest.java
+++ b/src/test/java/tools/jackson/core/fuzz/Fuzz34435ParseTest.java
@@ -43,7 +43,7 @@ class Fuzz34435ParseTest extends JUnit5TestBase
                     p.currentName();
                     break;
                 case VALUE_STRING:
-                    p.getText();
+                    p.getString();
                     break;
                 default:
                 }

--- a/src/test/java/tools/jackson/core/json/JsonFactoryTest.java
+++ b/src/test/java/tools/jackson/core/json/JsonFactoryTest.java
@@ -231,7 +231,7 @@ public class JsonFactoryTest
         JsonParser jsonParser = new JsonFactory()
                 .createParser(ObjectReadContext.empty(), inputStream);
 
-        assertEquals(jsonParser.nextTextValue(), "value");
+        assertEquals(jsonParser.nextStringValue(), "value");
     }
 
     public void test_createParser_File() throws Exception
@@ -241,7 +241,7 @@ public class JsonFactoryTest
         JsonParser jsonParser = new JsonFactory()
                 .createParser(ObjectReadContext.empty(), path.toFile());
 
-        assertEquals(jsonParser.nextTextValue(), "value");
+        assertEquals(jsonParser.nextStringValue(), "value");
     }
 
     public void test_createParser_Path() throws Exception
@@ -251,7 +251,7 @@ public class JsonFactoryTest
         JsonParser jsonParser = new JsonFactory()
                 .createParser(ObjectReadContext.empty(), path);
 
-        assertEquals(jsonParser.nextTextValue(), "value");
+        assertEquals(jsonParser.nextStringValue(), "value");
     }
 
     public void test_createParser_Url() throws Exception
@@ -261,7 +261,7 @@ public class JsonFactoryTest
         JsonParser jsonParser = new JsonFactory()
                 .createParser(ObjectReadContext.empty(), path.toUri().toURL());
 
-        assertEquals(jsonParser.nextTextValue(), "value");
+        assertEquals(jsonParser.nextStringValue(), "value");
     }
 
     public void test_createParser_Reader() throws Exception
@@ -270,7 +270,7 @@ public class JsonFactoryTest
         JsonParser jsonParser = new JsonFactory()
                 .createParser(ObjectReadContext.empty(), reader);
 
-        assertEquals(jsonParser.nextTextValue(), "value");
+        assertEquals(jsonParser.nextStringValue(), "value");
     }
 
     public void test_createParser_ByteArray() throws Exception
@@ -279,7 +279,7 @@ public class JsonFactoryTest
         JsonParser jsonParser = new JsonFactory()
                 .createParser(ObjectReadContext.empty(), bytes);
 
-        assertEquals(jsonParser.nextTextValue(), "value");
+        assertEquals(jsonParser.nextStringValue(), "value");
     }
 
     public void test_createParser_String() throws Exception
@@ -288,7 +288,7 @@ public class JsonFactoryTest
         JsonParser jsonParser = new JsonFactory()
                 .createParser(ObjectReadContext.empty(), string);
 
-        assertEquals(jsonParser.nextTextValue(), "value");
+        assertEquals(jsonParser.nextStringValue(), "value");
     }
 
     public void test_createParser_CharArray() throws Exception
@@ -297,7 +297,7 @@ public class JsonFactoryTest
         JsonParser jsonParser = new JsonFactory()
                 .createParser(ObjectReadContext.empty(), chars);
 
-        assertEquals(jsonParser.nextTextValue(), "value");
+        assertEquals(jsonParser.nextStringValue(), "value");
     }
 
     public void test_createParser_DataInput() throws Exception
@@ -307,7 +307,7 @@ public class JsonFactoryTest
         JsonParser jsonParser = new JsonFactory()
                 .createParser(ObjectReadContext.empty(), dataInput);
 
-        assertEquals(jsonParser.nextTextValue(), "value");
+        assertEquals(jsonParser.nextStringValue(), "value");
     }
 
 

--- a/src/test/java/tools/jackson/core/json/JsonReadFeaturesTest.java
+++ b/src/test/java/tools/jackson/core/json/JsonReadFeaturesTest.java
@@ -101,7 +101,7 @@ class JsonReadFeaturesTest
         try (JsonParser p = useStream ? createParserUsingStream(f, JSON, "UTF-8") : createParserUsingReader(f, JSON)) {
             assertToken(JsonToken.START_ARRAY, p.nextToken());
             p.nextToken();
-            p.getText();
+            p.getString();
             fail("Expected exception");
         } catch (StreamReadException e) {
             verifyException(e, "Illegal unquoted character");
@@ -120,9 +120,9 @@ class JsonReadFeaturesTest
 
         assertToken(JsonToken.START_OBJECT, p.nextToken());
         assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
-        assertEquals(PROP_NAME, p.getText());
+        assertEquals(PROP_NAME, p.getString());
         assertToken(JsonToken.VALUE_STRING, p.nextToken());
-        assertEquals(VALUE, p.getText());
+        assertEquals(VALUE, p.getString());
         assertToken(JsonToken.END_OBJECT, p.nextToken());
         p.close();
     }

--- a/src/test/java/tools/jackson/core/json/StringGenerationFromReaderTest.java
+++ b/src/test/java/tools/jackson/core/json/StringGenerationFromReaderTest.java
@@ -163,7 +163,7 @@ class StringGenerationFromReaderTest
         }
         assertToken(JsonToken.START_ARRAY, p.nextToken());
         assertToken(JsonToken.VALUE_STRING, p.nextToken());
-        assertEquals(text, p.getText());
+        assertEquals(text, p.getString());
         assertToken(JsonToken.END_ARRAY, p.nextToken());
         p.close();
     }
@@ -184,7 +184,7 @@ class StringGenerationFromReaderTest
             assertEquals(JsonToken.START_ARRAY, p.nextToken());
             JsonToken t = p.nextToken();
             assertEquals(JsonToken.VALUE_STRING, t);
-            assertEquals(VALUE, p.getText());
+            assertEquals(VALUE, p.getString());
             assertEquals(JsonToken.END_ARRAY, p.nextToken());
             assertNull(p.nextToken());
             p.close();
@@ -206,7 +206,7 @@ class StringGenerationFromReaderTest
         assertEquals(JsonToken.START_ARRAY, p.nextToken());
         JsonToken t = p.nextToken();
         assertEquals(JsonToken.VALUE_STRING, t);
-        String act = p.getText();
+        String act = p.getString();
         if (!text.equals(act)) {
             if (text.length() != act.length()) {
                 fail("Expected string length "+text.length()+", actual "+act.length());
@@ -267,7 +267,7 @@ class StringGenerationFromReaderTest
         offset = 0;
         while (p.nextToken() == JsonToken.VALUE_STRING) {
             // Let's verify, piece by piece
-            String act = p.getText();
+            String act = p.getString();
             String exp = text.substring(offset, offset+act.length());
             if (act.length() != exp.length()) {
                 fail("String segment ["+offset+" - "+(offset+act.length())+"[ differs; exp length "+exp+", actual "+act);

--- a/src/test/java/tools/jackson/core/json/StringGenerationTest.java
+++ b/src/test/java/tools/jackson/core/json/StringGenerationTest.java
@@ -163,7 +163,7 @@ class StringGenerationTest
         }
         assertToken(JsonToken.START_ARRAY, p.nextToken());
         assertToken(JsonToken.VALUE_STRING, p.nextToken());
-        assertEquals(text, p.getText());
+        assertEquals(text, p.getString());
         assertToken(JsonToken.END_ARRAY, p.nextToken());
         p.close();
     }
@@ -189,7 +189,7 @@ class StringGenerationTest
             assertEquals(JsonToken.START_ARRAY, p.nextToken());
             JsonToken t = p.nextToken();
             assertEquals(JsonToken.VALUE_STRING, t);
-            assertEquals(VALUE, p.getText());
+            assertEquals(VALUE, p.getString());
             assertEquals(JsonToken.END_ARRAY, p.nextToken());
             assertNull(p.nextToken());
             p.close();
@@ -217,7 +217,7 @@ class StringGenerationTest
         assertEquals(JsonToken.START_ARRAY, p.nextToken());
         JsonToken t = p.nextToken();
         assertEquals(JsonToken.VALUE_STRING, t);
-        String act = p.getText();
+        String act = p.getString();
         if (!text.equals(act)) {
             if (text.length() != act.length()) {
                 fail("Expected string length "+text.length()+", actual "+act.length());
@@ -283,7 +283,7 @@ class StringGenerationTest
         offset = 0;
         while (p.nextToken() == JsonToken.VALUE_STRING) {
             // Let's verify, piece by piece
-            String act = p.getText();
+            String act = p.getString();
             String exp = text.substring(offset, offset+act.length());
             if (act.length() != exp.length()) {
                 fail("String segment ["+offset+" - "+(offset+act.length())+"[ differs; exp length "+exp+", actual "+act);

--- a/src/test/java/tools/jackson/core/json/TestCharEscaping.java
+++ b/src/test/java/tools/jackson/core/json/TestCharEscaping.java
@@ -66,7 +66,7 @@ class TestCharEscaping
             JsonToken t = jp.nextToken();
             assertToken(JsonToken.VALUE_STRING, t);
             // and if not, should get it here:
-            jp.getText();
+            jp.getString();
             fail("Expected an exception for un-escaped linefeed in string value");
         } catch (StreamReadException jex) {
             verifyException(jex, "has to be escaped");
@@ -90,7 +90,7 @@ class TestCharEscaping
         JsonParser jp = createParser(JSON_F, readMode, DOC);
         assertToken(JsonToken.START_ARRAY, jp.nextToken());
         assertToken(JsonToken.VALUE_STRING, jp.nextToken());
-        assertEquals("LF=\n", jp.getText());
+        assertEquals("LF=\n", jp.getString());
         jp.close();
 
         // Note: must split Strings, so that javac won't try to handle
@@ -98,21 +98,21 @@ class TestCharEscaping
         jp = createParser(JSON_F, readMode, "[\"NULL:\\u0000!\"]");
         assertToken(JsonToken.START_ARRAY, jp.nextToken());
         assertToken(JsonToken.VALUE_STRING, jp.nextToken());
-        assertEquals("NULL:\0!", jp.getText());
+        assertEquals("NULL:\0!", jp.getString());
         jp.close();
 
         // Then just a single char escaping
         jp = createParser(JSON_F, readMode, "[\"\\u0123\"]");
         assertToken(JsonToken.START_ARRAY, jp.nextToken());
         assertToken(JsonToken.VALUE_STRING, jp.nextToken());
-        assertEquals("\u0123", jp.getText());
+        assertEquals("\u0123", jp.getString());
         jp.close();
 
         // And then double sequence
         jp = createParser(JSON_F, readMode, "[\"\\u0041\\u0043\"]");
         assertToken(JsonToken.START_ARRAY, jp.nextToken());
         assertToken(JsonToken.VALUE_STRING, jp.nextToken());
-        assertEquals("AC", jp.getText());
+        assertEquals("AC", jp.getString());
         jp.close();
     }
 
@@ -158,7 +158,7 @@ class TestCharEscaping
         assertToken(JsonToken.START_ARRAY, jp.nextToken());
         try {
             jp.nextToken();
-            jp.getText();
+            jp.getString();
             fail("Expected an exception for unclosed ARRAY");
         } catch (StreamReadException jpe) {
             verifyException(jpe, "for character escape");
@@ -183,7 +183,7 @@ class TestCharEscaping
         JsonParser jp = createParser(JSON_F, readMode, DOC);
         assertToken(JsonToken.START_ARRAY, jp.nextToken());
         assertToken(JsonToken.VALUE_STRING, jp.nextToken());
-        assertEquals("A1234", jp.getText());
+        assertEquals("A1234", jp.getString());
         jp.close();
     }
 
@@ -213,7 +213,7 @@ class TestCharEscaping
         assertToken(JsonToken.VALUE_STRING, p.nextToken());
         // this is where we should get proper exception
         try {
-            p.getText();
+            p.getString();
             fail("Should not pass");
         } catch (StreamReadException e) {
             verifyException(e, "Unexpected character");

--- a/src/test/java/tools/jackson/core/json/TestUnicode.java
+++ b/src/test/java/tools/jackson/core/json/TestUnicode.java
@@ -32,11 +32,11 @@ class TestUnicode extends tools.jackson.core.JUnit5TestBase
         assertToken(JsonToken.START_OBJECT, jp.nextToken());
         assertToken(JsonToken.PROPERTY_NAME, jp.nextToken());
         if (checkText) {
-            assertEquals("text", jp.getText());
+            assertEquals("text", jp.getString());
         }
         assertToken(JsonToken.VALUE_STRING, jp.nextToken());
         if (checkText) {
-            assertEquals("\uD83D\uDE03", jp.getText());
+            assertEquals("\uD83D\uDE03", jp.getString());
         }
         assertToken(JsonToken.END_OBJECT, jp.nextToken());
         jp.close();

--- a/src/test/java/tools/jackson/core/json/async/AsyncScalarArrayTest.java
+++ b/src/test/java/tools/jackson/core/json/async/AsyncScalarArrayTest.java
@@ -111,7 +111,7 @@ class AsyncScalarArrayTest extends AsyncTestBase
             String asStr = String.valueOf(values[i]);
             assertEquals(asStr, r.currentText());
             StringWriter sw = new StringWriter();
-            assertEquals(asStr.length(), r.parser().getText(sw));
+            assertEquals(asStr.length(), r.parser().getString(sw));
             assertEquals(asStr, sw.toString());
         }
         assertToken(JsonToken.END_ARRAY, r.nextToken());

--- a/src/test/java/tools/jackson/core/json/async/AsyncSimpleNestedTest.java
+++ b/src/test/java/tools/jackson/core/json/async/AsyncSimpleNestedTest.java
@@ -41,7 +41,7 @@ class AsyncSimpleNestedTest extends AsyncTestBase
     {
         try (AsyncReaderWrapper r = asyncForBytes(f, readSize, data, offset)) {
             assertToken(JsonToken.START_OBJECT, r.nextToken());
-            assertFalse(r.parser().hasTextCharacters());
+            assertFalse(r.parser().hasStringCharacters());
 
             assertToken(JsonToken.PROPERTY_NAME, r.nextToken());
             assertEquals("foobar", r.currentName());
@@ -106,7 +106,7 @@ class AsyncSimpleNestedTest extends AsyncTestBase
     {
         try (AsyncReaderWrapper r = asyncForBytes(f, readSize, data, offset)) {
             assertToken(JsonToken.START_ARRAY, r.nextToken());
-            assertFalse(r.parser().hasTextCharacters());
+            assertFalse(r.parser().hasStringCharacters());
 
             assertToken(JsonToken.VALUE_TRUE, r.nextToken());
             assertToken(JsonToken.START_OBJECT, r.nextToken());

--- a/src/test/java/tools/jackson/core/json/async/AsyncSimpleObjectTest.java
+++ b/src/test/java/tools/jackson/core/json/async/AsyncSimpleObjectTest.java
@@ -60,9 +60,9 @@ class AsyncSimpleObjectTest extends AsyncTestBase
         // by default no cheap access to char[] version:
         assertFalse(r.parser().hasStringCharacters());
         // but...
-        char[] ch = r.parser().getTextCharacters();
-        assertEquals(0, r.parser().getTextOffset());
-        assertEquals(1, r.parser().getTextLength());
+        char[] ch = r.parser().getStringCharacters();
+        assertEquals(0, r.parser().getStringOffset());
+        assertEquals(1, r.parser().getStringLength());
         assertEquals("a", new String(ch, 0, 1));
         assertTrue(r.parser().hasStringCharacters());
 

--- a/src/test/java/tools/jackson/core/json/async/AsyncSimpleObjectTest.java
+++ b/src/test/java/tools/jackson/core/json/async/AsyncSimpleObjectTest.java
@@ -58,13 +58,13 @@ class AsyncSimpleObjectTest extends AsyncTestBase
         assertToken(JsonToken.PROPERTY_NAME, r.nextToken());
         assertEquals("a", r.currentText());
         // by default no cheap access to char[] version:
-        assertFalse(r.parser().hasTextCharacters());
+        assertFalse(r.parser().hasStringCharacters());
         // but...
         char[] ch = r.parser().getTextCharacters();
         assertEquals(0, r.parser().getTextOffset());
         assertEquals(1, r.parser().getTextLength());
         assertEquals("a", new String(ch, 0, 1));
-        assertTrue(r.parser().hasTextCharacters());
+        assertTrue(r.parser().hasStringCharacters());
 
         assertToken(JsonToken.VALUE_TRUE, r.nextToken());
 

--- a/src/test/java/tools/jackson/core/json/async/AsyncStringObjectTest.java
+++ b/src/test/java/tools/jackson/core/json/async/AsyncStringObjectTest.java
@@ -66,7 +66,7 @@ class AsyncStringObjectTest extends AsyncTestBase
             assertToken(JsonToken.VALUE_STRING, r.nextToken());
             // also, should always be accessible this way:
             if (verifyContents) {
-                assertTrue(r.parser().hasTextCharacters());
+                assertTrue(r.parser().hasStringCharacters());
                 assertEquals(UNICODE_LONG_NAME, r.currentText());
             }
 

--- a/src/test/java/tools/jackson/core/read/DataInputTest.java
+++ b/src/test/java/tools/jackson/core/read/DataInputTest.java
@@ -44,7 +44,7 @@ class DataInputTest
     {
         JsonParser p = createParser(JSON_F, MODE_DATA_INPUT, "\"foobar\" ");
         assertToken(JsonToken.VALUE_STRING, p.nextToken());
-        assertEquals("foobar", p.getText());
+        assertEquals("foobar", p.getString());
         assertNull(p.nextToken());
         p.close();
     }

--- a/src/test/java/tools/jackson/core/read/NextNameParserTest.java
+++ b/src/test/java/tools/jackson/core/read/NextNameParserTest.java
@@ -53,7 +53,7 @@ class NextNameParserTest
         assertEquals("vector", p.nextName());
         assertToken(JsonToken.START_ARRAY, p.nextToken());
         assertToken(JsonToken.VALUE_STRING, p.nextToken());
-        assertEquals("yes", p.getText());
+        assertEquals("yes", p.getString());
         assertToken(JsonToken.VALUE_FALSE, p.nextToken());
         assertToken(JsonToken.END_ARRAY, p.nextToken());
 
@@ -62,7 +62,7 @@ class NextNameParserTest
 
         assertEquals("name", p.nextName());
         assertToken(JsonToken.VALUE_STRING, p.nextToken());
-        assertEquals("Bob", p.getText());
+        assertEquals("Bob", p.getString());
 
         assertNull(p.nextName());
         assertToken(JsonToken.END_OBJECT, p.currentToken());
@@ -74,7 +74,7 @@ class NextNameParserTest
         assertToken(JsonToken.START_OBJECT, p.nextToken());
         assertEquals("message", p.nextName());
         assertToken(JsonToken.VALUE_STRING, p.nextToken());
-        assertEquals("hello", p.getText());
+        assertEquals("hello", p.getString());
         assertEquals("value", p.nextName());
         assertToken(JsonToken.VALUE_NUMBER_INT, p.nextToken());
         assertEquals(42, p.getIntValue());

--- a/src/test/java/tools/jackson/core/read/NextNameWithMatcherTest.java
+++ b/src/test/java/tools/jackson/core/read/NextNameWithMatcherTest.java
@@ -80,7 +80,7 @@ public class NextNameWithMatcherTest
         assertEquals(names.get(2), p.currentName());
         assertEquals(PropertyNameMatcher.MATCH_ODD_TOKEN, p.nextNameMatch(matcher));
         assertToken(JsonToken.VALUE_STRING, p.currentToken());
-        assertEquals("Billy-Bob Burger", p.getText());
+        assertEquals("Billy-Bob Burger", p.getString());
 
         assertEquals(PropertyNameMatcher.MATCH_UNKNOWN_NAME, p.nextNameMatch(matcher));
         assertEquals("extra", p.currentName());

--- a/src/test/java/tools/jackson/core/read/NextXxxAccessTest.java
+++ b/src/test/java/tools/jackson/core/read/NextXxxAccessTest.java
@@ -341,13 +341,13 @@ class NextXxxAccessTest
     {
         final String DOC = a2q("{'a':'123','b':5,'c':[false,'foo']}");
         JsonParser p = createParser(mode, DOC);
-        assertNull(p.nextTextValue());
+        assertNull(p.nextStringValue());
         assertToken(JsonToken.START_OBJECT, p.currentToken());
-        assertNull(p.nextTextValue());
+        assertNull(p.nextStringValue());
         assertToken(JsonToken.PROPERTY_NAME, p.currentToken());
         assertEquals("a", p.currentName());
 
-        assertEquals("123", p.nextTextValue());
+        assertEquals("123", p.nextStringValue());
         assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
         assertEquals("b", p.currentName());
         assertNull(p.nextName());
@@ -355,18 +355,18 @@ class NextXxxAccessTest
 
         assertEquals("c", p.nextName());
 
-        assertNull(p.nextTextValue());
+        assertNull(p.nextStringValue());
         assertToken(JsonToken.START_ARRAY, p.currentToken());
-        assertNull(p.nextTextValue());
+        assertNull(p.nextStringValue());
         assertToken(JsonToken.VALUE_FALSE, p.currentToken());
-        assertEquals("foo", p.nextTextValue());
+        assertEquals("foo", p.nextStringValue());
 
-        assertNull(p.nextTextValue());
+        assertNull(p.nextStringValue());
         assertToken(JsonToken.END_ARRAY, p.currentToken());
-        assertNull(p.nextTextValue());
+        assertNull(p.nextStringValue());
         assertToken(JsonToken.END_OBJECT, p.currentToken());
         if (mode != MODE_DATA_INPUT) {
-            assertNull(p.nextTextValue());
+            assertNull(p.nextStringValue());
             assertNull(p.currentToken());
         }
         p.close();

--- a/src/test/java/tools/jackson/core/read/NextXxxAccessTest.java
+++ b/src/test/java/tools/jackson/core/read/NextXxxAccessTest.java
@@ -151,7 +151,7 @@ class NextXxxAccessTest
         assertTrue(p.nextName(NAME));
         assertToken(JsonToken.PROPERTY_NAME, p.currentToken());
         assertEquals(NAME.getValue(), p.currentName());
-        assertEquals(NAME.getValue(), p.getText());
+        assertEquals(NAME.getValue(), p.getString());
         assertFalse(p.nextName(NAME));
         assertToken(JsonToken.VALUE_NUMBER_INT, p.currentToken());
         assertEquals(123, p.getIntValue());
@@ -184,7 +184,7 @@ class NextXxxAccessTest
         assertFalse(p.nextName(new SerializedString("Nam")));
         assertToken(JsonToken.PROPERTY_NAME, p.currentToken());
         assertEquals(NAME.getValue(), p.currentName());
-        assertEquals(NAME.getValue(), p.getText());
+        assertEquals(NAME.getValue(), p.getString());
         assertFalse(p.nextName(NAME));
         assertToken(JsonToken.VALUE_NUMBER_INT, p.currentToken());
         assertEquals(123, p.getIntValue());
@@ -220,7 +220,7 @@ class NextXxxAccessTest
         assertTrue(p.nextName(NAME));
         assertToken(JsonToken.PROPERTY_NAME, p.currentToken());
         assertEquals(NAME.getValue(), p.currentName());
-        assertEquals(NAME.getValue(), p.getText());
+        assertEquals(NAME.getValue(), p.getString());
         assertFalse(p.nextName(NAME));
         assertToken(JsonToken.VALUE_NUMBER_INT, p.currentToken());
         assertEquals(123, p.getIntValue());
@@ -255,7 +255,7 @@ class NextXxxAccessTest
         assertEquals("name", p.nextName());
         assertToken(JsonToken.PROPERTY_NAME, p.currentToken());
         assertEquals("name", p.currentName());
-        assertEquals("name", p.getText());
+        assertEquals("name", p.getString());
         assertNull(p.nextName());
         assertToken(JsonToken.VALUE_NUMBER_INT, p.currentToken());
         assertEquals(123, p.getIntValue());
@@ -384,7 +384,7 @@ class NextXxxAccessTest
 
         assertEquals(0, p.nextIntValue(0));
         assertToken(JsonToken.VALUE_STRING, p.currentToken());
-        assertEquals("123", p.getText());
+        assertEquals("123", p.getString());
         assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
         assertEquals("b", p.currentName());
         assertEquals(5, p.nextIntValue(0));
@@ -420,7 +420,7 @@ class NextXxxAccessTest
 
         assertEquals(0L, p.nextLongValue(0L));
         assertToken(JsonToken.VALUE_STRING, p.currentToken());
-        assertEquals("xyz", p.getText());
+        assertEquals("xyz", p.getString());
         assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
         assertEquals("b", p.currentName());
         assertEquals(-59L, p.nextLongValue(0L));
@@ -456,7 +456,7 @@ class NextXxxAccessTest
 
         assertNull(p.nextBooleanValue());
         assertToken(JsonToken.VALUE_STRING, p.currentToken());
-        assertEquals("xyz", p.getText());
+        assertEquals("xyz", p.getString());
         assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
         assertEquals("b", p.currentName());
         assertEquals(Boolean.TRUE, p.nextBooleanValue());
@@ -521,7 +521,7 @@ class NextXxxAccessTest
         assertEquals(JsonToken.START_OBJECT, parser.nextToken());
         assertTrue(parser.nextName(fieldName));
         assertEquals(JsonToken.VALUE_STRING, parser.nextToken());
-        assertEquals("value", parser.getText());
+        assertEquals("value", parser.getString());
         assertEquals(JsonToken.END_OBJECT, parser.nextToken());
         if (mode != MODE_DATA_INPUT) {
             assertNull(parser.nextToken());

--- a/src/test/java/tools/jackson/core/read/NonStandardAposQuotedNamesTest.java
+++ b/src/test/java/tools/jackson/core/read/NonStandardAposQuotedNamesTest.java
@@ -93,26 +93,26 @@ class NonStandardAposQuotedNamesTest
         assertToken(JsonToken.START_OBJECT, p.nextToken());
 
         assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
-        assertEquals("a", p.getText());
+        assertEquals("a", p.getString());
         assertToken(JsonToken.VALUE_NUMBER_INT, p.nextToken());
-        assertEquals("1", p.getText());
+        assertEquals("1", p.getString());
         assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
-        assertEquals("foobar", p.getText());
+        assertEquals("foobar", p.getString());
         assertToken(JsonToken.VALUE_STRING, p.nextToken());
-        assertEquals("b", p.getText());
+        assertEquals("b", p.getString());
         assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
-        assertEquals("_abc\u00A0e'23'", p.getText());
+        assertEquals("_abc\u00A0e'23'", p.getString());
         assertToken(JsonToken.VALUE_STRING, p.nextToken());
-        assertEquals("d'foo'", p.getText());
+        assertEquals("d'foo'", p.getString());
         assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
-        assertEquals("\"", p.getText());
+        assertEquals("\"", p.getString());
         assertToken(JsonToken.VALUE_STRING, p.nextToken());
         //assertEquals("\"\"", p.getText());
 
         assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
-        assertEquals("", p.getText());
+        assertEquals("", p.getString());
         assertToken(JsonToken.VALUE_STRING, p.nextToken());
-        assertEquals("", p.getText());
+        assertEquals("", p.getString());
 
         assertToken(JsonToken.END_OBJECT, p.nextToken());
         p.close();
@@ -166,7 +166,7 @@ class NonStandardAposQuotedNamesTest
 
         assertToken(JsonToken.START_ARRAY, p.nextToken());
         assertToken(JsonToken.VALUE_STRING, p.nextToken());
-        assertEquals("16'", p.getText());
+        assertEquals("16'", p.getString());
         assertToken(JsonToken.END_ARRAY, p.nextToken());
         p.close();
     }
@@ -196,7 +196,7 @@ class NonStandardAposQuotedNamesTest
         assertToken(JsonToken.START_OBJECT, p.nextToken());
         assertEquals(expKey, p.nextName());
         assertToken(JsonToken.VALUE_STRING, p.nextToken());
-        assertEquals("value", p.getText());
+        assertEquals("value", p.getString());
         assertToken(JsonToken.END_OBJECT, p.nextToken());
         p.close();
     }
@@ -226,7 +226,7 @@ class NonStandardAposQuotedNamesTest
         assertToken(JsonToken.START_OBJECT, p.nextToken());
         assertEquals("bar", p.nextName());
         assertToken(JsonToken.VALUE_STRING, p.nextToken());
-        assertEquals(expValue, p.getText());
+        assertEquals(expValue, p.getString());
         assertToken(JsonToken.END_OBJECT, p.nextToken());
         p.close();
     }

--- a/src/test/java/tools/jackson/core/read/NonStandardJsonReadFeaturesTest.java
+++ b/src/test/java/tools/jackson/core/read/NonStandardJsonReadFeaturesTest.java
@@ -87,7 +87,7 @@ class NonStandardParserFeaturesTest
         JsonParser p = createParser(STD_F, mode, JSON);
         try {
             p.nextToken();
-            p.getText();
+            p.getString();
             fail("Should have thrown an exception for doc <"+JSON+">");
         } catch (StreamReadException e) {
             verifyException(e, "unrecognized character escape");
@@ -100,7 +100,7 @@ class NonStandardParserFeaturesTest
                 .build();
         p = createParser(f, mode, JSON);
         assertToken(JsonToken.VALUE_STRING, p.nextToken());
-        assertEquals("'", p.getText());
+        assertEquals("'", p.getString());
         p.close();
     }
 
@@ -114,7 +114,7 @@ class NonStandardParserFeaturesTest
         JsonParser p = createParser(STD_F, mode, JSON);
         try {
             p.nextToken();
-            p.getText();
+            p.getString();
             fail("Should have thrown an exception for doc <"+JSON+">");
         } catch (StreamReadException e) {
             verifyException(e, "invalid numeric value");
@@ -136,7 +136,7 @@ class NonStandardParserFeaturesTest
         p = createParser(LEADING_ZERO_F, mode, JSON);
         assertToken(JsonToken.VALUE_NUMBER_INT, p.nextToken());
         assertEquals(3, p.getIntValue());
-        assertEquals("3", p.getText());
+        assertEquals("3", p.getString());
         p.close();
 
         // Plus, also: verify that leading zero magnitude is ok:
@@ -146,7 +146,7 @@ class NonStandardParserFeaturesTest
         }
         p = createParser(LEADING_ZERO_F, mode, JSON);
         assertToken(JsonToken.VALUE_NUMBER_INT, p.nextToken());
-        assertEquals(String.valueOf(Integer.MAX_VALUE), p.getText());
+        assertEquals(String.valueOf(Integer.MAX_VALUE), p.getString());
         assertEquals(Integer.MAX_VALUE, p.getIntValue());
         Number nr = p.getNumberValue();
         assertSame(Integer.class, nr.getClass());
@@ -159,7 +159,7 @@ class NonStandardParserFeaturesTest
         assertEquals(0, p.getIntValue());
         // 03-Jan-2020, tatu: Actually not 100% sure if we ought to retain invalid
         //   representation or not? Won't, for now:
-        assertEquals("0", p.getText());
+        assertEquals("0", p.getString());
         assertToken(JsonToken.END_ARRAY, p.nextToken());
         p.close();
     }
@@ -190,7 +190,7 @@ class NonStandardParserFeaturesTest
 
         double d = p.getDoubleValue();
         assertTrue(Double.isNaN(d));
-        assertEquals("NaN", p.getText());
+        assertEquals("NaN", p.getString());
 
         // [Issue#98]
         try {
@@ -234,31 +234,31 @@ class NonStandardParserFeaturesTest
 
         assertToken(JsonToken.VALUE_NUMBER_FLOAT, p.nextToken());
         double d = p.getDoubleValue();
-        assertEquals("-INF", p.getText());
+        assertEquals("-INF", p.getString());
         assertTrue(Double.isInfinite(d));
         assertEquals(Double.NEGATIVE_INFINITY, d);
 
         assertToken(JsonToken.VALUE_NUMBER_FLOAT, p.nextToken());
         d = p.getDoubleValue();
-        assertEquals("+INF", p.getText());
+        assertEquals("+INF", p.getString());
         assertTrue(Double.isInfinite(d));
         assertEquals(Double.POSITIVE_INFINITY, d);
 
         assertToken(JsonToken.VALUE_NUMBER_FLOAT, p.nextToken());
         d = p.getDoubleValue();
-        assertEquals("+Infinity", p.getText());
+        assertEquals("+Infinity", p.getString());
         assertTrue(Double.isInfinite(d));
         assertEquals(Double.POSITIVE_INFINITY, d);
 
         assertToken(JsonToken.VALUE_NUMBER_FLOAT, p.nextToken());
         d = p.getDoubleValue();
-        assertEquals("Infinity", p.getText());
+        assertEquals("Infinity", p.getString());
         assertTrue(Double.isInfinite(d));
         assertEquals(Double.POSITIVE_INFINITY, d);
 
         assertToken(JsonToken.VALUE_NUMBER_FLOAT, p.nextToken());
         d = p.getDoubleValue();
-        assertEquals("-Infinity", p.getText());
+        assertEquals("-Infinity", p.getString());
         assertTrue(Double.isInfinite(d));
         assertEquals(Double.NEGATIVE_INFINITY, d);
 

--- a/src/test/java/tools/jackson/core/read/NonStandardNumberParsingTest.java
+++ b/src/test/java/tools/jackson/core/read/NonStandardNumberParsingTest.java
@@ -251,7 +251,7 @@ class NonStandardNumberParsingTest
             assertEquals(JsonToken.VALUE_NUMBER_FLOAT, p.nextToken());
             assertEquals(0.125, p.getValueAsDouble());
             assertEquals("0.125", p.getDecimalValue().toString());
-            assertEquals(".125", p.getText());
+            assertEquals(".125", p.getString());
         }
     }
 
@@ -261,19 +261,19 @@ class NonStandardNumberParsingTest
             assertEquals(JsonToken.VALUE_NUMBER_INT, p.nextToken());
             assertEquals(125.0, p.getValueAsDouble());
             assertEquals("125", p.getDecimalValue().toString());
-            assertEquals("125", p.getText());
+            assertEquals("125", p.getString());
         }
         try (JsonParser p = createParser(f, mode, " +0.125 ")) {
             assertEquals(JsonToken.VALUE_NUMBER_FLOAT, p.nextToken());
             assertEquals(0.125, p.getValueAsDouble());
             assertEquals("0.125", p.getDecimalValue().toString());
-            assertEquals("0.125", p.getText());
+            assertEquals("0.125", p.getString());
         }
         try (JsonParser p = createParser(f, mode, " +.125 ")) {
             assertEquals(JsonToken.VALUE_NUMBER_FLOAT, p.nextToken());
             assertEquals(0.125, p.getValueAsDouble());
             assertEquals("0.125", p.getDecimalValue().toString());
-            assertEquals(".125", p.getText());
+            assertEquals(".125", p.getString());
         }
     }
 
@@ -283,7 +283,7 @@ class NonStandardNumberParsingTest
             assertEquals(JsonToken.VALUE_NUMBER_FLOAT, p.nextToken());
             assertEquals(125.0, p.getValueAsDouble());
             assertEquals("125", p.getDecimalValue().toString());
-            assertEquals("125.", p.getText());
+            assertEquals("125.", p.getString());
         }
     }
 
@@ -293,7 +293,7 @@ class NonStandardNumberParsingTest
             assertEquals(JsonToken.VALUE_NUMBER_FLOAT, p.nextToken());
             assertEquals(-0.125, p.getValueAsDouble());
             assertEquals("-0.125", p.getDecimalValue().toString());
-            assertEquals("-.125", p.getText());
+            assertEquals("-.125", p.getString());
         }
     }
 }

--- a/src/test/java/tools/jackson/core/read/NonStandardUnquotedNamesTest.java
+++ b/src/test/java/tools/jackson/core/read/NonStandardUnquotedNamesTest.java
@@ -88,26 +88,26 @@ class NonStandardUnquotedNamesTest
         assertToken(JsonToken.START_OBJECT, p.nextToken());
 
         assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
-        assertEquals("@type", p.getText());
+        assertEquals("@type", p.getString());
         assertToken(JsonToken.VALUE_STRING, p.nextToken());
-        assertEquals("mytype", p.getText());
+        assertEquals("mytype", p.getString());
 
         assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
-        assertEquals("#color", p.getText());
+        assertEquals("#color", p.getString());
         assertToken(JsonToken.VALUE_NUMBER_INT, p.nextToken());
         assertEquals(123, p.getIntValue());
 
         assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
-        assertEquals("*error*", p.getText());
+        assertEquals("*error*", p.getString());
         assertToken(JsonToken.VALUE_TRUE, p.nextToken());
 
         assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
-        assertEquals("hyphen-ated", p.getText());
+        assertEquals("hyphen-ated", p.getString());
         assertToken(JsonToken.VALUE_STRING, p.nextToken());
-        assertEquals("yes", p.getText());
+        assertEquals("yes", p.getString());
 
         assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
-        assertEquals("me+my", p.getText());
+        assertEquals("me+my", p.getString());
         assertToken(JsonToken.VALUE_NULL, p.nextToken());
 
         assertToken(JsonToken.END_OBJECT, p.nextToken());
@@ -162,7 +162,7 @@ class NonStandardUnquotedNamesTest
         assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
         assertEquals("$", p.currentName());
         assertToken(JsonToken.VALUE_STRING, p.nextToken());
-        assertEquals("money!", p.getText());
+        assertEquals("money!", p.getString());
 
         // and then regular quoted one should still work too:
         assertToken(JsonToken.PROPERTY_NAME, p.nextToken());

--- a/src/test/java/tools/jackson/core/read/NumberOverflowTest.java
+++ b/src/test/java/tools/jackson/core/read/NumberOverflowTest.java
@@ -49,7 +49,7 @@ class NumberOverflowTest
             p.nextToken();
             try {
                 long x = p.getLongValue();
-                fail("Expected an exception for underflow (input "+p.getText()+"): instead, got long value: "+x);
+                fail("Expected an exception for underflow (input "+p.getString()+"): instead, got long value: "+x);
             } catch (InputCoercionException e) {
                 verifyException(e, "out of range of `long`");
             }
@@ -59,7 +59,7 @@ class NumberOverflowTest
             p.nextToken();
             try {
                 long x = p.getLongValue();
-                fail("Expected an exception for underflow (input "+p.getText()+"): instead, got long value: "+x);
+                fail("Expected an exception for underflow (input "+p.getString()+"): instead, got long value: "+x);
             } catch (InputCoercionException e) {
                 verifyException(e, "out of range of `long`");
                 assertEquals(JsonToken.VALUE_NUMBER_INT, e.getInputType());

--- a/src/test/java/tools/jackson/core/read/NumberParsingTest.java
+++ b/src/test/java/tools/jackson/core/read/NumberParsingTest.java
@@ -91,7 +91,7 @@ class NumberParsingTest
         assertEquals(JsonParser.NumberType.INT, p.getNumberType());
         assertEquals(JsonParser.NumberTypeFP.UNKNOWN, p.getNumberTypeFP());
         assertTrue(p.isExpectedNumberIntToken());
-        assertEquals(""+EXP_I, p.getText());
+        assertEquals(""+EXP_I, p.getString());
 
         if (((short) EXP_I) == EXP_I) {
             assertEquals((short) EXP_I, p.getShortValue());
@@ -131,7 +131,7 @@ class NumberParsingTest
         p = createParser(jsonFactory(), mode, DOC + " "); // DataInput requires separator
         assertToken(JsonToken.VALUE_NUMBER_INT, p.nextToken());
         assertTrue(p.isExpectedNumberIntToken());
-        assertEquals(DOC, p.getText());
+        assertEquals(DOC, p.getString());
 
         int i = p.getIntValue();
 
@@ -320,7 +320,7 @@ class NumberParsingTest
         assertToken(JsonToken.VALUE_NUMBER_INT, p.nextToken());
         // beyond int, should be long
         assertEquals(JsonParser.NumberType.LONG, p.getNumberType());
-        assertEquals(""+EXP_L, p.getText());
+        assertEquals(""+EXP_L, p.getString());
 
         assertEquals(EXP_L, p.getLongValue());
         // Should get an exception if trying to convert to int
@@ -466,7 +466,7 @@ class NumberParsingTest
             try (JsonParser p = createParser(jsonFactory(), mode, NUMBER_STR + " ")) {
                 assertToken(JsonToken.VALUE_NUMBER_INT, p.nextToken());
                 assertEquals(JsonParser.NumberType.BIG_INTEGER, p.getNumberType());
-                assertEquals(NUMBER_STR, p.getText());
+                assertEquals(NUMBER_STR, p.getString());
                 assertEquals(biggie, p.getBigIntegerValue());
             }
         }
@@ -486,7 +486,7 @@ class NumberParsingTest
                     assertToken(JsonToken.VALUE_NUMBER_INT, p.nextToken());
                     assertEquals(JsonParser.NumberType.BIG_INTEGER, p.getNumberType());
                     assertEquals(biggie, p.getBigIntegerValue());
-                    assertEquals(value, p.getText());
+                    assertEquals(value, p.getString());
                 }
             }
         }
@@ -513,7 +513,7 @@ class NumberParsingTest
                 // it `NumberType.DOUBLE`
 //                assertEquals(JsonParser.NumberType.BIG_DECIMAL, p.getNumberType());
                 assertFalse(p.isNaN());
-                assertEquals(tooBigString, p.getText());
+                assertEquals(tooBigString, p.getString());
                 assertEquals(tooBig, p.getDecimalValue());
                 assertFalse(p.isNaN());
             }
@@ -599,7 +599,7 @@ class NumberParsingTest
                 assertToken(JsonToken.START_ARRAY, p.nextToken());
 
                 assertToken(JsonToken.VALUE_NUMBER_FLOAT, p.nextToken());
-                assertEquals(STR, p.getText());
+                assertEquals(STR, p.getString());
                 assertEquals(EXP_D, p.getDoubleValue());
                 assertToken(JsonToken.END_ARRAY, p.nextToken());
                 if (mode != MODE_DATA_INPUT) {
@@ -618,7 +618,7 @@ class NumberParsingTest
                 }
 
                 assertToken(JsonToken.VALUE_NUMBER_FLOAT, t);
-                assertEquals(STR, p.getText());
+                assertEquals(STR, p.getString());
                 if (mode != MODE_DATA_INPUT) {
                     assertNull(p.nextToken());
                 }
@@ -690,7 +690,7 @@ class NumberParsingTest
         assertEquals(-13, p.getIntValue());
         assertEquals(-13L, p.getLongValue());
         assertEquals(-13., p.getDoubleValue());
-        assertEquals("-13", p.getText());
+        assertEquals("-13", p.getString());
 
         assertToken(JsonToken.VALUE_NUMBER_INT, p.nextToken());
         assertEquals(8100200300L, p.getLongValue());
@@ -702,25 +702,25 @@ class NumberParsingTest
             verifyException(e, "out of range of `int`");
         }
         assertEquals(8100200300.0, p.getDoubleValue());
-        assertEquals("8100200300", p.getText());
+        assertEquals("8100200300", p.getString());
 
         assertToken(JsonToken.VALUE_NUMBER_FLOAT, p.nextToken());
         assertEquals(13, p.getIntValue());
         assertEquals(13L, p.getLongValue());
         assertEquals(13.5, p.getDoubleValue());
-        assertEquals("13.5", p.getText());
+        assertEquals("13.5", p.getString());
 
         assertToken(JsonToken.VALUE_NUMBER_FLOAT, p.nextToken());
         assertEquals(0, p.getIntValue());
         assertEquals(0L, p.getLongValue());
         assertEquals(0.00010, p.getDoubleValue());
-        assertEquals("0.00010", p.getText());
+        assertEquals("0.00010", p.getString());
 
         assertToken(JsonToken.VALUE_NUMBER_FLOAT, p.nextToken());
         assertEquals(-2, p.getIntValue());
         assertEquals(-2L, p.getLongValue());
         assertEquals(-2.033, p.getDoubleValue());
-        assertEquals("-2.033", p.getText());
+        assertEquals("-2.033", p.getString());
 
         assertToken(JsonToken.END_ARRAY, p.nextToken());
 
@@ -812,7 +812,7 @@ class NumberParsingTest
                         : f.createParser(ObjectReadContext.empty(), doc)) {
             assertToken(JsonToken.START_ARRAY, p.nextToken());
             assertToken(JsonToken.VALUE_NUMBER_INT, p.nextToken());
-            assertEquals(num, p.getText());
+            assertEquals(num, p.getString());
             assertToken(JsonToken.END_ARRAY, p.nextToken());
         }
     }
@@ -1001,7 +1001,7 @@ class NumberParsingTest
     private void _testLongerFloat(JsonParser p, String text)
     {
         assertToken(JsonToken.VALUE_NUMBER_FLOAT, p.nextToken());
-        assertEquals(text, p.getText());
+        assertEquals(text, p.getString());
         assertNull(p.nextToken());
     }
 

--- a/src/test/java/tools/jackson/core/read/SimpleParserTest.java
+++ b/src/test/java/tools/jackson/core/read/SimpleParserTest.java
@@ -612,7 +612,7 @@ class SimpleParserTest extends JUnit5TestBase
     private void _getAndVerifyText(JsonParser p, String exp)
     {
         Writer writer = new StringWriter();
-        int len = p.getText(writer);
+        int len = p.getString(writer);
         String resultString = writer.toString();
         assertEquals(len, resultString.length());
         assertEquals(exp, resultString);
@@ -641,7 +641,7 @@ class SimpleParserTest extends JUnit5TestBase
         assertToken(JsonToken.VALUE_STRING, parser.nextToken());
 
         Writer writer = new StringWriter();
-        int len = parser.getText(writer);
+        int len = parser.getString(writer);
         String resultString = writer.toString();
         assertEquals(len, resultString.length());
         assertEquals(longText, resultString);

--- a/src/test/java/tools/jackson/core/read/SimpleParserTest.java
+++ b/src/test/java/tools/jackson/core/read/SimpleParserTest.java
@@ -144,10 +144,10 @@ class SimpleParserTest extends JUnit5TestBase
         // Before advancing to content, we should have following default state...
         assertFalse(p.hasCurrentToken());
         assertNull(p.getString());
-        assertNull(p.getTextCharacters());
-        assertEquals(0, p.getTextLength());
+        assertNull(p.getStringCharacters());
+        assertEquals(0, p.getStringLength());
         // not sure if this is defined but:
-        assertEquals(0, p.getTextOffset());
+        assertEquals(0, p.getStringOffset());
 
         assertToken(JsonToken.START_OBJECT, p.nextToken());
         assertEquals("/", ctxt.toString());

--- a/src/test/java/tools/jackson/core/read/SimpleParserTest.java
+++ b/src/test/java/tools/jackson/core/read/SimpleParserTest.java
@@ -143,7 +143,7 @@ class SimpleParserTest extends JUnit5TestBase
 
         // Before advancing to content, we should have following default state...
         assertFalse(p.hasCurrentToken());
-        assertNull(p.getText());
+        assertNull(p.getString());
         assertNull(p.getTextCharacters());
         assertEquals(0, p.getTextLength());
         // not sure if this is defined but:
@@ -540,7 +540,7 @@ class SimpleParserTest extends JUnit5TestBase
         assertEquals("foobar", p.getValueAsString("foobar"));
 
         assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
-        assertEquals("a", p.getText());
+        assertEquals("a", p.getString());
         assertEquals("a", p.getValueAsString());
         assertEquals("a", p.getValueAsString("default"));
         assertToken(JsonToken.VALUE_NUMBER_INT, p.nextToken());
@@ -706,7 +706,7 @@ class SimpleParserTest extends JUnit5TestBase
             assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
             assertEquals("mac", p.currentName());
             assertToken(JsonToken.VALUE_STRING, p.nextToken());
-            assertNotNull(p.getText());
+            assertNotNull(p.getString());
             assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
             assertEquals("data", p.currentName());
             assertToken(JsonToken.START_OBJECT, p.nextToken());
@@ -899,13 +899,13 @@ class SimpleParserTest extends JUnit5TestBase
 
     protected void verifyFieldName(JsonParser p, String expName)
     {
-        assertEquals(expName, p.getText());
+        assertEquals(expName, p.getString());
         assertEquals(expName, p.currentName());
     }
 
     protected void verifyIntValue(JsonParser p, long expValue)
     {
         // First, via textual
-        assertEquals(String.valueOf(expValue), p.getText());
+        assertEquals(String.valueOf(expValue), p.getString());
     }
 }

--- a/src/test/java/tools/jackson/core/read/TestReadHumongousString.java
+++ b/src/test/java/tools/jackson/core/read/TestReadHumongousString.java
@@ -35,7 +35,7 @@ class TestReadHumongousString extends JUnit5TestBase
             // Let's not construct String but just check that length is
             // expected: this avoids having to allocate 4 gig more of heap
             // for test -- should still trigger problem if fix not valid
-            assertEquals(len, parser.getTextLength());
+            assertEquals(len, parser.getStringLength());
             // TODO: could use streaming accessor (`JsonParser.getText(Writer)`)
             assertNull(parser.nextToken());
         }

--- a/src/test/java/tools/jackson/core/read/TrailingCommasTest.java
+++ b/src/test/java/tools/jackson/core/read/TrailingCommasTest.java
@@ -57,10 +57,10 @@ public class TrailingCommasTest extends JUnit5TestBase
       assertEquals(JsonToken.START_ARRAY, p.nextToken());
 
       assertToken(JsonToken.VALUE_STRING, p.nextToken());
-      assertEquals("a", p.getText());
+      assertEquals("a", p.getString());
 
       assertToken(JsonToken.VALUE_STRING, p.nextToken());
-      assertEquals("b", p.getText());
+      assertEquals("b", p.getString());
 
       assertEquals(JsonToken.END_ARRAY, p.nextToken());
       assertEnd(p);
@@ -78,7 +78,7 @@ public class TrailingCommasTest extends JUnit5TestBase
       assertEquals(JsonToken.START_ARRAY, p.nextToken());
 
       assertToken(JsonToken.VALUE_STRING, p.nextToken());
-      assertEquals("a", p.getText());
+      assertEquals("a", p.getString());
 
       if (!features.contains(JsonReadFeature.ALLOW_MISSING_VALUES)) {
         assertUnexpected(p, ',');
@@ -88,7 +88,7 @@ public class TrailingCommasTest extends JUnit5TestBase
       assertToken(JsonToken.VALUE_NULL, p.nextToken());
 
       assertToken(JsonToken.VALUE_STRING, p.nextToken());
-      assertEquals("b", p.getText());
+      assertEquals("b", p.getString());
 
       assertEquals(JsonToken.END_ARRAY, p.nextToken());
       assertEnd(p);
@@ -113,10 +113,10 @@ public class TrailingCommasTest extends JUnit5TestBase
       assertToken(JsonToken.VALUE_NULL, p.nextToken());
 
       assertToken(JsonToken.VALUE_STRING, p.nextToken());
-      assertEquals("a", p.getText());
+      assertEquals("a", p.getString());
 
       assertToken(JsonToken.VALUE_STRING, p.nextToken());
-      assertEquals("b", p.getText());
+      assertEquals("b", p.getString());
 
       assertEquals(JsonToken.END_ARRAY, p.nextToken());
       assertEnd(p);
@@ -134,10 +134,10 @@ public class TrailingCommasTest extends JUnit5TestBase
       assertEquals(JsonToken.START_ARRAY, p.nextToken());
 
       assertToken(JsonToken.VALUE_STRING, p.nextToken());
-      assertEquals("a", p.getText());
+      assertEquals("a", p.getString());
 
       assertToken(JsonToken.VALUE_STRING, p.nextToken());
-      assertEquals("b", p.getText());
+      assertEquals("b", p.getString());
 
       // ALLOW_TRAILING_COMMA takes priority over ALLOW_MISSING_VALUES
       if (features.contains(JsonReadFeature.ALLOW_TRAILING_COMMA)) {
@@ -164,10 +164,10 @@ public class TrailingCommasTest extends JUnit5TestBase
       assertEquals(JsonToken.START_ARRAY, p.nextToken());
 
       assertToken(JsonToken.VALUE_STRING, p.nextToken());
-      assertEquals("a", p.getText());
+      assertEquals("a", p.getString());
 
       assertToken(JsonToken.VALUE_STRING, p.nextToken());
-      assertEquals("b", p.getText());
+      assertEquals("b", p.getString());
 
       // ALLOW_TRAILING_COMMA takes priority over ALLOW_MISSING_VALUES
       if (features.contains(JsonReadFeature.ALLOW_MISSING_VALUES) &&
@@ -197,10 +197,10 @@ public class TrailingCommasTest extends JUnit5TestBase
       assertEquals(JsonToken.START_ARRAY, p.nextToken());
 
       assertToken(JsonToken.VALUE_STRING, p.nextToken());
-      assertEquals("a", p.getText());
+      assertEquals("a", p.getString());
 
       assertToken(JsonToken.VALUE_STRING, p.nextToken());
-      assertEquals("b", p.getText());
+      assertEquals("b", p.getString());
 
       // ALLOW_TRAILING_COMMA takes priority over ALLOW_MISSING_VALUES
       if (features.contains(JsonReadFeature.ALLOW_MISSING_VALUES) &&
@@ -231,11 +231,11 @@ public class TrailingCommasTest extends JUnit5TestBase
         assertEquals(JsonToken.START_OBJECT, p.nextToken());
 
         assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
-        assertEquals("a", p.getText());
+        assertEquals("a", p.getString());
         assertToken(JsonToken.VALUE_TRUE, p.nextToken());
     
         assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
-        assertEquals("b", p.getText());
+        assertEquals("b", p.getString());
         assertToken(JsonToken.VALUE_FALSE, p.nextToken());
 
         assertEquals(JsonToken.END_OBJECT, p.nextToken());
@@ -253,7 +253,7 @@ public class TrailingCommasTest extends JUnit5TestBase
         assertEquals(JsonToken.START_OBJECT, p.nextToken());
 
         assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
-        assertEquals("a", p.getText());
+        assertEquals("a", p.getString());
         assertToken(JsonToken.VALUE_TRUE, p.nextToken());
 
         assertUnexpected(p, ',');
@@ -285,11 +285,11 @@ public class TrailingCommasTest extends JUnit5TestBase
         assertEquals(JsonToken.START_OBJECT, p.nextToken());
 
         assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
-        assertEquals("a", p.getText());
+        assertEquals("a", p.getString());
         assertToken(JsonToken.VALUE_TRUE, p.nextToken());
     
         assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
-        assertEquals("b", p.getText());
+        assertEquals("b", p.getString());
         assertToken(JsonToken.VALUE_FALSE, p.nextToken());
 
         if (features.contains(JsonReadFeature.ALLOW_TRAILING_COMMA)) {
@@ -371,11 +371,11 @@ public class TrailingCommasTest extends JUnit5TestBase
         assertEquals(JsonToken.START_OBJECT, p.nextToken());
 
         assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
-        assertEquals("a", p.getText());
+        assertEquals("a", p.getString());
         assertToken(JsonToken.VALUE_TRUE, p.nextToken());
     
         assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
-        assertEquals("b", p.getText());
+        assertEquals("b", p.getString());
         assertToken(JsonToken.VALUE_FALSE, p.nextToken());
 
         assertUnexpected(p, ',');

--- a/src/test/java/tools/jackson/core/read/UTF8NamesParseTest.java
+++ b/src/test/java/tools/jackson/core/read/UTF8NamesParseTest.java
@@ -56,7 +56,7 @@ public class UTF8NamesParseTest
         assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
         assertEquals("", p.currentName());
         assertToken(JsonToken.VALUE_STRING, p.nextToken());
-        assertEquals("", p.getText());
+        assertEquals("", p.getString());
         assertToken(JsonToken.END_OBJECT, p.nextToken());
         p.close();
     }
@@ -215,7 +215,7 @@ public class UTF8NamesParseTest
         JsonParser p = createParser(mode, bout.toByteArray());
         assertToken(JsonToken.START_ARRAY, p.nextToken());
         assertToken(JsonToken.VALUE_STRING, p.nextToken());
-        String act = p.getText();
+        String act = p.getString();
 
         assertEquals(VALUE.length(), act.length());
         assertEquals(VALUE, act);
@@ -233,7 +233,7 @@ public class UTF8NamesParseTest
         assertToken(JsonToken.START_OBJECT, p.nextToken());
         assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
 
-        act = p.getText();
+        act = p.getString();
         assertEquals(VALUE.length(), act.length());
         assertEquals(VALUE, act);
 

--- a/src/test/java/tools/jackson/core/read/loc/LocationOffsetsTest.java
+++ b/src/test/java/tools/jackson/core/read/loc/LocationOffsetsTest.java
@@ -294,7 +294,7 @@ class LocationOffsetsTest extends JUnit5TestBase
         assertEquals(1, loc.getLineNr());
         assertEquals(9, loc.getColumnNr());
 
-        p.getTextCharacters();
+        p.getStringCharacters();
         loc = p.currentTokenLocation();
         assertEquals(7, loc.getByteOffset());
         assertEquals(-1L, loc.getCharOffset());

--- a/src/test/java/tools/jackson/core/read/loc/LocationOffsetsTest.java
+++ b/src/test/java/tools/jackson/core/read/loc/LocationOffsetsTest.java
@@ -132,7 +132,7 @@ class LocationOffsetsTest extends JUnit5TestBase
         assertToken(JsonToken.VALUE_STRING, p.nextToken());
         assertEquals(1, p.currentLocation().getLineNr());
         p.finishToken();
-        assertEquals("text", p.getText());
+        assertEquals("text", p.getString());
         p.close();
     }
 
@@ -151,7 +151,7 @@ class LocationOffsetsTest extends JUnit5TestBase
         assertEquals(8, p.currentLocation().getColumnNr());
 
         // also just for fun, verify content
-        assertEquals("text", p.getText());
+        assertEquals("text", p.getString());
         assertEquals(8, p.currentLocation().getColumnNr());
         p.close();
     }

--- a/src/test/java/tools/jackson/core/testsupport/AsyncReaderWrapper.java
+++ b/src/test/java/tools/jackson/core/testsupport/AsyncReaderWrapper.java
@@ -36,7 +36,7 @@ public abstract class AsyncReaderWrapper
     public String currentTextViaWriter()
     {
         StringWriter sw = new StringWriter();
-        int len = _streamReader.getText(sw);
+        int len = _streamReader.getString(sw);
         String str = sw.toString();
         if (len != str.length()) {
             throw new IllegalStateException(String.format(

--- a/src/test/java/tools/jackson/core/testsupport/AsyncReaderWrapper.java
+++ b/src/test/java/tools/jackson/core/testsupport/AsyncReaderWrapper.java
@@ -27,9 +27,9 @@ public abstract class AsyncReaderWrapper
 
     public String currentTextViaCharacters()
     {
-        char[] ch = _streamReader.getTextCharacters();
-        int start = _streamReader.getTextOffset();
-        int len = _streamReader.getTextLength();
+        char[] ch = _streamReader.getStringCharacters();
+        int start = _streamReader.getStringOffset();
+        int len = _streamReader.getStringLength();
         return new String(ch, start, len);
     }
 

--- a/src/test/java/tools/jackson/core/testsupport/AsyncReaderWrapper.java
+++ b/src/test/java/tools/jackson/core/testsupport/AsyncReaderWrapper.java
@@ -22,7 +22,7 @@ public abstract class AsyncReaderWrapper
         return _streamReader.currentToken();
     }
     public String currentText() {
-        return _streamReader.getText();
+        return _streamReader.getString();
     }
 
     public String currentTextViaCharacters()

--- a/src/test/java/tools/jackson/core/util/DelegatesTest.java
+++ b/src/test/java/tools/jackson/core/util/DelegatesTest.java
@@ -163,7 +163,7 @@ class DelegatesTest extends JUnit5TestBase
         assertTrue(del.isExpectedStartArrayToken());
         assertFalse(del.isExpectedStartObjectToken());
         assertFalse(del.isExpectedNumberIntToken());
-        assertEquals("[", del.getText());
+        assertEquals("[", del.getString());
         assertNotNull(del.streamReadContext());
         assertSame(parser.streamReadContext(), del.streamReadContext());
 
@@ -207,7 +207,7 @@ class DelegatesTest extends JUnit5TestBase
 
         assertToken(JsonToken.VALUE_STRING, del.nextToken());
         assertTrue(del.hasStringCharacters());
-        assertEquals("foo", del.getText());
+        assertEquals("foo", del.getString());
 
         assertToken(JsonToken.END_OBJECT, del.nextToken());
         assertEquals(TOKEN, del.currentValue());

--- a/src/test/java/tools/jackson/core/util/DelegatesTest.java
+++ b/src/test/java/tools/jackson/core/util/DelegatesTest.java
@@ -150,7 +150,7 @@ class DelegatesTest extends JUnit5TestBase
         // initial state
         assertNull(del.currentToken());
         assertFalse(del.hasCurrentToken());
-        assertFalse(del.hasTextCharacters());
+        assertFalse(del.hasStringCharacters());
         assertNull(del.currentValue());
         assertNull(del.currentName());
 
@@ -206,7 +206,7 @@ class DelegatesTest extends JUnit5TestBase
         assertEquals("a", del.currentName());
 
         assertToken(JsonToken.VALUE_STRING, del.nextToken());
-        assertTrue(del.hasTextCharacters());
+        assertTrue(del.hasStringCharacters());
         assertEquals("foo", del.getText());
 
         assertToken(JsonToken.END_OBJECT, del.nextToken());

--- a/src/test/java/tools/jackson/core/util/JsonBufferRecyclersTest.java
+++ b/src/test/java/tools/jackson/core/util/JsonBufferRecyclersTest.java
@@ -58,7 +58,7 @@ class JsonBufferRecyclersTest extends JUnit5TestBase
         assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
         assertEquals("b", p.currentName());
         assertToken(JsonToken.VALUE_STRING, p.nextToken());
-        assertEquals("foobar", p.getText());
+        assertEquals("foobar", p.getString());
         assertToken(JsonToken.END_OBJECT, p.nextToken());
         
         p.close();

--- a/src/test/java/tools/jackson/core/write/ArrayWriteTest.java
+++ b/src/test/java/tools/jackson/core/write/ArrayWriteTest.java
@@ -110,7 +110,7 @@ class ArrayWriteTest
         assertEquals(13, p.getIntValue());
         assertEquals(JsonToken.VALUE_TRUE, p.nextToken());
         assertEquals(JsonToken.VALUE_STRING, p.nextToken());
-        assertEquals("foobar", p.getText());
+        assertEquals("foobar", p.getString());
         assertEquals(JsonToken.END_ARRAY, p.nextToken());
         assertEquals(null, p.nextToken());
         p.close();

--- a/src/test/java/tools/jackson/core/write/GeneratorBasicTest.java
+++ b/src/test/java/tools/jackson/core/write/GeneratorBasicTest.java
@@ -55,7 +55,7 @@ public class GeneratorBasicTest
                     JsonToken t = jp.nextToken();
                     assertNotNull(t, "Document \""+utf8String(bout)+"\" yielded no tokens");
                     assertEquals(JsonToken.VALUE_STRING, t);
-                    assertEquals(input, jp.getText());
+                    assertEquals(input, jp.getString());
                     assertNull(jp.nextToken());
                     jp.close();
                 }
@@ -102,8 +102,8 @@ public class GeneratorBasicTest
             JsonParser jp = createParserUsingReader(docStr);
             JsonToken t = jp.nextToken();
             String exp = Boolean.valueOf(state).toString();
-            if (!exp.equals(jp.getText())) {
-                fail("Expected '"+exp+"', got '"+jp.getText());
+            if (!exp.equals(jp.getString())) {
+                fail("Expected '"+exp+"', got '"+jp.getString());
             }
             assertEquals(state ? JsonToken.VALUE_TRUE : JsonToken.VALUE_FALSE, t);
             assertNull(jp.nextToken());
@@ -128,8 +128,8 @@ public class GeneratorBasicTest
             JsonParser jp = createParserUsingReader(docStr);
             JsonToken t = jp.nextToken();
             String exp = "null";
-            if (!exp.equals(jp.getText())) {
-                fail("Expected '"+exp+"', got '"+jp.getText());
+            if (!exp.equals(jp.getString())) {
+                fail("Expected '"+exp+"', got '"+jp.getString());
             }
             assertEquals(JsonToken.VALUE_NULL, t);
             assertNull(jp.nextToken());
@@ -376,8 +376,8 @@ public class GeneratorBasicTest
             assertNotNull(t, "Document \""+docStr+"\" yielded no tokens");
             // Number are always available as lexical representation too
             String exp = ""+VALUE;
-            if (!exp.equals(p.getText())) {
-                fail("Expected '"+exp+"', got '"+p.getText());
+            if (!exp.equals(p.getString())) {
+                fail("Expected '"+exp+"', got '"+p.getString());
             }
             assertEquals(JsonToken.VALUE_NUMBER_INT, t);
             assertEquals(VALUE, p.getIntValue());
@@ -431,8 +431,8 @@ public class GeneratorBasicTest
             }
             assertNotNull(t, "Document \""+docStr+"\" yielded no tokens");
             String exp = ""+VALUE;
-            if (!exp.equals(p.getText())) {
-                fail("Expected '"+exp+"', got '"+p.getText());
+            if (!exp.equals(p.getString())) {
+                fail("Expected '"+exp+"', got '"+p.getString());
             }
             assertEquals(JsonToken.VALUE_NUMBER_INT, t);
             assertEquals(VALUE, p.getLongValue());

--- a/src/test/java/tools/jackson/core/write/GeneratorMiscTest.java
+++ b/src/test/java/tools/jackson/core/write/GeneratorMiscTest.java
@@ -72,7 +72,7 @@ public class GeneratorMiscTest
         assertEquals(-123, jp.getIntValue());
         assertToken(JsonToken.VALUE_TRUE, jp.nextToken());
         assertToken(JsonToken.VALUE_STRING, jp.nextToken());
-        assertEquals("x", jp.getText());
+        assertEquals("x", jp.getString());
         assertToken(JsonToken.END_ARRAY, jp.nextToken());
         jp.close();
     }

--- a/src/test/java/tools/jackson/core/write/ObjectWriteTest.java
+++ b/src/test/java/tools/jackson/core/write/ObjectWriteTest.java
@@ -95,16 +95,16 @@ public class ObjectWriteTest
         JsonParser p = createParserUsingReader(docStr);
         assertEquals(JsonToken.START_OBJECT, p.nextToken());
         assertEquals(JsonToken.PROPERTY_NAME, p.nextToken());
-        assertEquals("first", p.getText());
+        assertEquals("first", p.getString());
         assertEquals(JsonToken.VALUE_NUMBER_INT, p.nextToken());
         assertEquals(-901, p.getIntValue());
         assertEquals(JsonToken.PROPERTY_NAME, p.nextToken());
-        assertEquals("sec", p.getText());
+        assertEquals("sec", p.getString());
         assertEquals(JsonToken.VALUE_FALSE, p.nextToken());
         assertEquals(JsonToken.PROPERTY_NAME, p.nextToken());
-        assertEquals("3rd!", p.getText());
+        assertEquals("3rd!", p.getString());
         assertEquals(JsonToken.VALUE_STRING, p.nextToken());
-        assertEquals("yee-haw", p.getText());
+        assertEquals("yee-haw", p.getString());
         assertEquals(JsonToken.END_OBJECT, p.nextToken());
         assertEquals(null, p.nextToken());
         p.close();
@@ -144,68 +144,68 @@ public class ObjectWriteTest
         assertEquals(JsonToken.START_OBJECT, p.nextToken());
 
         assertEquals(JsonToken.PROPERTY_NAME, p.nextToken());
-        assertEquals("null", p.getText());
+        assertEquals("null", p.getString());
         assertEquals(JsonToken.VALUE_NULL, p.nextToken());
 
         assertEquals(JsonToken.PROPERTY_NAME, p.nextToken());
-        assertEquals("bt", p.getText());
+        assertEquals("bt", p.getString());
         assertEquals(JsonToken.VALUE_TRUE, p.nextToken());
 
         assertEquals(JsonToken.PROPERTY_NAME, p.nextToken());
-        assertEquals("bf", p.getText());
+        assertEquals("bf", p.getString());
         assertEquals(JsonToken.VALUE_FALSE, p.nextToken());
 
         //Short parsed as int
         assertEquals(JsonToken.PROPERTY_NAME, p.nextToken());
-        assertEquals("short", p.getText());
+        assertEquals("short", p.getString());
         assertEquals(JsonToken.VALUE_NUMBER_INT, p.nextToken());
         assertEquals(JsonParser.NumberType.INT, p.getNumberType());
 
         assertEquals(JsonToken.PROPERTY_NAME, p.nextToken());
-        assertEquals("int", p.getText());
+        assertEquals("int", p.getString());
         assertEquals(JsonToken.VALUE_NUMBER_INT, p.nextToken());
         assertEquals(JsonParser.NumberType.INT, p.getNumberType());
 
         assertEquals(JsonToken.PROPERTY_NAME, p.nextToken());
-        assertEquals("long", p.getText());
+        assertEquals("long", p.getString());
         assertEquals(JsonToken.VALUE_NUMBER_INT, p.nextToken());
         assertEquals(JsonParser.NumberType.LONG, p.getNumberType());
 
         assertEquals(JsonToken.PROPERTY_NAME, p.nextToken());
-        assertEquals("big", p.getText());
+        assertEquals("big", p.getString());
         assertEquals(JsonToken.VALUE_NUMBER_INT, p.nextToken());
         assertEquals(JsonParser.NumberType.BIG_INTEGER, p.getNumberType());
 
         //All floating point types parsed as double
         assertEquals(JsonToken.PROPERTY_NAME, p.nextToken());
-        assertEquals("float", p.getText());
+        assertEquals("float", p.getString());
         assertEquals(JsonToken.VALUE_NUMBER_FLOAT, p.nextToken());
         assertEquals(JsonParser.NumberType.DOUBLE, p.getNumberType());
 
         //All floating point types parsed as double
         assertEquals(JsonToken.PROPERTY_NAME, p.nextToken());
-        assertEquals("double", p.getText());
+        assertEquals("double", p.getString());
         assertEquals(JsonToken.VALUE_NUMBER_FLOAT, p.nextToken());
         assertEquals(JsonParser.NumberType.DOUBLE, p.getNumberType());
 
         //All floating point types parsed as double
         assertEquals(JsonToken.PROPERTY_NAME, p.nextToken());
-        assertEquals("dec", p.getText());
+        assertEquals("dec", p.getString());
         assertEquals(JsonToken.VALUE_NUMBER_FLOAT, p.nextToken());
         assertEquals(JsonParser.NumberType.DOUBLE, p.getNumberType());
 
         assertEquals(JsonToken.PROPERTY_NAME, p.nextToken());
-        assertEquals("ob", p.getText());
+        assertEquals("ob", p.getString());
         assertEquals(JsonToken.START_OBJECT, p.nextToken());
         assertEquals(JsonToken.PROPERTY_NAME, p.nextToken());
 
-        assertEquals("str", p.getText());
+        assertEquals("str", p.getString());
         assertEquals(JsonToken.VALUE_STRING, p.nextToken());
         assertEquals(TEXT, getAndVerifyText(p));
         assertEquals(JsonToken.END_OBJECT, p.nextToken());
 
         assertEquals(JsonToken.PROPERTY_NAME, p.nextToken());
-        assertEquals("arr", p.getText());
+        assertEquals("arr", p.getString());
         assertEquals(JsonToken.START_ARRAY, p.nextToken());
         assertEquals(JsonToken.END_ARRAY, p.nextToken());
 
@@ -253,7 +253,7 @@ public class ObjectWriteTest
         assertEquals("bin", p.currentName());
         // no native binary indicator in JSON, so:
         assertEquals(JsonToken.VALUE_STRING, p.nextToken());
-        assertEquals("AQI=", p.getText());
+        assertEquals("AQI=", p.getString());
 
         assertEquals(JsonToken.END_OBJECT, p.nextToken());
         p.close();

--- a/src/test/java/tools/jackson/core/write/PrettyPrinterTest.java
+++ b/src/test/java/tools/jackson/core/write/PrettyPrinterTest.java
@@ -281,7 +281,7 @@ class PrettyPrinterTest
         assertEquals(JsonToken.VALUE_NUMBER_INT, jp.nextToken());
         assertEquals(3, jp.getIntValue());
         assertEquals(JsonToken.VALUE_STRING, jp.nextToken());
-        assertEquals("abc", jp.getText());
+        assertEquals("abc", jp.getString());
 
         assertEquals(JsonToken.START_ARRAY, jp.nextToken());
         assertEquals(JsonToken.VALUE_TRUE, jp.nextToken());
@@ -289,10 +289,10 @@ class PrettyPrinterTest
 
         assertEquals(JsonToken.START_OBJECT, jp.nextToken());
         assertEquals(JsonToken.PROPERTY_NAME, jp.nextToken());
-        assertEquals("f", jp.getText());
+        assertEquals("f", jp.getString());
         assertEquals(JsonToken.VALUE_NULL, jp.nextToken());
         assertEquals(JsonToken.PROPERTY_NAME, jp.nextToken());
-        assertEquals("f2", jp.getText());
+        assertEquals("f2", jp.getString());
         assertEquals(JsonToken.VALUE_NULL, jp.nextToken());
         assertEquals(JsonToken.END_OBJECT, jp.nextToken());
 

--- a/src/test/java/tools/jackson/core/write/RawStringWriteTest.java
+++ b/src/test/java/tools/jackson/core/write/RawStringWriteTest.java
@@ -39,7 +39,7 @@ class RawStringWriteTest extends JUnit5TestBase
         assertToken(JsonToken.START_ARRAY, jp.nextToken());
         for (byte[] inputBytes : strings) {
             assertToken(JsonToken.VALUE_STRING, jp.nextToken());
-            String string = jp.getText();
+            String string = jp.getString();
             byte[] outputBytes = string.getBytes("UTF-8");
             assertEquals(inputBytes.length, outputBytes.length);
             assertArrayEquals(inputBytes, outputBytes);
@@ -74,7 +74,7 @@ class RawStringWriteTest extends JUnit5TestBase
         assertToken(JsonToken.START_ARRAY, jp.nextToken());
         for (byte[] inputBytes : strings) {
             assertToken(JsonToken.VALUE_STRING, jp.nextToken());
-            String string = jp.getText();
+            String string = jp.getString();
 
             byte[] outputBytes = string.getBytes("UTF-8");
             assertEquals(inputBytes.length, outputBytes.length);
@@ -116,7 +116,7 @@ class RawStringWriteTest extends JUnit5TestBase
 
         assertToken(JsonToken.START_ARRAY, p.nextToken());
         assertToken(JsonToken.VALUE_STRING, p.nextToken());
-        assertEquals("foo", p.getText());
+        assertEquals("foo", p.getString());
         assertToken(JsonToken.VALUE_NUMBER_INT, p.nextToken());
         assertEquals(12, p.getIntValue());
         assertToken(JsonToken.VALUE_FALSE, p.nextToken());

--- a/src/test/java/tools/jackson/core/write/SerializedStringWriteTest.java
+++ b/src/test/java/tools/jackson/core/write/SerializedStringWriteTest.java
@@ -120,24 +120,24 @@ class SerializedStringWriteTest
 
         assertToken(JsonToken.START_OBJECT, p.nextToken());
         assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
-        assertEquals(NAME_WITH_QUOTES, p.getText());
+        assertEquals(NAME_WITH_QUOTES, p.getString());
         assertToken(JsonToken.VALUE_STRING, p.nextToken());
-        assertEquals("a", p.getText());
+        assertEquals("a", p.getString());
         assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
-        assertEquals(NAME_WITH_LATIN1, p.getText());
+        assertEquals(NAME_WITH_LATIN1, p.getString());
         assertToken(JsonToken.VALUE_STRING, p.nextToken());
-        assertEquals("b", p.getText());
+        assertEquals("b", p.getString());
         assertToken(JsonToken.END_OBJECT, p.nextToken());
 
         assertToken(JsonToken.START_OBJECT, p.nextToken());
         assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
-        assertEquals(NAME_WITH_LATIN1, p.getText());
+        assertEquals(NAME_WITH_LATIN1, p.getString());
         assertToken(JsonToken.VALUE_STRING, p.nextToken());
-        assertEquals("c", p.getText());
+        assertEquals("c", p.getString());
         assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
-        assertEquals(NAME_WITH_QUOTES, p.getText());
+        assertEquals(NAME_WITH_QUOTES, p.getString());
         assertToken(JsonToken.VALUE_STRING, p.nextToken());
-        assertEquals("d", p.getText());
+        assertEquals("d", p.getString());
         assertToken(JsonToken.END_OBJECT, p.nextToken());
 
         assertToken(JsonToken.END_ARRAY, p.nextToken());
@@ -150,24 +150,24 @@ class SerializedStringWriteTest
 
         assertToken(JsonToken.START_OBJECT, p.nextToken());
         assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
-        assertEquals(NAME_WITH_QUOTES, p.getText());
+        assertEquals(NAME_WITH_QUOTES, p.getString());
         assertToken(JsonToken.VALUE_STRING, p.nextToken());
-        assertEquals(VALUE_WITH_QUOTES, p.getText());
+        assertEquals(VALUE_WITH_QUOTES, p.getString());
         assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
-        assertEquals(NAME_WITH_LATIN1, p.getText());
+        assertEquals(NAME_WITH_LATIN1, p.getString());
         assertToken(JsonToken.VALUE_STRING, p.nextToken());
-        assertEquals(VALUE2, p.getText());
+        assertEquals(VALUE2, p.getString());
         assertToken(JsonToken.END_OBJECT, p.nextToken());
 
         assertToken(JsonToken.START_OBJECT, p.nextToken());
         assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
-        assertEquals(NAME_WITH_LATIN1, p.getText());
+        assertEquals(NAME_WITH_LATIN1, p.getString());
         assertToken(JsonToken.VALUE_STRING, p.nextToken());
-        assertEquals(VALUE_WITH_QUOTES, p.getText());
+        assertEquals(VALUE_WITH_QUOTES, p.getString());
         assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
-        assertEquals(NAME_WITH_QUOTES, p.getText());
+        assertEquals(NAME_WITH_QUOTES, p.getString());
         assertToken(JsonToken.VALUE_STRING, p.nextToken());
-        assertEquals(VALUE2, p.getText());
+        assertEquals(VALUE2, p.getString());
         assertToken(JsonToken.END_OBJECT, p.nextToken());
 
         assertToken(JsonToken.END_ARRAY, p.nextToken());

--- a/src/test/java/tools/jackson/core/write/SurrogateWrite223Test.java
+++ b/src/test/java/tools/jackson/core/write/SurrogateWrite223Test.java
@@ -49,7 +49,7 @@ class SurrogateWrite223Test extends JUnit5TestBase
         JsonParser p = f.createParser(ObjectReadContext.empty(), out.toByteArray());
         assertToken(JsonToken.START_ARRAY, p.nextToken());
         assertToken(JsonToken.VALUE_STRING, p.nextToken());
-        assertEquals(toQuote, p.getText());
+        assertEquals(toQuote, p.getString());
         assertToken(JsonToken.END_ARRAY, p.nextToken());
         p.close();
 
@@ -86,7 +86,7 @@ class SurrogateWrite223Test extends JUnit5TestBase
         try (JsonParser p = DEFAULT_JSON_F.createParser(ObjectReadContext.empty(), out.toString())) {
             assertToken(JsonToken.START_ARRAY, p.nextToken());
             assertToken(JsonToken.VALUE_STRING, p.nextToken());
-            assertEquals(toQuote, p.getText());
+            assertEquals(toQuote, p.getString());
             assertToken(JsonToken.END_ARRAY, p.nextToken());
         }
     }

--- a/src/test/java/tools/jackson/core/write/UTF8GeneratorTest.java
+++ b/src/test/java/tools/jackson/core/write/UTF8GeneratorTest.java
@@ -49,7 +49,7 @@ class UTF8GeneratorTest extends JUnit5TestBase
             assertEquals(1, p.getIntValue());
         }
         assertToken(JsonToken.VALUE_STRING, p.nextToken());
-        assertEquals(str, p.getText());
+        assertEquals(str, p.getString());
         assertNull(p.nextToken());
         p.close();
     }
@@ -101,7 +101,7 @@ class UTF8GeneratorTest extends JUnit5TestBase
         JsonParser jp = JSON_F.createParser(ObjectReadContext.empty(), JSON);
         assertToken(JsonToken.START_ARRAY, jp.nextToken());
         assertToken(JsonToken.VALUE_STRING, jp.nextToken());
-        String str = jp.getText();
+        String str = jp.getString();
         assertEquals(2, str.length());
         assertEquals((char) 0xD83D, str.charAt(0));
         assertEquals((char) 0xDE0C, str.charAt(1));
@@ -151,7 +151,7 @@ class UTF8GeneratorTest extends JUnit5TestBase
             assertEquals("escapes", p.currentName());
     
             assertToken(JsonToken.VALUE_STRING, p.nextToken());
-            assertEquals(SAMPLE_WITH_QUOTES, p.getText());
+            assertEquals(SAMPLE_WITH_QUOTES, p.getString());
             assertToken(JsonToken.END_OBJECT, p.nextToken());
             assertNull(p.nextToken());
         }


### PR DESCRIPTION
as well as other `JsonParser` methods with `Text` in them.