### PR TITLE
Enforce JaCoCo execution by default with opt-out via jacocoStrict

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,8 +60,6 @@ com.fasterxml.jackson.core.*;version=${project.version}
     <project.build.outputTimestamp>2024-09-27T01:42:02Z</project.build.outputTimestamp>
 
     <!-- for validation of JaCoCo execution -->
-    <version.maven-enforcer-plugin>3.5.0</version.maven-enforcer-plugin>
-    <version.jacoco-maven-plugin>0.8.12</version.jacoco-maven-plugin>
     <jacocoStrict>true</jacocoStrict>
   </properties>
 
@@ -90,13 +88,10 @@ com.fasterxml.jackson.core.*;version=${project.version}
             <goals>
               <goal>prepare-agent</goal>
             </goals>
-	    <configuration>
-      	      <propertyName>jacoco.argLine</propertyName>
-            </configuration>
           </execution>
           <execution>
             <id>report</id>
-            <phase>test</phase>
+            <phase>verify</phase>
             <goals>
               <goal>report</goal>
             </goals>
@@ -115,7 +110,7 @@ com.fasterxml.jackson.core.*;version=${project.version}
           </execution>
 	  <execution>
             <id>enforce-jacoco-exec</id>
-            <phase>test</phase>
+            <phase>verify</phase>
             <goals>
                 <goal>enforce</goal>
             </goals>

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,11 @@ com.fasterxml.jackson.core.*;version=${project.version}
 
     <!-- for Reproducible Builds -->
     <project.build.outputTimestamp>2024-09-27T01:42:02Z</project.build.outputTimestamp>
+
+    <!-- for validation of JaCoCo execution -->
+    <version.maven-enforcer-plugin>3.5.0</version.maven-enforcer-plugin>
+    <version.jacoco-maven-plugin>0.8.12</version.jacoco-maven-plugin>
+    <jacocoStrict>true</jacocoStrict>
   </properties>
 
   <!-- Alas, need to include snapshot reference since otherwise can not find
@@ -85,6 +90,9 @@ com.fasterxml.jackson.core.*;version=${project.version}
             <goals>
               <goal>prepare-agent</goal>
             </goals>
+	    <configuration>
+      	      <propertyName>jacoco.argLine</propertyName>
+            </configuration>
           </execution>
           <execution>
             <id>report</id>
@@ -104,6 +112,23 @@ com.fasterxml.jackson.core.*;version=${project.version}
             <id>enforce-properties</id>
 	        <phase>validate</phase>
             <goals><goal>enforce</goal></goals>
+          </execution>
+	  <execution>
+            <id>enforce-jacoco-exec</id>
+            <phase>test</phase>
+            <goals>
+                <goal>enforce</goal>
+            </goals>
+            <configuration>
+                <rules>
+                    <requireFilesExist>
+                        <files>
+                            <file>${project.build.directory}/jacoco.exec</file>
+                        </files>
+                    </requireFilesExist>
+                </rules>
+                <fail>${jacocoStrict}</fail>
+            </configuration>
           </execution>
         </executions>
       </plugin>


### PR DESCRIPTION
Enforce JaCoCo execution by default, allowing opt-out via property  

- Added Maven Enforcer execution to fail the build if `jacoco.exec` is missing  
- Introduced `jacocoStrict` property (default: `true`) to enforce execution  
- Users can override with `-DjacocoStrict=false` if failure should be ignored  

This ensures JaCoCo always runs by default, aligning with the project's intent while allowing flexibility when needed, as suggested in this comment: https://github.com/FasterXML/jackson-databind/pull/4971#issuecomment-2660202497