### PR TITLE
Skip RS CTRL-CHAR to support JSON Text Sequence (RFC7464)

### DIFF
--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -467,6 +467,14 @@ Haruki (@stackunderflow111)
   when custom characterEscape is used
   (2.18.3)
 
+Yanming Zhou (@quaff)
+ * Requested #633: Allow skipping `RS` CTRL-CHAR to support JSON Text Sequences
+  (2.19.0)
+
+Fawzi Essam (@iifawzi)
+ * Contributed #633: Allow skipping `RS` CTRL-CHAR to support JSON Text Sequences
+  (2.19.0)
+
 Eduard Gomoliako (@Gems)
  * Contributed #1356: Make `JsonGenerator::writeTypePrefix` method to not write a
   `WRAPPER_ARRAY` when `typeIdDef.id == null`

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -16,6 +16,9 @@ a pure JSON library.
 
 2.19.0 (not yet released)
 
+#633: Allow skipping `RS` CTRL-CHAR to support JSON Text Sequences
+ (requested by Yanming Z)
+ (contributed by Fawzi E)
 #1328: Optimize handling of `JsonPointer.head()`
 #1356: Make `JsonGenerator::writeTypePrefix` method to not write a
   `WRAPPER_ARRAY` when `typeIdDef.id == null`

--- a/src/main/java/com/fasterxml/jackson/core/JsonParser.java
+++ b/src/main/java/com/fasterxml/jackson/core/JsonParser.java
@@ -194,6 +194,19 @@ public abstract class JsonParser
         ALLOW_UNQUOTED_CONTROL_CHARS(false),
 
         /**
+         * Feature that determines whether parser will allow
+         * Record Separator (RS) control character ({@code 0x1E})
+         * as part of ignorable whitespace in JSON input, similar to the TAB character.
+         * <p>
+         * Since the official JSON specification permits only a limited set of control
+         * characters as whitespace, this is a non-standard feature and is disabled by default.
+         * </p>
+         *
+         * @since 2.18
+         */
+        ALLOW_RS_CONTROL_CHAR(false),
+
+        /**
          * Feature that can be enabled to accept quoting of all character
          * using backslash quoting mechanism: if not enabled, only characters
          * that are explicitly listed by JSON specification can be thus

--- a/src/main/java/com/fasterxml/jackson/core/JsonParser.java
+++ b/src/main/java/com/fasterxml/jackson/core/JsonParser.java
@@ -202,7 +202,7 @@ public abstract class JsonParser
          * characters as whitespace, this is a non-standard feature and is disabled by default.
          * </p>
          *
-         * @since 2.18
+         * @since 2.19
          */
         ALLOW_RS_CONTROL_CHAR(false),
 

--- a/src/main/java/com/fasterxml/jackson/core/JsonParser.java
+++ b/src/main/java/com/fasterxml/jackson/core/JsonParser.java
@@ -194,16 +194,9 @@ public abstract class JsonParser
         ALLOW_UNQUOTED_CONTROL_CHARS(false),
 
         /**
-         * Feature that determines whether parser will allow
-         * Record Separator (RS) control character ({@code 0x1E})
-         * as part of ignorable whitespace in JSON input, similar to the TAB character.
-         * <p>
-         * Since the official JSON specification permits only a limited set of control
-         * characters as whitespace, this is a non-standard feature and is disabled by default.
-         * </p>
-         *
-         * @since 2.19
+         * @deprecated Use {@link com.fasterxml.jackson.core.json.JsonReadFeature#ALLOW_RS_CONTROL_CHAR} instead
          */
+        @Deprecated // but due to technical reasons we need this entry too
         ALLOW_RS_CONTROL_CHAR(false),
 
         /**

--- a/src/main/java/com/fasterxml/jackson/core/base/ParserMinimalBase.java
+++ b/src/main/java/com/fasterxml/jackson/core/base/ParserMinimalBase.java
@@ -770,6 +770,12 @@ public abstract class ParserMinimalBase extends JsonParser
     protected void _throwInvalidSpace(int i) throws JsonParseException {
         char c = (char) i;
         String msg = "Illegal character ("+_getCharDesc(c)+"): only regular white space (\\r, \\n, \\t, \\u001E) is allowed between tokens";
+
+        if (i == INT_RS) {
+            msg += " Consider enabling ALLOW_RS_CONTROL_CHAR feature to allow use of record separators (\\u001E).";
+        }
+
+
         throw _constructReadException(msg);
     }
 

--- a/src/main/java/com/fasterxml/jackson/core/base/ParserMinimalBase.java
+++ b/src/main/java/com/fasterxml/jackson/core/base/ParserMinimalBase.java
@@ -772,10 +772,8 @@ public abstract class ParserMinimalBase extends JsonParser
         String msg = "Illegal character ("+_getCharDesc(c)+"): only regular white space (\\r, \\n, \\t) is allowed between tokens";
 
         if (i == INT_RS) {
-            msg += " Consider enabling ALLOW_RS_CONTROL_CHAR feature to allow use of record separators (\\u001E).";
+            msg += " (consider enabling `JsonReadFeature.ALLOW_RS_CONTROL_CHAR` feature to allow use of Record Separators (\\u001E).";
         }
-
-
         throw _constructReadException(msg);
     }
 

--- a/src/main/java/com/fasterxml/jackson/core/base/ParserMinimalBase.java
+++ b/src/main/java/com/fasterxml/jackson/core/base/ParserMinimalBase.java
@@ -31,6 +31,7 @@ public abstract class ParserMinimalBase extends JsonParser
     protected final static int INT_LF = '\n';
     protected final static int INT_CR = '\r';
     protected final static int INT_SPACE = 0x0020;
+    protected final static int INT_RS = 0x001E;
 
     // Markup
     protected final static int INT_LBRACKET = '[';
@@ -768,7 +769,7 @@ public abstract class ParserMinimalBase extends JsonParser
     
     protected void _throwInvalidSpace(int i) throws JsonParseException {
         char c = (char) i;
-        String msg = "Illegal character ("+_getCharDesc(c)+"): only regular white space (\\r, \\n, \\t) is allowed between tokens";
+        String msg = "Illegal character ("+_getCharDesc(c)+"): only regular white space (\\r, \\n, \\t, \\u001E) is allowed between tokens";
         throw _constructReadException(msg);
     }
 

--- a/src/main/java/com/fasterxml/jackson/core/base/ParserMinimalBase.java
+++ b/src/main/java/com/fasterxml/jackson/core/base/ParserMinimalBase.java
@@ -769,7 +769,7 @@ public abstract class ParserMinimalBase extends JsonParser
     
     protected void _throwInvalidSpace(int i) throws JsonParseException {
         char c = (char) i;
-        String msg = "Illegal character ("+_getCharDesc(c)+"): only regular white space (\\r, \\n, \\t, \\u001E) is allowed between tokens";
+        String msg = "Illegal character ("+_getCharDesc(c)+"): only regular white space (\\r, \\n, \\t) is allowed between tokens";
 
         if (i == INT_RS) {
             msg += " Consider enabling ALLOW_RS_CONTROL_CHAR feature to allow use of record separators (\\u001E).";

--- a/src/main/java/com/fasterxml/jackson/core/json/JsonParserBase.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/JsonParserBase.java
@@ -26,6 +26,9 @@ public abstract class JsonParserBase
     protected final static int FEAT_MASK_NON_NUM_NUMBERS = Feature.ALLOW_NON_NUMERIC_NUMBERS.getMask();
     @SuppressWarnings("deprecation")
     protected final static int FEAT_MASK_ALLOW_MISSING = Feature.ALLOW_MISSING_VALUES.getMask();
+    @SuppressWarnings("deprecation")
+    protected final static int FEAT_MASK_ALLOW_CTRL_RS = Feature.ALLOW_RS_CONTROL_CHAR.getMask();
+    
     protected final static int FEAT_MASK_ALLOW_SINGLE_QUOTES = Feature.ALLOW_SINGLE_QUOTES.getMask();
     protected final static int FEAT_MASK_ALLOW_UNQUOTED_NAMES = Feature.ALLOW_UNQUOTED_FIELD_NAMES.getMask();
     protected final static int FEAT_MASK_ALLOW_JAVA_COMMENTS = Feature.ALLOW_COMMENTS.getMask();
@@ -129,5 +132,16 @@ public abstract class JsonParserBase
     @Override
     public final JsonLocation getTokenLocation() {
         return currentTokenLocation();
+    }
+
+    /*
+    /**********************************************************************
+    /* Other helper methods
+    /**********************************************************************
+     */
+
+    // @since 2.19
+    protected boolean _isAllowedCtrlCharRS(int i) {
+        return (i == INT_RS)  && (_features & FEAT_MASK_ALLOW_CTRL_RS) != 0;
     }
 }

--- a/src/main/java/com/fasterxml/jackson/core/json/JsonParserBase.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/JsonParserBase.java
@@ -30,6 +30,7 @@ public abstract class JsonParserBase
     protected final static int FEAT_MASK_ALLOW_UNQUOTED_NAMES = Feature.ALLOW_UNQUOTED_FIELD_NAMES.getMask();
     protected final static int FEAT_MASK_ALLOW_JAVA_COMMENTS = Feature.ALLOW_COMMENTS.getMask();
     protected final static int FEAT_MASK_ALLOW_YAML_COMMENTS = Feature.ALLOW_YAML_COMMENTS.getMask();
+    protected final static int FEAT_MASK_ALLOW_RS_CTRL_CHAR = Feature.ALLOW_RS_CONTROL_CHAR.getMask();
 
     // Latin1 encoding is not supported, but we do use 8-bit subset for
     // pre-processing task, to simplify first pass, keep it fast.

--- a/src/main/java/com/fasterxml/jackson/core/json/JsonParserBase.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/JsonParserBase.java
@@ -30,7 +30,6 @@ public abstract class JsonParserBase
     protected final static int FEAT_MASK_ALLOW_UNQUOTED_NAMES = Feature.ALLOW_UNQUOTED_FIELD_NAMES.getMask();
     protected final static int FEAT_MASK_ALLOW_JAVA_COMMENTS = Feature.ALLOW_COMMENTS.getMask();
     protected final static int FEAT_MASK_ALLOW_YAML_COMMENTS = Feature.ALLOW_YAML_COMMENTS.getMask();
-    protected final static int FEAT_MASK_ALLOW_RS_CTRL_CHAR = Feature.ALLOW_RS_CONTROL_CHAR.getMask();
 
     // Latin1 encoding is not supported, but we do use 8-bit subset for
     // pre-processing task, to simplify first pass, keep it fast.

--- a/src/main/java/com/fasterxml/jackson/core/json/JsonReadFeature.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/JsonReadFeature.java
@@ -89,7 +89,7 @@ public enum JsonReadFeature
      * characters as whitespace, this is a non-standard feature and is disabled by default.
      * </p>
      *
-     * @since 2.18
+     * @since 2.19
      */
     ALLOW_RS_CONTROL_CHAR(false, JsonParser.Feature.ALLOW_RS_CONTROL_CHAR),
 

--- a/src/main/java/com/fasterxml/jackson/core/json/JsonReadFeature.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/JsonReadFeature.java
@@ -87,10 +87,10 @@ public enum JsonReadFeature
      * <p>
      * Since the official JSON specification permits only a limited set of control
      * characters as whitespace, this is a non-standard feature and is disabled by default.
-     * </p>
      *
      * @since 2.19
      */
+    @SuppressWarnings("deprecation")
     ALLOW_RS_CONTROL_CHAR(false, JsonParser.Feature.ALLOW_RS_CONTROL_CHAR),
 
     /**

--- a/src/main/java/com/fasterxml/jackson/core/json/JsonReadFeature.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/JsonReadFeature.java
@@ -81,6 +81,19 @@ public enum JsonReadFeature
     ALLOW_UNESCAPED_CONTROL_CHARS(false, JsonParser.Feature.ALLOW_UNQUOTED_CONTROL_CHARS),
 
     /**
+     * Feature that determines whether parser will allow
+     * Record Separator (RS) control character ({@code 0x1E})
+     * as part of ignorable whitespace in JSON input, similar to the TAB character.
+     * <p>
+     * Since the official JSON specification permits only a limited set of control
+     * characters as whitespace, this is a non-standard feature and is disabled by default.
+     * </p>
+     *
+     * @since 2.18
+     */
+    ALLOW_RS_CONTROL_CHAR(false, JsonParser.Feature.ALLOW_RS_CONTROL_CHAR),
+
+    /**
      * Feature that can be enabled to accept quoting of all character
      * using backslash quoting mechanism: if not enabled, only characters
      * that are explicitly listed by JSON specification can be thus

--- a/src/main/java/com/fasterxml/jackson/core/json/ReaderBasedJsonParser.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/ReaderBasedJsonParser.java
@@ -2498,13 +2498,14 @@ public class ReaderBasedJsonParser
             }
             return i;
         }
+        boolean n = !JsonParser.Feature.ALLOW_RS_CONTROL_CHAR.enabledIn(_features);
         if (i != INT_SPACE) {
             if (i == INT_LF) {
                 ++_currInputRow;
                 _currInputRowStart = _inputPtr;
             } else if (i == INT_CR) {
                 _skipCR();
-            } else if (i != INT_TAB && ((_features & FEAT_MASK_ALLOW_RS_CTRL_CHAR) == 0 || i != INT_RS)) {
+            } else if (i != INT_TAB && (!JsonParser.Feature.ALLOW_RS_CONTROL_CHAR.enabledIn(_features) || i != INT_RS)) {
                 _throwInvalidSpace(i);
             }
         }
@@ -2524,7 +2525,7 @@ public class ReaderBasedJsonParser
                     _currInputRowStart = _inputPtr;
                 } else if (i == INT_CR) {
                     _skipCR();
-                } else if (i != INT_TAB && ((_features & FEAT_MASK_ALLOW_RS_CTRL_CHAR) == 0 || i != INT_RS)) {
+                } else if (i != INT_TAB && (!JsonParser.Feature.ALLOW_RS_CONTROL_CHAR.enabledIn(_features) || i != INT_RS)) {
                     _throwInvalidSpace(i);
                 }
             }

--- a/src/main/java/com/fasterxml/jackson/core/json/ReaderBasedJsonParser.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/ReaderBasedJsonParser.java
@@ -2504,7 +2504,7 @@ public class ReaderBasedJsonParser
                 _currInputRowStart = _inputPtr;
             } else if (i == INT_CR) {
                 _skipCR();
-            } else if (i != INT_TAB && (!JsonParser.Feature.ALLOW_RS_CONTROL_CHAR.enabledIn(_features) || i != INT_RS)) {
+            } else if (i != INT_TAB && !_isAllowedCtrlCharRS(i)) {
                 _throwInvalidSpace(i);
             }
         }
@@ -2524,7 +2524,7 @@ public class ReaderBasedJsonParser
                     _currInputRowStart = _inputPtr;
                 } else if (i == INT_CR) {
                     _skipCR();
-                } else if (i != INT_TAB && (!JsonParser.Feature.ALLOW_RS_CONTROL_CHAR.enabledIn(_features) || i != INT_RS)) {
+                } else if (i != INT_TAB && !_isAllowedCtrlCharRS(i)) {
                     _throwInvalidSpace(i);
                 }
             }

--- a/src/main/java/com/fasterxml/jackson/core/json/ReaderBasedJsonParser.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/ReaderBasedJsonParser.java
@@ -2498,7 +2498,6 @@ public class ReaderBasedJsonParser
             }
             return i;
         }
-        boolean n = !JsonParser.Feature.ALLOW_RS_CONTROL_CHAR.enabledIn(_features);
         if (i != INT_SPACE) {
             if (i == INT_LF) {
                 ++_currInputRow;

--- a/src/main/java/com/fasterxml/jackson/core/json/ReaderBasedJsonParser.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/ReaderBasedJsonParser.java
@@ -2504,7 +2504,7 @@ public class ReaderBasedJsonParser
                 _currInputRowStart = _inputPtr;
             } else if (i == INT_CR) {
                 _skipCR();
-            } else if (i != INT_TAB) {
+            } else if (i != INT_TAB && ((_features & FEAT_MASK_ALLOW_RS_CTRL_CHAR) == 0 || i != INT_RS)) {
                 _throwInvalidSpace(i);
             }
         }
@@ -2524,7 +2524,7 @@ public class ReaderBasedJsonParser
                     _currInputRowStart = _inputPtr;
                 } else if (i == INT_CR) {
                     _skipCR();
-                } else if (i != INT_TAB) {
+                } else if (i != INT_TAB && ((_features & FEAT_MASK_ALLOW_RS_CTRL_CHAR) == 0 || i != INT_RS)) {
                     _throwInvalidSpace(i);
                 }
             }

--- a/src/main/java/com/fasterxml/jackson/core/json/UTF8StreamJsonParser.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/UTF8StreamJsonParser.java
@@ -3080,7 +3080,7 @@ public class UTF8StreamJsonParser
                 _currInputRowStart = _inputPtr;
             } else if (i == INT_CR) {
                 _skipCR();
-            } else if (i != INT_TAB && (!JsonParser.Feature.ALLOW_RS_CONTROL_CHAR.enabledIn(_features) || i != INT_RS)) {
+            } else if (i != INT_TAB  && !_isAllowedCtrlCharRS(i)) {
                 _throwInvalidSpace(i);
             }
         }
@@ -3100,7 +3100,7 @@ public class UTF8StreamJsonParser
                     _currInputRowStart = _inputPtr;
                 } else if (i == INT_CR) {
                     _skipCR();
-                } else if (i != INT_TAB && (!JsonParser.Feature.ALLOW_RS_CONTROL_CHAR.enabledIn(_features) || i != INT_RS)) {
+                } else if (i != INT_TAB && !_isAllowedCtrlCharRS(i)) {
                     _throwInvalidSpace(i);
                 }
             }

--- a/src/main/java/com/fasterxml/jackson/core/json/UTF8StreamJsonParser.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/UTF8StreamJsonParser.java
@@ -3080,7 +3080,7 @@ public class UTF8StreamJsonParser
                 _currInputRowStart = _inputPtr;
             } else if (i == INT_CR) {
                 _skipCR();
-            } else if (i != INT_TAB) {
+            } else if (i != INT_TAB && (!JsonParser.Feature.ALLOW_RS_CONTROL_CHAR.enabledIn(_features) || i != INT_RS)) {
                 _throwInvalidSpace(i);
             }
         }
@@ -3100,7 +3100,7 @@ public class UTF8StreamJsonParser
                     _currInputRowStart = _inputPtr;
                 } else if (i == INT_CR) {
                     _skipCR();
-                } else if (i != INT_TAB) {
+                } else if (i != INT_TAB && (!JsonParser.Feature.ALLOW_RS_CONTROL_CHAR.enabledIn(_features) || i != INT_RS)) {
                     _throwInvalidSpace(i);
                 }
             }

--- a/src/main/java/com/fasterxml/jackson/core/json/async/NonBlockingUtf8JsonParserBase.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/async/NonBlockingUtf8JsonParserBase.java
@@ -3,7 +3,6 @@ package com.fasterxml.jackson.core.json.async;
 import java.io.IOException;
 
 import com.fasterxml.jackson.core.JsonParseException;
-import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.core.io.CharTypes;
 import com.fasterxml.jackson.core.io.IOContext;
@@ -943,7 +942,7 @@ public abstract class NonBlockingUtf8JsonParserBase
                 } else if (ch == INT_CR) {
                     ++_currInputRowAlt;
                     _currInputRowStart = _inputPtr;
-                } else if (ch != INT_TAB && (!JsonParser.Feature.ALLOW_RS_CONTROL_CHAR.enabledIn(_features) || ch != INT_RS)) {
+                } else if (ch != INT_TAB && !_isAllowedCtrlCharRS(ch)) {
                     _throwInvalidSpace(ch);
                 }
             }

--- a/src/main/java/com/fasterxml/jackson/core/json/async/NonBlockingUtf8JsonParserBase.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/async/NonBlockingUtf8JsonParserBase.java
@@ -3,6 +3,7 @@ package com.fasterxml.jackson.core.json.async;
 import java.io.IOException;
 
 import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.core.io.CharTypes;
 import com.fasterxml.jackson.core.io.IOContext;
@@ -942,7 +943,7 @@ public abstract class NonBlockingUtf8JsonParserBase
                 } else if (ch == INT_CR) {
                     ++_currInputRowAlt;
                     _currInputRowStart = _inputPtr;
-                } else if (ch != INT_TAB) {
+                } else if (ch != INT_TAB && (!JsonParser.Feature.ALLOW_RS_CONTROL_CHAR.enabledIn(_features) || ch != INT_RS)) {
                     _throwInvalidSpace(ch);
                 }
             }

--- a/src/test/java/com/fasterxml/jackson/core/json/JsonFactoryTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/json/JsonFactoryTest.java
@@ -405,7 +405,7 @@ class JsonFactoryTest
             assertEquals("key", field1);
             assertToken(JsonToken.VALUE_TRUE, parser.nextToken());
             assertToken(JsonToken.END_OBJECT, parser.nextToken());
-            parser.nextToken(); // 
+            parser.nextToken(); // RS token
             if (!recordSeparation) {
                 fail("Should have thrown an exception");
             }

--- a/src/test/java/com/fasterxml/jackson/core/read/NonStandardAllowRSTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/read/NonStandardAllowRSTest.java
@@ -1,0 +1,73 @@
+package com.fasterxml.jackson.core.read;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.core.*;
+import com.fasterxml.jackson.core.exc.StreamReadException;
+import com.fasterxml.jackson.core.json.JsonReadFeature;
+import com.fasterxml.jackson.core.json.async.NonBlockingJsonParser;
+
+// for [core#633]: optionally allow Record-Separator ctrl char
+class NonStandardAllowRSTest
+    extends JUnit5TestBase
+{
+    @Test
+    void recordSeparatorEnabled() throws Exception {
+        doRecordSeparationTest(true);
+    }
+
+    @Test
+    void recordSeparatorDisabled() throws Exception {
+        doRecordSeparationTest(false);
+    }
+
+    // Testing record separation for all parser implementations
+    private void doRecordSeparationTest(boolean recordSeparation) throws Exception {
+        String contents = "{\"key\":true}\u001E";
+        JsonFactory factory = JsonFactory.builder()
+                .configure(JsonReadFeature.ALLOW_RS_CONTROL_CHAR, recordSeparation)
+                .build();
+        try (JsonParser parser = factory.createParser(contents)) {
+            verifyRecordSeparation(parser, recordSeparation);
+        }
+        try (JsonParser parser = factory.createParser(new StringReader(contents))) {
+            verifyRecordSeparation(parser, recordSeparation);
+        }
+        try (JsonParser parser = factory.createParser(contents.getBytes(StandardCharsets.UTF_8))) {
+            verifyRecordSeparation(parser, recordSeparation);
+        }
+        try (NonBlockingJsonParser parser = (NonBlockingJsonParser) factory.createNonBlockingByteArrayParser()) {
+            byte[] data = contents.getBytes(StandardCharsets.UTF_8);
+            parser.feedInput(data, 0, data.length);
+            parser.endOfInput();
+            verifyRecordSeparation(parser, recordSeparation);
+        }
+    }
+
+    private void verifyRecordSeparation(JsonParser parser, boolean recordSeparation) throws Exception {
+        try {
+            assertToken(JsonToken.START_OBJECT, parser.nextToken());
+            String field1 = parser.nextFieldName();
+            assertEquals("key", field1);
+            assertToken(JsonToken.VALUE_TRUE, parser.nextToken());
+            assertToken(JsonToken.END_OBJECT, parser.nextToken());
+            parser.nextToken(); // RS token
+            if (!recordSeparation) {
+                fail("Should have thrown an exception");
+            }
+        } catch (StreamReadException e) {
+            if (!recordSeparation) {
+                verifyException(e, "Illegal character ((CTRL-CHAR");
+                verifyException(e, "consider enabling `JsonReadFeature.ALLOW_RS_CONTROL_CHAR`");
+            } else {
+                throw e;
+            }
+        }
+    }    
+}

--- a/src/test/java/com/fasterxml/jackson/core/read/ParserFeaturesTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/read/ParserFeaturesTest.java
@@ -157,9 +157,9 @@ class ParserFeaturesTest
 
         assertToken(JsonToken.START_ARRAY, p.nextToken());
         try {
-            p.nextToken(); // key
+            p.nextToken(); // val
             p.nextToken(); // ]
-            p.nextToken(); // 
+            p.nextToken(); // RS token
             fail("Expected exception");
         } catch (JsonParseException e) {
             verifyException(e, "Illegal character");
@@ -185,7 +185,7 @@ class ParserFeaturesTest
         assertToken(JsonToken.VALUE_STRING, p.nextToken());
         assertEquals(VALUE, p.getText());
         assertToken(JsonToken.END_OBJECT, p.nextToken());
-        p.nextToken();
+        p.nextToken(); // RS token
         p.close();
     }
 }

--- a/src/test/java/com/fasterxml/jackson/core/read/ParserFeaturesTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/read/ParserFeaturesTest.java
@@ -151,7 +151,7 @@ class ParserFeaturesTest
 
     private void _testRecordSeparatorDefault(boolean useStream) throws Exception {
         JsonFactory f = new JsonFactory();
-        String JSON = "[\"key:\"]\u001E";
+        String JSON = "[\"val:\"]\u001E";
 
         JsonParser p = useStream ? createParserUsingStream(f, JSON, "UTF-8") : createParserUsingReader(f, JSON);
 
@@ -171,12 +171,12 @@ class ParserFeaturesTest
     private void _testRecordSeparatorEnabled(boolean useStream) throws Exception
     {
         JsonFactory f = JsonFactory.builder()
-                .configure(JsonReadFeature.ALLOW_UNESCAPED_CONTROL_CHARS, true)
+                .configure(JsonReadFeature.ALLOW_RS_CONTROL_CHAR, true)
                 .build();
 
-        String FIELD = "a\u001Eb";
-        String VALUE = "\u001E";
-        String JSON = "{ "+q(FIELD)+" : "+q(VALUE)+"}";
+        String FIELD = "key";
+        String VALUE = "value";
+        String JSON = "{ "+q(FIELD)+" : "+q(VALUE)+"}\u001E";
         JsonParser p = useStream ? createParserUsingStream(f, JSON, "UTF-8") : createParserUsingReader(f, JSON);
 
         assertToken(JsonToken.START_OBJECT, p.nextToken());
@@ -185,6 +185,7 @@ class ParserFeaturesTest
         assertToken(JsonToken.VALUE_STRING, p.nextToken());
         assertEquals(VALUE, p.getText());
         assertToken(JsonToken.END_OBJECT, p.nextToken());
+        p.nextToken();
         p.close();
     }
 }


### PR DESCRIPTION
Hello, This PR tries to resolve https://github.com/FasterXML/jackson-core/issues/633

This is my first PR for the project, so I could be missing a point. Feel free to guide me through points that might need to be added. 

I didn't implement it in the data input parser as it seems like we're skipping the validation of WS
https://github.com/FasterXML/jackson-core/blob/99f749d958a55013724571d825625e1032af9d4b/src/main/java/com/fasterxml/jackson/core/json/UTF8DataInputJsonParser.java#L2299-L2304
so not sure if we need to have it now, the same way we do for other parsers