### PR TITLE
Upgrade `FastDoubleParser` to 2.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -175,6 +175,7 @@ com.fasterxml.jackson.core.*;version=${project.version}
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
+        <version>3.6.0</version>
         <configuration>
           <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
           <createDependencyReducedPom>true</createDependencyReducedPom>
@@ -210,6 +211,14 @@ com.fasterxml.jackson.core.*;version=${project.version}
                      parent pom
                     -->
                   <shadedPattern>com/fasterxml/jackson/core/internal/shaded/fdp/v${project.version.underscore}</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>ch/randelshofer/fastdoubleparser/bte</pattern>
+                  <shadedPattern>com/fasterxml/jackson/core/internal/shaded/fdp/v${project.version.underscore}/bte</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>ch/randelshofer/fastdoubleparser/chr</pattern>
+                  <shadedPattern>com/fasterxml/jackson/core/internal/shaded/fdp/v${project.version.underscore}/chr</shadedPattern>
                 </relocation>
                 <relocation>
                   <pattern>META-INF/LICENSE</pattern>

--- a/pom.xml
+++ b/pom.xml
@@ -196,8 +196,8 @@ com.fasterxml.jackson.core.*;version=${project.version}
                     <exclude>META-INF/MANIFEST.MF</exclude>
                     <exclude>META-INF/versions/**/module-info.*</exclude>
                     <!-- 09-Jun-2025, PJ: [core#1446] Exclude Multi-Release classes
-                       for Java 22 due to issues in Android Linting tool -->
-                    <exclude>META-INF/versions/22/**</exclude>
+                       for Java 23 due to issues in Android Linting tool -->
+                    <exclude>META-INF/versions/23/**</exclude>
                   </excludes>
                 </filter>
               </filters>

--- a/pom.xml
+++ b/pom.xml
@@ -175,7 +175,6 @@ com.fasterxml.jackson.core.*;version=${project.version}
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>3.6.0</version>
         <configuration>
           <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
           <createDependencyReducedPom>true</createDependencyReducedPom>

--- a/pom.xml
+++ b/pom.xml
@@ -292,7 +292,7 @@ com.fasterxml.jackson.core.*;version=${project.version}
     <dependency>
       <groupId>ch.randelshofer</groupId>
       <artifactId>fastdoubleparser</artifactId>
-      <version>1.0.90</version>
+      <version>2.0.1</version>
     </dependency>
     <!-- Test dependencies -->
     <dependency>

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -18,6 +18,8 @@ a pure JSON library.
 
 #1438: `ParserBase.close()` does not clear `_currToken`
 #1441: Add `StreamReadFeature.CLEAR_CURRENT_TOKEN_ON_CLOSE` (default: true)
+#1448: Upgrade `FastDoubleParser` to 2.0.1
+ (contributed by @pjfanning)
 - Generate SBOMs [JSTEP-14]
 
 2.19.1 (not yet released)
@@ -29,7 +31,6 @@ a pure JSON library.
   `com.fasterxml.jackson.core:jackson-core` (from `FastDoubleParser`) [Android]
  (reported by Vincent B)
  (fix by @pjfanning)
-
 
 2.19.0 (24-Apr-2025)
 


### PR DESCRIPTION
* not ready yet - let's wait till after #1447 is dealt with
* aim would be to update the versioned class excludes in #1447 to match what is in fastdoubleparser 2.0.1 (this jar has Java 23 classes but no Java 22 ones)