### PR TITLE
Fix #1462: deprecate `JsonFactory.createParser(URL)`

### DIFF
--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -14,6 +14,8 @@ a pure JSON library.
 === Releases ===
 ------------------------------------------------------------------------
 
+#1462: Deprecate `URL`-taking factory method of `JsonFactory`
+
 2.20.0-rc1 (04-Aug-2025)
 
 #1438: `ParserBase.close()` does not clear `_currToken`

--- a/src/main/java/com/fasterxml/jackson/core/JsonFactory.java
+++ b/src/main/java/com/fasterxml/jackson/core/JsonFactory.java
@@ -1221,23 +1221,18 @@ public class JsonFactory
     }
 
     /**
-     * Method for constructing JSON parser instance to parse
-     * contents of resource reference by given URL.
-     *<p>
-     * Encoding is auto-detected from contents according to JSON
-     * specification recommended mechanism. Json specification
-     * supports only UTF-8, UTF-16 and UTF-32 as valid encodings,
-     * so auto-detection implemented only for this charsets.
-     * For other charsets use {@link #createParser(java.io.Reader)}.
-     *<p>
-     * Underlying input stream (needed for reading contents)
-     * will be <b>owned</b> (and managed, i.e. closed as need be) by
-     * the parser, since caller has no access to it.
+     * Deprecated variant of {@link #createParser(InputStream)} 
+     * no longer recommended to be used due to implementation
+     * problems like {@href "https://github.com/FasterXML/jackson-core/issues/803"}.
      *
      * @param url URL pointing to resource that contains JSON content to parse
      *
      * @since 2.1
+     *
+     * @deprecated Since 2.20 use other variants (like {@link #createParser(InputStream)})
+     *   instead.
      */
+    @Deprecated // since 2.20
     @Override
     public JsonParser createParser(URL url) throws IOException, JsonParseException {
         // true, since we create InputStream from URL

--- a/src/main/java/com/fasterxml/jackson/core/TokenStreamFactory.java
+++ b/src/main/java/com/fasterxml/jackson/core/TokenStreamFactory.java
@@ -198,6 +198,15 @@ public abstract class TokenStreamFactory
     public abstract JsonParser createParser(InputStream in) throws IOException;
     public abstract JsonParser createParser(Reader r) throws IOException;
     public abstract JsonParser createParser(String content) throws IOException;
+
+    /**
+     * Deprecated factory method: no longer recommended to be used due to implementation
+     * problems like {@href "https://github.com/FasterXML/jackson-core/issues/803"}.
+     *
+     * @deprecated since 2.20 caller needs to construct {@link InputStream} (or {@link Reader})
+     *    from {@link URL} directly and pass that.
+     */
+    @Deprecated
     public abstract JsonParser createParser(URL url) throws IOException;
 
     /**


### PR DESCRIPTION
Implements #1462.