### PR TITLE
Fixing parser incorrect location when fed with non-zero offset

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/json/async/NonBlockingUtf8JsonParserBase.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/async/NonBlockingUtf8JsonParserBase.java
@@ -138,7 +138,8 @@ public abstract class NonBlockingUtf8JsonParserBase
 
         // No: fresh new token; may or may not have existing one
         _numTypesValid = NR_UNKNOWN;
-        _tokenInputTotal = _currInputProcessed + _inputPtr;
+        _tokenInputTotal = _currInputProcessed + (_inputPtr - _currBufferStart);
+
         // also: clear any data retained so far
         _binaryValue = null;
         int ch = getNextUnsignedByteFromBuffer();

--- a/src/test/java/com/fasterxml/jackson/core/tofix/async/AsyncLocation1412Test.java
+++ b/src/test/java/com/fasterxml/jackson/core/tofix/async/AsyncLocation1412Test.java
@@ -76,7 +76,6 @@ class AsyncLocation1412Test extends AsyncTestBase
       }
     }
 
-    @JacksonTestFailureExpected
     @Test
     @DisplayName("Feed one byte at a time from non-zero array offset")
     void feedByteByByteFromNonZeroOffset() throws Exception {
@@ -94,7 +93,6 @@ class AsyncLocation1412Test extends AsyncTestBase
       }
     }
 
-    @JacksonTestFailureExpected
     @Test
     @DisplayName("Feed whole document at once from non-zero array offset")
     void feedWholeDocumentFromNonZeroOffset() throws Exception {


### PR DESCRIPTION
Hello, this PR is an attempt to resolve #1412 
The issue with the changed line is that it was double counting the offset as `_inputPtr` keeps increasing

This change ensures we track the relative position of each token in the JSON input stream, rather than being affected by the absolute array indices used when feeding the data.