### PR TITLE
fix the surrogate utf8 feature when custom characterEscapes is used

### DIFF
--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -461,3 +461,9 @@ Justin Gosselin (@jgosselin-accesso)
  * Reported #1359: Non-surrogate characters being incorrectly combined when
   `JsonWriteFeature.COMBINE_UNICODE_SURROGATES_IN_UTF8` is enabled
   (2.18.2)
+
+Haruki (@stackunderflow111)
+ * Reported #1398: feature COMBINE_UNICODE_SURROGATES_IN_UTF8 doesn't work
+  when custom characterEscape is used
+  (2.18.2)
+

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -20,6 +20,10 @@ a pure JSON library.
   parsing later numbers
  (fix contributed by @pjfanning)
 
+#1398: Fix issue that feature COMBINE_UNICODE_SURROGATES_IN_UTF8 doesn't work
+  when custom characterEscape is used
+ (reported and fixed by @stackunderflow111)
+
 2.18.2 (27-Nov-2024)
 
 #1359: Non-surrogate characters being incorrectly combined when

--- a/src/main/java/com/fasterxml/jackson/core/json/UTF8JsonGenerator.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/UTF8JsonGenerator.java
@@ -1732,6 +1732,16 @@ public class UTF8JsonGenerator
                 outputBuffer[outputPtr++] = (byte) (0xc0 | (ch >> 6));
                 outputBuffer[outputPtr++] = (byte) (0x80 | (ch & 0x3f));
             } else {
+                // 3- or 4-byte character
+                if (_isStartOfSurrogatePair(ch)) {
+                    final boolean combineSurrogates = Feature.COMBINE_UNICODE_SURROGATES_IN_UTF8.enabledIn(_features);
+                    if (combineSurrogates && offset < end) {
+                        char highSurrogate = (char) ch;
+                        char lowSurrogate = cbuf[offset++];
+                        outputPtr = _outputSurrogatePair(highSurrogate, lowSurrogate, outputPtr);
+                        continue;
+                    }
+                }
                 outputPtr = _outputMultiByteChar(ch, outputPtr);
             }
         }
@@ -1789,6 +1799,16 @@ public class UTF8JsonGenerator
                 outputBuffer[outputPtr++] = (byte) (0xc0 | (ch >> 6));
                 outputBuffer[outputPtr++] = (byte) (0x80 | (ch & 0x3f));
             } else {
+                // 3- or 4-byte character
+                if (_isStartOfSurrogatePair(ch)) {
+                    final boolean combineSurrogates = Feature.COMBINE_UNICODE_SURROGATES_IN_UTF8.enabledIn(_features);
+                    if (combineSurrogates && offset < end) {
+                        char highSurrogate = (char) ch;
+                        char lowSurrogate = text.charAt(offset++);
+                        outputPtr = _outputSurrogatePair(highSurrogate, lowSurrogate, outputPtr);
+                        continue;
+                    }
+                }
                 outputPtr = _outputMultiByteChar(ch, outputPtr);
             }
         }

--- a/src/test/java/com/fasterxml/jackson/core/write/SurrogateWrite223Test.java
+++ b/src/test/java/com/fasterxml/jackson/core/write/SurrogateWrite223Test.java
@@ -123,4 +123,21 @@ class SurrogateWrite223Test extends JUnit5TestBase
         assertTrue(json.contains("foo\u3042bar"));
         assertTrue(json.contains("\"test_emoji\":\"\uD83D\uDE0A\""));
     }
+
+    @Test
+    void checkSurrogateWithCharacterEscapes() throws Exception {
+        JsonFactory f = JsonFactory.builder()
+                .enable(JsonWriteFeature.COMBINE_UNICODE_SURROGATES_IN_UTF8)
+                .build();
+        f.setCharacterEscapes(JsonpCharacterEscapes.instance());
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try (JsonGenerator gen = f.createGenerator(out)) {
+            gen.writeStartObject();
+            // Outside the BMP; 0x1F60A - emoji
+            gen.writeStringField("test_emoji", new String(Character.toChars(0x1F60A)));
+            gen.writeEndObject();
+        }
+        String json = out.toString("UTF-8");
+        assertEquals("{\"test_emoji\":\"\uD83D\uDE0A\"}", json);
+    }
 }


### PR DESCRIPTION
Issue: https://github.com/FasterXML/jackson-core/issues/1398

Fixed by applying what I have described in the issue: just port the changes we made in https://github.com/FasterXML/jackson-core/pull/1335 and https://github.com/FasterXML/jackson-core/pull/1360 to the two `_writeCustomStringSegment2()` methods.