### PR TITLE
Fix issue where the parser can read back old number state when parsing later numbers

### DIFF
--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -14,6 +14,12 @@ a pure JSON library.
 === Releases ===
 ------------------------------------------------------------------------
 
+2.17.4 (not yet released)
+
+#1391: Fix issue where the parser can read back old number state when
+  parsing later numbers
+ (fix contributed by @pjfanning)
+
 2.17.3 (01-Nov-2024)
 
 #1331: Update to FastDoubleParser v1.0.1 to fix `BigDecimal` decoding problem
@@ -23,7 +29,6 @@ a pure JSON library.
 #1352: Fix infinite loop due to integer overflow when reading large strings
  (reported by Adam J.S)
  (fix contributed by @pjfanning)
- 
 
 2.17.2 (05-Jul-2024)
 

--- a/src/main/java/com/fasterxml/jackson/core/base/ParserBase.java
+++ b/src/main/java/com/fasterxml/jackson/core/base/ParserBase.java
@@ -790,6 +790,7 @@ public abstract class ParserBase extends ParserMinimalBase
             }
             if ((_numTypesValid & NR_INT) == 0) { // wasn't an int natively?
                 convertNumberToInt(); // let's make it so, if possible
+                _numberString = null;
             }
         }
         return _numberInt;
@@ -804,6 +805,7 @@ public abstract class ParserBase extends ParserMinimalBase
             }
             if ((_numTypesValid & NR_LONG) == 0) {
                 convertNumberToLong();
+                _numberString = null;
             }
         }
         return _numberLong;
@@ -818,6 +820,8 @@ public abstract class ParserBase extends ParserMinimalBase
             }
             if ((_numTypesValid & NR_BIGINT) == 0) {
                 convertNumberToBigInteger();
+                _numberString = null;
+                return _numberBigInt;
             }
         }
         return _getBigInteger();
@@ -840,6 +844,8 @@ public abstract class ParserBase extends ParserMinimalBase
             }
             if ((_numTypesValid & NR_FLOAT) == 0) {
                 convertNumberToFloat();
+                _numberString = null;
+                return _numberFloat;
             }
         }
         return _getNumberFloat();
@@ -854,6 +860,8 @@ public abstract class ParserBase extends ParserMinimalBase
             }
             if ((_numTypesValid & NR_DOUBLE) == 0) {
                 convertNumberToDouble();
+                _numberString = null;
+                return _numberDouble;
             }
         }
         return _getNumberDouble();
@@ -868,6 +876,8 @@ public abstract class ParserBase extends ParserMinimalBase
             }
             if ((_numTypesValid & NR_BIGDECIMAL) == 0) {
                 convertNumberToBigDecimal();
+                _numberString = null;
+                return _numberBigDecimal;
             }
         }
         return _getBigDecimal();

--- a/src/main/java/com/fasterxml/jackson/core/base/ParserBase.java
+++ b/src/main/java/com/fasterxml/jackson/core/base/ParserBase.java
@@ -790,7 +790,6 @@ public abstract class ParserBase extends ParserMinimalBase
             }
             if ((_numTypesValid & NR_INT) == 0) { // wasn't an int natively?
                 convertNumberToInt(); // let's make it so, if possible
-                _numberString = null;
             }
         }
         return _numberInt;
@@ -805,7 +804,6 @@ public abstract class ParserBase extends ParserMinimalBase
             }
             if ((_numTypesValid & NR_LONG) == 0) {
                 convertNumberToLong();
-                _numberString = null;
             }
         }
         return _numberLong;
@@ -820,7 +818,6 @@ public abstract class ParserBase extends ParserMinimalBase
             }
             if ((_numTypesValid & NR_BIGINT) == 0) {
                 convertNumberToBigInteger();
-                _numberString = null;
                 return _numberBigInt;
             }
         }
@@ -844,7 +841,6 @@ public abstract class ParserBase extends ParserMinimalBase
             }
             if ((_numTypesValid & NR_FLOAT) == 0) {
                 convertNumberToFloat();
-                _numberString = null;
                 return _numberFloat;
             }
         }
@@ -860,7 +856,6 @@ public abstract class ParserBase extends ParserMinimalBase
             }
             if ((_numTypesValid & NR_DOUBLE) == 0) {
                 convertNumberToDouble();
-                _numberString = null;
                 return _numberDouble;
             }
         }
@@ -876,7 +871,6 @@ public abstract class ParserBase extends ParserMinimalBase
             }
             if ((_numTypesValid & NR_BIGDECIMAL) == 0) {
                 convertNumberToBigDecimal();
-                _numberString = null;
                 return _numberBigDecimal;
             }
         }

--- a/src/test/java/com/fasterxml/jackson/core/read/JsonNumberParsingTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/read/JsonNumberParsingTest.java
@@ -1,0 +1,37 @@
+package com.fasterxml.jackson.core.read;
+
+import com.fasterxml.jackson.core.JUnit5TestBase;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.core.TokenStreamFactory;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class JsonNumberParsingTest extends JUnit5TestBase
+{
+    // [jackson-databind#4917]
+    @Test
+    public void bigDecimal4917() throws Exception
+    {
+        final String json = a2q("{'decimalHolder':100.00,'number':50}");
+        TokenStreamFactory jsonF = newStreamFactory();
+        for (int mode : ALL_MODES) {
+            try (JsonParser p = createParser(jsonF, MODE_READER, json)) {
+                assertToken(JsonToken.START_OBJECT, p.nextToken());
+                assertToken(JsonToken.FIELD_NAME, p.nextToken());
+                assertEquals("decimalHolder", p.currentName());
+                assertToken(JsonToken.VALUE_NUMBER_FLOAT, p.nextToken());
+                assertEquals(new BigDecimal("100.00"), p.getDecimalValue());
+                assertToken(JsonToken.FIELD_NAME, p.nextToken());
+                assertEquals("number", p.currentName());
+                assertToken(JsonToken.VALUE_NUMBER_INT, p.nextToken());
+                assertEquals(50.0, p.getDoubleValue());
+                assertEquals(50, p.getIntValue());
+                assertToken(JsonToken.END_OBJECT, p.nextToken());
+            }
+        }
+    }
+}

--- a/src/test/java/com/fasterxml/jackson/core/read/JsonNumberParsingTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/read/JsonNumberParsingTest.java
@@ -19,15 +19,18 @@ class JsonNumberParsingTest extends JUnit5TestBase
         final String json = a2q("{'decimalHolder':100.00,'number':50}");
         TokenStreamFactory jsonF = newStreamFactory();
         for (int mode : ALL_MODES) {
-            try (JsonParser p = createParser(jsonF, MODE_READER, json)) {
+            try (JsonParser p = createParser(jsonF, mode, json)) {
                 assertToken(JsonToken.START_OBJECT, p.nextToken());
                 assertToken(JsonToken.FIELD_NAME, p.nextToken());
                 assertEquals("decimalHolder", p.currentName());
                 assertToken(JsonToken.VALUE_NUMBER_FLOAT, p.nextToken());
+                assertEquals("100.00", p.getNumberValueDeferred());
                 assertEquals(new BigDecimal("100.00"), p.getDecimalValue());
+                assertEquals("100.00", p.getText());
                 assertToken(JsonToken.FIELD_NAME, p.nextToken());
                 assertEquals("number", p.currentName());
                 assertToken(JsonToken.VALUE_NUMBER_INT, p.nextToken());
+                assertEquals(Integer.valueOf(50), p.getNumberValueDeferred());
                 assertEquals(50.0, p.getDoubleValue());
                 assertEquals(50, p.getIntValue());
                 assertToken(JsonToken.END_OBJECT, p.nextToken());

--- a/src/test/java/com/fasterxml/jackson/core/read/JsonNumberParsingTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/read/JsonNumberParsingTest.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.core.TokenStreamFactory;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
 import java.math.BigDecimal;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -19,24 +20,35 @@ class JsonNumberParsingTest extends JUnit5TestBase
         final String json = a2q("{'decimalHolder':100.00,'number':50}");
         TokenStreamFactory jsonF = newStreamFactory();
         for (int mode : ALL_MODES) {
-            try (JsonParser p = createParser(jsonF, mode, json)) {
-                assertToken(JsonToken.START_OBJECT, p.nextToken());
-                assertToken(JsonToken.FIELD_NAME, p.nextToken());
-                assertEquals("decimalHolder", p.currentName());
-                assertToken(JsonToken.VALUE_NUMBER_FLOAT, p.nextToken());
-                assertEquals(JsonParser.NumberType.DOUBLE, p.getNumberType());
+            testBigDecimal4917(jsonF, mode, json, false);
+            testBigDecimal4917(jsonF, mode, json, true);
+        }
+    }
+
+    private void testBigDecimal4917(final TokenStreamFactory jsonF,
+                                    final int mode,
+                                    final String json,
+                                    final boolean checkFirstNumValues) throws IOException {
+        // checkFirstNumValues=false reproduces the issue in https://github.com/FasterXML/jackson-databind/issues/4917
+        try (JsonParser p = createParser(jsonF, mode, json)) {
+            assertToken(JsonToken.START_OBJECT, p.nextToken());
+            assertToken(JsonToken.FIELD_NAME, p.nextToken());
+            assertEquals("decimalHolder", p.currentName());
+            assertToken(JsonToken.VALUE_NUMBER_FLOAT, p.nextToken());
+            assertEquals(JsonParser.NumberType.DOUBLE, p.getNumberType());
+            if (checkFirstNumValues) {
                 assertEquals(Double.valueOf(100.0), p.getNumberValueDeferred());
                 assertEquals(new BigDecimal("100.00"), p.getDecimalValue());
-                assertEquals("100.00", p.getText());
-                assertToken(JsonToken.FIELD_NAME, p.nextToken());
-                assertEquals("number", p.currentName());
-                assertToken(JsonToken.VALUE_NUMBER_INT, p.nextToken());
-                assertEquals(JsonParser.NumberType.INT, p.getNumberType());
-                assertEquals(Integer.valueOf(50), p.getNumberValueDeferred());
-                assertEquals(50.0, p.getDoubleValue());
-                assertEquals(50, p.getIntValue());
-                assertToken(JsonToken.END_OBJECT, p.nextToken());
             }
+            assertEquals("100.00", p.getText());
+            assertToken(JsonToken.FIELD_NAME, p.nextToken());
+            assertEquals("number", p.currentName());
+            assertToken(JsonToken.VALUE_NUMBER_INT, p.nextToken());
+            assertEquals(JsonParser.NumberType.INT, p.getNumberType());
+            assertEquals(Integer.valueOf(50), p.getNumberValueDeferred());
+            assertEquals(50.0, p.getDoubleValue());
+            assertEquals(50, p.getIntValue());
+            assertToken(JsonToken.END_OBJECT, p.nextToken());
         }
     }
 }

--- a/src/test/java/com/fasterxml/jackson/core/read/JsonNumberParsingTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/read/JsonNumberParsingTest.java
@@ -24,12 +24,14 @@ class JsonNumberParsingTest extends JUnit5TestBase
                 assertToken(JsonToken.FIELD_NAME, p.nextToken());
                 assertEquals("decimalHolder", p.currentName());
                 assertToken(JsonToken.VALUE_NUMBER_FLOAT, p.nextToken());
-                assertEquals("100.00", p.getNumberValueDeferred());
+                assertEquals(JsonParser.NumberType.DOUBLE, p.getNumberType());
+                assertEquals(Double.valueOf(100.0), p.getNumberValueDeferred());
                 assertEquals(new BigDecimal("100.00"), p.getDecimalValue());
                 assertEquals("100.00", p.getText());
                 assertToken(JsonToken.FIELD_NAME, p.nextToken());
                 assertEquals("number", p.currentName());
                 assertToken(JsonToken.VALUE_NUMBER_INT, p.nextToken());
+                assertEquals(JsonParser.NumberType.INT, p.getNumberType());
                 assertEquals(Integer.valueOf(50), p.getNumberValueDeferred());
                 assertEquals(50.0, p.getDoubleValue());
                 assertEquals(50, p.getIntValue());

--- a/src/test/java/com/fasterxml/jackson/core/read/NumberParsingDb4917Test.java
+++ b/src/test/java/com/fasterxml/jackson/core/read/NumberParsingDb4917Test.java
@@ -29,6 +29,7 @@ class NumberParsingDb4917Test extends JUnit5TestBase
         }
     }
 
+    @Test
     public void bigDecimal4917Floats() throws Exception
     {
         for (int mode : ALL_MODES) {

--- a/src/test/java/com/fasterxml/jackson/core/read/NumberParsingDb4917Test.java
+++ b/src/test/java/com/fasterxml/jackson/core/read/NumberParsingDb4917Test.java
@@ -1,41 +1,50 @@
 package com.fasterxml.jackson.core.read;
 
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+import org.junit.jupiter.api.Test;
+
 import com.fasterxml.jackson.core.JUnit5TestBase;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.core.TokenStreamFactory;
-import org.junit.jupiter.api.Test;
-
-import java.io.IOException;
-import java.math.BigDecimal;
-import java.math.BigInteger;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-class JsonNumberParsingTest extends JUnit5TestBase
+class NumberParsingDb4917Test extends JUnit5TestBase
 {
+    private TokenStreamFactory JSON_F = newStreamFactory();
+
+    final String INPUT_JSON = a2q("{'decimalHolder':100.00,'number':50}");
+
     // [jackson-databind#4917]
     @Test
-    public void bigDecimal4917() throws Exception
+    public void bigDecimal4917Integers() throws Exception
     {
-        final String json = a2q("{'decimalHolder':100.00,'number':50}");
-        TokenStreamFactory jsonF = newStreamFactory();
         for (int mode : ALL_MODES) {
-            testBigDecimal4917(jsonF, mode, json, false, JsonParser.NumberType.DOUBLE);
-            testBigDecimal4917(jsonF, mode, json, true, JsonParser.NumberType.DOUBLE);
-            testBigDecimal4917(jsonF, mode, json, true, JsonParser.NumberType.FLOAT);
-            testBigDecimal4917(jsonF, mode, json, true, JsonParser.NumberType.BIG_DECIMAL);
-            testBigDecimal4917(jsonF, mode, json, true, JsonParser.NumberType.BIG_INTEGER);
-            testBigDecimal4917(jsonF, mode, json, true, JsonParser.NumberType.INT);
-            testBigDecimal4917(jsonF, mode, json, true, JsonParser.NumberType.LONG);
+            testBigDecimal4917(JSON_F, mode, INPUT_JSON, true, JsonParser.NumberType.BIG_INTEGER);
+            testBigDecimal4917(JSON_F, mode, INPUT_JSON, true, JsonParser.NumberType.INT);
+            testBigDecimal4917(JSON_F, mode, INPUT_JSON, true, JsonParser.NumberType.LONG);
         }
     }
 
+    public void bigDecimal4917Floats() throws Exception
+    {
+        for (int mode : ALL_MODES) {
+            testBigDecimal4917(JSON_F, mode, INPUT_JSON, false, JsonParser.NumberType.DOUBLE);
+            testBigDecimal4917(JSON_F, mode, INPUT_JSON, true, JsonParser.NumberType.DOUBLE);
+            testBigDecimal4917(JSON_F, mode, INPUT_JSON, true, JsonParser.NumberType.FLOAT);
+            testBigDecimal4917(JSON_F, mode, INPUT_JSON, true, JsonParser.NumberType.BIG_DECIMAL);
+        }
+    }
+    
     private void testBigDecimal4917(final TokenStreamFactory jsonF,
-                                    final int mode,
-                                    final String json,
-                                    final boolean checkFirstNumValues,
-                                    final JsonParser.NumberType secondNumTypeCheck) throws IOException {
+            final int mode,
+            final String json,
+            final boolean checkFirstNumValues,
+            final JsonParser.NumberType secondNumTypeCheck) throws Exception
+    {
         // checkFirstNumValues=false reproduces the issue in https://github.com/FasterXML/jackson-databind/issues/4917
         // it is useful to check the second number value while requesting different number types
         // but the call adjusts state of the parser, so it is better to redo the test and then test w


### PR DESCRIPTION
* new version of #1389 but targeted at 2.17 branch
* only the original test in https://github.com/FasterXML/jackson-databind/pull/4918 is affected by the bug - similar tests (V2, V3, etc) are not affected.
* Aim is to use this fix for patch releases but to later try a bigger change to better manage number state in the parser code - in the 2.19 development branch