### PR TITLE
Fixes Implicit narrowing conversion in compound assignment FloatToDecimal

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/io/schubfach/FloatToDecimal.java
+++ b/src/main/java/com/fasterxml/jackson/core/io/schubfach/FloatToDecimal.java
@@ -405,14 +405,14 @@ final public class FloatToDecimal {
     /*
     Formats the decimal f 10^e.
      */
-    private int toChars(int f, int e) {
+    private int toChars(long f, int e) {
         /*
         For details not discussed here see section 10 of [1].
 
         Determine len such that
             10^(len-1) <= f < 10^len
          */
-        int len = flog10pow2(Integer.SIZE - numberOfLeadingZeros(f));
+        int len = flog10pow2(Long.SIZE - numberOfLeadingZeros(f));
         if (f >= pow10(len)) {
             len += 1;
         }
@@ -437,7 +437,7 @@ final public class FloatToDecimal {
             floor(f / 10^8) = floor(1_441_151_881 f / 2^57)
          */
         int h = (int) (f * 1_441_151_881L >>> 57);
-        int l = f - 100_000_000 * h;
+        int l = (int) (f - 100_000_000L * h);
 
         if (0 < e && e <= 7) {
             return toChars1(h, l, e);


### PR DESCRIPTION
https://github.com/FasterXML/jackson-core/blob/6affde88dd3820b8c2eeb8700ae24b75651c8fcd/src/main/java/com/fasterxml/jackson/core/io/schubfach/FloatToDecimal.java#L408-L408
https://github.com/FasterXML/jackson-core/blob/6affde88dd3820b8c2eeb8700ae24b75651c8fcd/src/main/java/com/fasterxml/jackson/core/io/schubfach/FloatToDecimal.java#L415-L415
https://github.com/FasterXML/jackson-core/blob/6affde88dd3820b8c2eeb8700ae24b75651c8fcd/src/main/java/com/fasterxml/jackson/core/io/schubfach/FloatToDecimal.java#L426-L426
https://github.com/FasterXML/jackson-core/blob/6affde88dd3820b8c2eeb8700ae24b75651c8fcd/src/main/java/com/fasterxml/jackson/core/io/schubfach/FloatToDecimal.java#L440-L440


Fix the issue need to ensure that the type of the left-hand side (`f`) is at least as wide as the type of the right-hand side (`pow10(H - len)`). Since `pow10` likely returns a `long`, the simplest and safest fix is to change the type of `f` from `int` to `long`. This avoids the implicit narrowing conversion and ensures that the computation can handle larger values without overflow.

**Steps to implement the fix:**
1. Change the type of `f` from `int` to `long` in the method `toChars`.
2. Update any other code within the method that interacts with `f` to ensure compatibility with the new type.
3. Verify that the change does not introduce any unintended side effects or performance issues.



--- 

Compound assignment statements of the form `x += y` or `x *= y` perform an implicit narrowing conversion if the type of `x` is narrower than the type of `y`. `x += y` is equivalent to `x = (T)(x + y)`, where `T` is the type of `x`. This can result in information loss and numeric errors such as overflows.

#### References
[Compound Assignment Operators](https://docs.oracle.com/javase/specs/jls/se11/html/jls-15.html#jls-15.26.2), [Narrowing Primitive Conversion](https://docs.oracle.com/javase/specs/jls/se11/html/jls-5.html#jls-5.1.3)
[NUM00-J. Detect or prevent integer overflow](https://wiki.sei.cmu.edu/confluence/display/java/NUM00-J.+Detect+or+prevent+integer+overflow)
