### PR TITLE
Remove Java 22 files (`FastDoubleParser`)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -171,6 +171,8 @@ com.fasterxml.jackson.core.*;version=${project.version}
                     <exclude>META-INF/LICENSE</exclude>
                     <exclude>META-INF/MANIFEST.MF</exclude>
                     <exclude>META-INF/versions/**/module-info.*</exclude>
+                    <!-- 09-Jun-2025, PJ: [core#1446] Exclude Multi-Release classes
+                       for Java 22 due to issues in Android Linting tool -->
                     <exclude>META-INF/versions/22/**</exclude>
                   </excludes>
                 </filter>

--- a/pom.xml
+++ b/pom.xml
@@ -168,7 +168,10 @@ com.fasterxml.jackson.core.*;version=${project.version}
                 <filter>
                   <artifact>ch.randelshofer:fastdoubleparser</artifact>
                   <excludes>
+                    <exclude>META-INF/LICENSE</exclude>
+                    <exclude>META-INF/MANIFEST.MF</exclude>
                     <exclude>META-INF/versions/**/module-info.*</exclude>
+                    <exclude>META-INF/versions/22/**</exclude>
                   </excludes>
                 </filter>
               </filters>
@@ -209,10 +212,6 @@ com.fasterxml.jackson.core.*;version=${project.version}
                 <relocation>
                   <pattern>META-INF/versions/21/ch/randelshofer/fastdoubleparser</pattern>
                   <shadedPattern>META-INF/versions/21/com/fasterxml/jackson/core/internal/shaded/fdp/v${project.version.underscore}</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>META-INF/versions/22/ch/randelshofer/fastdoubleparser</pattern>
-                  <shadedPattern>META-INF/versions/22/com/fasterxml/jackson/core/internal/shaded/fdp/v${project.version.underscore}</shadedPattern>
                 </relocation>
               </relocations>
             </configuration>

--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -467,3 +467,8 @@ Haruki (@stackunderflow111)
   when custom characterEscape is used
   (2.18.3)
 
+Vincent Biret (@baywet)
+ * Reported #1446: Invalid package reference to "java.lang.foreign" from
+  `com.fasterxml.jackson.core:jackson-core` (from `FastDoubleParser`) [Android]
+  (2.18.5)
+

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -19,6 +19,10 @@ a pure JSON library.
 #1433: `JsonParser#getNumberType()` throws `JsonParseException` when
   the current token is non-numeric instead of returning null
  (reported by @CrazySqueak)
+#1446: Invalid package reference to "java.lang.foreign" from
+  `com.fasterxml.jackson.core:jackson-core` (from `FastDoubleParser`) [Android]
+ (reported by Vincent B)
+ (fix by @pjfanning)
 
 2.18.4 (06-May-2025)
 


### PR DESCRIPTION
To address #1446 

I got build warning about the META-INF/LICENSE and MANIFEST.MF too so I added them to the exclude.