### PR TITLE
Changes post #4917: forcibly clear `_numberString` when new number token set

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/base/ParserBase.java
+++ b/src/main/java/com/fasterxml/jackson/core/base/ParserBase.java
@@ -597,6 +597,7 @@ public abstract class ParserBase extends ParserMinimalBase
         _fractLength = 0;
         _expLength = 0;
         _numTypesValid = NR_UNKNOWN; // to force decoding
+        _numberString = null;
         return JsonToken.VALUE_NUMBER_INT;
     }
 
@@ -611,6 +612,7 @@ public abstract class ParserBase extends ParserMinimalBase
         _fractLength = fractLen;
         _expLength = expLen;
         _numTypesValid = NR_UNKNOWN; // to force decoding
+        _numberString = null;
         return JsonToken.VALUE_NUMBER_FLOAT;
     }
 
@@ -621,6 +623,7 @@ public abstract class ParserBase extends ParserMinimalBase
         _numberDouble = value;
         _numTypesValid = NR_DOUBLE;
         _numberIsNaN = true;
+        _numberString = null;
         return JsonToken.VALUE_NUMBER_FLOAT;
     }
 

--- a/src/test/java/com/fasterxml/jackson/core/read/NumberParsing1397Test.java
+++ b/src/test/java/com/fasterxml/jackson/core/read/NumberParsing1397Test.java
@@ -35,6 +35,7 @@ class NumberParsing1397Test extends JUnit5TestBase
                            final String json,
                            final boolean checkFirstNumValues) throws Exception
     {
+        // checkFirstNumValues=false reproduces the issue in https://github.com/FasterXML/jackson-core/issues/1397
         try (JsonParser p = createParser(jsonF, mode, json)) {
             assertToken(JsonToken.START_OBJECT, p.nextToken());
             assertToken(JsonToken.FIELD_NAME, p.nextToken());


### PR DESCRIPTION
* based on extra report in #1397 
* additional test case added