### PR TITLE
Fixes #1421: make `JsonReadContext` non-final

### DIFF
--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -490,3 +490,6 @@ Fawzi Essam (@iifawzi)
  * Contributed fix for #1412: More cases of Non-blocking parser reporting incorrect locations
    when fed with non-zero offset
   (2.19.0)
+
+Ilenia Salvadori (@isalvadori)
+ * Requested #1421: Make `JsonReadContext` non-final

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -37,6 +37,9 @@ a pure JSON library.
   when fed with non-zero offset
  (reported by David N)
  (fixed by Fawzi E)
+#1421: Make `JsonReadContext` non-final
+ (requested by Ilenia S)
+ (fixed by @pjfanning)
 
 2.18.3 (28-Feb-2025)
 

--- a/src/main/java/com/fasterxml/jackson/core/json/JsonReadContext.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/JsonReadContext.java
@@ -7,8 +7,10 @@ import com.fasterxml.jackson.core.io.ContentReference;
  * Extension of {@link JsonStreamContext}, which implements
  * core methods needed, and also exposes
  * more complete API to parser implementation classes.
+ *<p>
+ * NOTE: non-final since 2.19
  */
-public final class JsonReadContext extends JsonStreamContext
+public class JsonReadContext extends JsonStreamContext
 {
     // // // Configuration
 

--- a/src/test/java/com/fasterxml/jackson/core/json/JsonReadContextTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/json/JsonReadContextTest.java
@@ -2,9 +2,7 @@ package com.fasterxml.jackson.core.json;
 
 import org.junit.jupiter.api.Test;
 
-import com.fasterxml.jackson.core.JUnit5TestBase;
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.*;
 import com.fasterxml.jackson.core.io.ContentReference;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -14,9 +12,16 @@ import static org.junit.jupiter.api.Assertions.*;
  */
 class JsonReadContextTest extends JUnit5TestBase
 {
+    static class MyContext extends JsonReadContext {
+        public MyContext(JsonReadContext parent, int nestingDepth, DupDetector dups,
+                         int type, int lineNr, int colNr) {
+            super(parent, nestingDepth, dups, type, lineNr, colNr);
+        }
+    }
+
     @Test
     void setCurrentNameTwiceWithSameNameRaisesJsonParseException() throws Exception
-  {
+    {
       DupDetector dupDetector = DupDetector.rootDetector((JsonGenerator) null);
       JsonReadContext jsonReadContext = new JsonReadContext((JsonReadContext) null, 0,
               dupDetector, 2441, 2441, 2441);
@@ -27,21 +32,21 @@ class JsonReadContextTest extends JUnit5TestBase
       } catch (JsonParseException e) {
           verifyException(e, "Duplicate field 'dupField'");
       }
-  }
+    }
 
     @Test
     void setCurrentName() throws Exception
-  {
+    {
       JsonReadContext jsonReadContext = JsonReadContext.createRootContext(0, 0, (DupDetector) null);
       jsonReadContext.setCurrentName("abc");
       assertEquals("abc", jsonReadContext.getCurrentName());
       jsonReadContext.setCurrentName(null);
       assertNull(jsonReadContext.getCurrentName());
-  }
+    }
 
     @Test
     void reset()
-  {
+    {
       DupDetector dupDetector = DupDetector.rootDetector((JsonGenerator) null);
       JsonReadContext jsonReadContext = JsonReadContext.createRootContext(dupDetector);
       final ContentReference bogusSrc = ContentReference.unknown();
@@ -57,6 +62,12 @@ class JsonReadContextTest extends JUnit5TestBase
       assertEquals("?", jsonReadContext.typeDesc());
       assertEquals(500, jsonReadContext.startLocation(bogusSrc).getLineNr());
       assertEquals(200, jsonReadContext.startLocation(bogusSrc).getColumnNr());
-  }
+    }
 
+    // [core#1421]
+    @Test
+    void testExtension() {
+        MyContext context = new MyContext(null, 0, null, 0, 0, 0);
+        assertNotNull(context);
+    }
 }

--- a/src/test/java/com/fasterxml/jackson/core/json/JsonWriteContextTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/json/JsonWriteContextTest.java
@@ -1,0 +1,26 @@
+package com.fasterxml.jackson.core.json;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.core.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for class {@link JsonWriteContext}.
+ */
+public class JsonWriteContextTest extends JUnit5TestBase
+{
+    static class MyContext extends JsonWriteContext {
+        public MyContext(int type, JsonWriteContext parent, DupDetector dups, Object currValue) {
+            super(type, parent, dups, currValue);
+        }
+    }
+
+    // [core#1421]
+    @Test
+    void testExtension() {
+        MyContext context = new MyContext(0, null, null, 0);
+        assertNotNull(context);
+    }
+}


### PR DESCRIPTION
Re-do of #1422 for 2.19.
