### PR TITLE
Fixes the segment logic from splitting surrogates in half and not encoding correctly

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/json/UTF8JsonGenerator.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/UTF8JsonGenerator.java
@@ -1375,7 +1375,7 @@ public class UTF8JsonGenerator
     {
         do {
             int len = Math.min(_outputMaxContiguous, totalLen);
-            // avoids splitting surrogates between two segments.
+            // [core#1473]: avoid splitting surrogates between two segments.
             // if len == 1 (edge case) don't apply to avoid infinite loop
             if (len > 1 && _isStartOfSurrogatePair(cbuf[offset + len-1])) {
                 --len;
@@ -1393,7 +1393,7 @@ public class UTF8JsonGenerator
     {
         do {
             int len = Math.min(_outputMaxContiguous, totalLen);
-            // avoids splitting surrogates between two segments.
+            // [core#1473]: avoid splitting surrogates between two segments.
             // if len == 1 (edge case) don't apply to avoid infinite loop
             if (len > 1 && _isStartOfSurrogatePair(text.charAt(offset + len-1))) {
                 --len;
@@ -1884,7 +1884,7 @@ public class UTF8JsonGenerator
     {
         do {
             int len = Math.min(_outputMaxContiguous, totalLen);
-            // avoids splitting surrogates between two segments.
+            // [core#1473]: avoid splitting surrogates between two segments.
             // if len == 1 (edge case) don't apply to avoid infinite loop
             if (len > 1 && _isStartOfSurrogatePair(utf8[offset + len-1])) {
                 --len;

--- a/src/main/java/com/fasterxml/jackson/core/json/UTF8JsonGenerator.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/UTF8JsonGenerator.java
@@ -1346,7 +1346,7 @@ public class UTF8JsonGenerator
             int len = Math.min(_outputMaxContiguous, left);
             // [core#1473]: avoid splitting surrogates between two segments.
             // if len == 1 (edge case) don't apply to avoid infinite loop
-            if (len > 1 && _isStartOfSurrogatePair(text.charAt(len-1))) {
+            if (len > 1 && _isStartOfSurrogatePair(text.charAt(offset + len-1))) {
                 len--;
             }
             if ((_outputTail + len) > _outputEnd) { // caller must ensure enough space
@@ -1377,7 +1377,7 @@ public class UTF8JsonGenerator
             int len = Math.min(_outputMaxContiguous, totalLen);
             // avoids splitting surrogates between two segments.
             // if len == 1 (edge case) don't apply to avoid infinite loop
-            if (len > 1 && _isStartOfSurrogatePair(cbuf[len-1])) {
+            if (len > 1 && _isStartOfSurrogatePair(cbuf[offset + len-1])) {
                 len--;
             }
             if ((_outputTail + len) > _outputEnd) { // caller must ensure enough space
@@ -1395,7 +1395,7 @@ public class UTF8JsonGenerator
             int len = Math.min(_outputMaxContiguous, totalLen);
             // avoids splitting surrogates between two segments.
             // if len == 1 (edge case) don't apply to avoid infinite loop
-            if (len > 1 && _isStartOfSurrogatePair(text.charAt(len-1))) {
+            if (len > 1 && _isStartOfSurrogatePair(text.charAt(offset + len-1))) {
                 len--;
             }
             if ((_outputTail + len) > _outputEnd) { // caller must ensure enough space
@@ -1886,7 +1886,7 @@ public class UTF8JsonGenerator
             int len = Math.min(_outputMaxContiguous, totalLen);
             // avoids splitting surrogates between two segments.
             // if len == 1 (edge case) don't apply to avoid infinite loop
-            if (len > 1 && _isStartOfSurrogatePair(utf8[len-1])) {
+            if (len > 1 && _isStartOfSurrogatePair(utf8[offset + len-1])) {
                 len--;
             }
             _writeUTF8Segment(utf8, offset, len);

--- a/src/main/java/com/fasterxml/jackson/core/json/UTF8JsonGenerator.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/UTF8JsonGenerator.java
@@ -1345,7 +1345,8 @@ public class UTF8JsonGenerator
         while (left > 0) {
             int len = Math.min(_outputMaxContiguous, left);
             // avoids splitting surrogates between two segments.
-            if (_isStartOfSurrogatePair(text.charAt(len-1))) {
+            // if len == 1 (edge case) don't apply to avoid infinite loop
+            if (len > 1 && _isStartOfSurrogatePair(text.charAt(len-1))) {
                 len--;
             }
             if ((_outputTail + len) > _outputEnd) { // caller must ensure enough space
@@ -1375,7 +1376,8 @@ public class UTF8JsonGenerator
         do {
             int len = Math.min(_outputMaxContiguous, totalLen);
             // avoids splitting surrogates between two segments.
-            if (_isStartOfSurrogatePair(cbuf[len-1])) {
+            // if len == 1 (edge case) don't apply to avoid infinite loop
+            if (len > 1 && _isStartOfSurrogatePair(cbuf[len-1])) {
                 len--;
             }
             if ((_outputTail + len) > _outputEnd) { // caller must ensure enough space
@@ -1392,7 +1394,8 @@ public class UTF8JsonGenerator
         do {
             int len = Math.min(_outputMaxContiguous, totalLen);
             // avoids splitting surrogates between two segments.
-            if (_isStartOfSurrogatePair(text.charAt(len-1))) {
+            // if len == 1 (edge case) don't apply to avoid infinite loop
+            if (len > 1 && _isStartOfSurrogatePair(text.charAt(len-1))) {
                 len--;
             }
             if ((_outputTail + len) > _outputEnd) { // caller must ensure enough space
@@ -1882,7 +1885,8 @@ public class UTF8JsonGenerator
         do {
             int len = Math.min(_outputMaxContiguous, totalLen);
             // avoids splitting surrogates between two segments.
-            if (_isStartOfSurrogatePair(utf8[len-1])) {
+            // if len == 1 (edge case) don't apply to avoid infinite loop
+            if (len > 1 && _isStartOfSurrogatePair(utf8[len-1])) {
                 len--;
             }
             _writeUTF8Segment(utf8, offset, len);

--- a/src/main/java/com/fasterxml/jackson/core/json/UTF8JsonGenerator.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/UTF8JsonGenerator.java
@@ -1344,7 +1344,7 @@ public class UTF8JsonGenerator
 
         while (left > 0) {
             int len = Math.min(_outputMaxContiguous, left);
-            // avoids splitting surrogates between two segments.
+            // [core#1473]: avoid splitting surrogates between two segments.
             if (_isStartOfSurrogatePair(text.charAt(len-1))) {
                 len--;
             }

--- a/src/main/java/com/fasterxml/jackson/core/json/UTF8JsonGenerator.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/UTF8JsonGenerator.java
@@ -1344,6 +1344,7 @@ public class UTF8JsonGenerator
 
         while (left > 0) {
             int len = Math.min(_outputMaxContiguous, left);
+            // avoids splitting surrogates between two segments.
             if (_isStartOfSurrogatePair(text.charAt(len-1))) {
                 len--;
             }
@@ -1373,6 +1374,7 @@ public class UTF8JsonGenerator
     {
         do {
             int len = Math.min(_outputMaxContiguous, totalLen);
+            // avoids splitting surrogates between two segments.
             if (_isStartOfSurrogatePair(cbuf[len-1])) {
                 len--;
             }
@@ -1389,6 +1391,7 @@ public class UTF8JsonGenerator
     {
         do {
             int len = Math.min(_outputMaxContiguous, totalLen);
+            // avoids splitting surrogates between two segments.
             if (_isStartOfSurrogatePair(text.charAt(len-1))) {
                 len--;
             }
@@ -1878,6 +1881,7 @@ public class UTF8JsonGenerator
     {
         do {
             int len = Math.min(_outputMaxContiguous, totalLen);
+            // avoids splitting surrogates between two segments.
             if (_isStartOfSurrogatePair(utf8[len-1])) {
                 len--;
             }

--- a/src/main/java/com/fasterxml/jackson/core/json/UTF8JsonGenerator.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/UTF8JsonGenerator.java
@@ -1347,7 +1347,7 @@ public class UTF8JsonGenerator
             // [core#1473]: avoid splitting surrogates between two segments.
             // if len == 1 (edge case) don't apply to avoid infinite loop
             if (len > 1 && _isStartOfSurrogatePair(text.charAt(offset + len-1))) {
-                len--;
+                --len;
             }
             if ((_outputTail + len) > _outputEnd) { // caller must ensure enough space
                 _flushBuffer();
@@ -1378,7 +1378,7 @@ public class UTF8JsonGenerator
             // avoids splitting surrogates between two segments.
             // if len == 1 (edge case) don't apply to avoid infinite loop
             if (len > 1 && _isStartOfSurrogatePair(cbuf[offset + len-1])) {
-                len--;
+                --len;
             }
             if ((_outputTail + len) > _outputEnd) { // caller must ensure enough space
                 _flushBuffer();
@@ -1396,7 +1396,7 @@ public class UTF8JsonGenerator
             // avoids splitting surrogates between two segments.
             // if len == 1 (edge case) don't apply to avoid infinite loop
             if (len > 1 && _isStartOfSurrogatePair(text.charAt(offset + len-1))) {
-                len--;
+                --len;
             }
             if ((_outputTail + len) > _outputEnd) { // caller must ensure enough space
                 _flushBuffer();
@@ -1887,7 +1887,7 @@ public class UTF8JsonGenerator
             // avoids splitting surrogates between two segments.
             // if len == 1 (edge case) don't apply to avoid infinite loop
             if (len > 1 && _isStartOfSurrogatePair(utf8[offset + len-1])) {
-                len--;
+                --len;
             }
             _writeUTF8Segment(utf8, offset, len);
             offset += len;

--- a/src/main/java/com/fasterxml/jackson/core/json/UTF8JsonGenerator.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/UTF8JsonGenerator.java
@@ -1344,6 +1344,9 @@ public class UTF8JsonGenerator
 
         while (left > 0) {
             int len = Math.min(_outputMaxContiguous, left);
+            if (_isStartOfSurrogatePair(text.charAt(len-1))) {
+                len--;
+            }
             if ((_outputTail + len) > _outputEnd) { // caller must ensure enough space
                 _flushBuffer();
             }
@@ -1370,6 +1373,9 @@ public class UTF8JsonGenerator
     {
         do {
             int len = Math.min(_outputMaxContiguous, totalLen);
+            if (_isStartOfSurrogatePair(cbuf[len-1])) {
+                len--;
+            }
             if ((_outputTail + len) > _outputEnd) { // caller must ensure enough space
                 _flushBuffer();
             }
@@ -1383,6 +1389,9 @@ public class UTF8JsonGenerator
     {
         do {
             int len = Math.min(_outputMaxContiguous, totalLen);
+            if (_isStartOfSurrogatePair(text.charAt(len-1))) {
+                len--;
+            }
             if ((_outputTail + len) > _outputEnd) { // caller must ensure enough space
                 _flushBuffer();
             }
@@ -1869,6 +1878,9 @@ public class UTF8JsonGenerator
     {
         do {
             int len = Math.min(_outputMaxContiguous, totalLen);
+            if (_isStartOfSurrogatePair(utf8[len-1])) {
+                len--;
+            }
             _writeUTF8Segment(utf8, offset, len);
             offset += len;
             totalLen -= len;

--- a/src/test/java/com/fasterxml/jackson/core/write/SurrogateWrite223Test.java
+++ b/src/test/java/com/fasterxml/jackson/core/write/SurrogateWrite223Test.java
@@ -3,6 +3,7 @@ package com.fasterxml.jackson.core.write;
 import java.io.ByteArrayOutputStream;
 import java.io.StringWriter;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 
 import org.junit.jupiter.api.Test;
 
@@ -16,6 +17,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class SurrogateWrite223Test extends JUnit5TestBase
 {
     private final JsonFactory DEFAULT_JSON_F = newStreamFactory();
+
+    private final JsonFactory SURROGATE_COMBINING_JSON_F = JsonFactory.builder()
+            .enable(JsonWriteFeature.COMBINE_UNICODE_SURROGATES_IN_UTF8)
+            .build();
 
     // for [core#223]
     @Test
@@ -35,9 +40,7 @@ class SurrogateWrite223Test extends JUnit5TestBase
 
         out = new ByteArrayOutputStream();
 
-        JsonFactory f = JsonFactory.builder()
-                .enable(JsonWriteFeature.COMBINE_UNICODE_SURROGATES_IN_UTF8)
-                .build();
+        JsonFactory f = SURROGATE_COMBINING_JSON_F;
         g = f.createGenerator(out);
         g.writeStartArray();
         g.writeString(toQuote);
@@ -96,9 +99,7 @@ class SurrogateWrite223Test extends JUnit5TestBase
     //https://github.com/FasterXML/jackson-core/issues/1359
     @Test
     void checkNonSurrogates() throws Exception {
-        JsonFactory f = JsonFactory.builder()
-                .enable(JsonWriteFeature.COMBINE_UNICODE_SURROGATES_IN_UTF8)
-                .build();
+        JsonFactory f = SURROGATE_COMBINING_JSON_F;
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         try (JsonGenerator gen = f.createGenerator(out)) {
             gen.writeStartObject();
@@ -126,9 +127,7 @@ class SurrogateWrite223Test extends JUnit5TestBase
 
     @Test
     void checkSurrogateWithCharacterEscapes() throws Exception {
-        JsonFactory f = JsonFactory.builder()
-                .enable(JsonWriteFeature.COMBINE_UNICODE_SURROGATES_IN_UTF8)
-                .build();
+        JsonFactory f = SURROGATE_COMBINING_JSON_F;
         f.setCharacterEscapes(JsonpCharacterEscapes.instance());
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         try (JsonGenerator gen = f.createGenerator(out)) {
@@ -139,5 +138,35 @@ class SurrogateWrite223Test extends JUnit5TestBase
         }
         String json = out.toString("UTF-8");
         assertEquals("{\"test_emoji\":\"\uD83D\uDE0A\"}", json);
+    }
+
+    //https://github.com/FasterXML/jackson-core/issues/1473
+    @Test
+    void surrogateCharSplitInTwoSegments() throws Exception
+    {
+        // Segments split every 1000 chars.
+        // We need a string with length 1001 where the surrogate is
+        // at 1000 and 1001 positions
+        int count = 999;
+        char[] chars = new char[count];
+        java.util.Arrays.fill(chars, 'x');
+        String base = new String(chars);
+
+        final String VALUE = base + "\uD83E\uDEE1";
+
+        ByteArrayOutputStream bb = new ByteArrayOutputStream();
+        try (JsonGenerator g = SURROGATE_COMBINING_JSON_F.createGenerator(bb)) {
+            g.enable(JsonGenerator.Feature.COMBINE_UNICODE_SURROGATES_IN_UTF8);
+    
+            g.writeStartArray();
+            g.writeString(VALUE);
+            g.writeEndArray();
+        }
+
+        String result = new String(bb.toByteArray(), StandardCharsets.UTF_8);
+
+        // +2 and -2 to remove array and quotes: result should contain ["xxxx....🫡"]
+        // "\uD83E\uDEE1" is the combined surrogate form of the emoji
+        assertEquals("\uD83E\uDEE1", result.substring(count+2, result.length()-2));
     }
 }

--- a/src/test/java/com/fasterxml/jackson/core/write/SurrogateWrite223Test.java
+++ b/src/test/java/com/fasterxml/jackson/core/write/SurrogateWrite223Test.java
@@ -144,10 +144,13 @@ class SurrogateWrite223Test extends JUnit5TestBase
     @Test
     void surrogateCharSplitInTwoSegments() throws Exception
     {
-        // Segments split every 1000 chars.
-        // We need a string with length 1001 where the surrogate is
-        // at 1000 and 1001 positions
-        int count = 999;
+        // UTF8JsonGenerator must avoid splitting surrogate chars
+        // into separate segments. We want to test the third segment
+        // split to make sure indexes, offsets, etc are all correct.
+        // By default, segments split in every 1000 chars.
+        // Thus, we need a string with length 2001 where the surrogate is
+        // at 2000 and 2001 positions.
+        int count = 1999;
         char[] chars = new char[count];
         java.util.Arrays.fill(chars, 'x');
         String base = new String(chars);

--- a/src/test/java/com/fasterxml/jackson/core/write/UTF8GeneratorTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/write/UTF8GeneratorTest.java
@@ -1,6 +1,7 @@
 package com.fasterxml.jackson.core.write;
 
 import java.io.*;
+import java.nio.charset.StandardCharsets;
 
 import com.fasterxml.jackson.core.io.SegmentedStringWriter;
 import com.fasterxml.jackson.core.util.BufferRecycler;
@@ -133,7 +134,7 @@ class UTF8GeneratorTest extends JUnit5TestBase
 
         g.close();
 
-        String result = new String(bb.toByteArray());
+        String result = new String(bb.toByteArray(), StandardCharsets.UTF_8);
 
         bb.release();
         br.releaseToPool();

--- a/src/test/java/com/fasterxml/jackson/core/write/UTF8GeneratorTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/write/UTF8GeneratorTest.java
@@ -107,7 +107,7 @@ class UTF8GeneratorTest extends JUnit5TestBase
     }
 
     @Test
-    void lastSegmentCharSplitSurrogateCharInTwoSegments() throws Exception
+    void surrogateCharSplitInTwoSegments() throws Exception
     {
         // segments split every 1000 chars.
         // We need a string with length 1001 where the surrogate is

--- a/src/test/java/com/fasterxml/jackson/core/write/UTF8GeneratorTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/write/UTF8GeneratorTest.java
@@ -2,6 +2,9 @@ package com.fasterxml.jackson.core.write;
 
 import java.io.*;
 
+import com.fasterxml.jackson.core.io.SegmentedStringWriter;
+import com.fasterxml.jackson.core.util.BufferRecycler;
+import com.fasterxml.jackson.core.util.ByteArrayBuilder;
 import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.core.*;
@@ -103,6 +106,39 @@ class UTF8GeneratorTest extends JUnit5TestBase
         assertEquals((char) 0xDE0C, str.charAt(1));
         assertToken(JsonToken.END_ARRAY, jp.nextToken());
         jp.close();
+    }
+
+    @Test
+    void lastSegmentCharSplitSurrogateCharInTwoSegments() throws Exception
+    {
+        // segments split every 1000 chars.
+        // We need a string with length 1001 where the surrogate is
+        // at 1000 and 1001 positions
+        int count = 999;
+        char[] chars = new char[count];
+        java.util.Arrays.fill(chars, 'x');
+        String base = new String(chars);
+
+        final String VALUE = base + "\uD83E\uDEE1";
+
+        // alas, we have to pull the recycler directly here...
+        final BufferRecycler br = JSON_F._getBufferRecycler();
+        ByteArrayBuilder bb = new ByteArrayBuilder(br);
+        JsonGenerator g = JSON_F.createGenerator(bb);
+        g.enable(JsonGenerator.Feature.COMBINE_UNICODE_SURROGATES_IN_UTF8);
+
+        g.writeStartArray();
+        g.writeString(VALUE);
+        g.writeEndArray();
+
+        g.close();
+
+        String result = new String(bb.toByteArray());
+
+        bb.release();
+        br.releaseToPool();
+
+        assertEquals("\uD83E\uDEE1", result.substring(count+2, result.length()-2));
     }
 
     @Test

--- a/src/test/java/com/fasterxml/jackson/core/write/UTF8GeneratorTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/write/UTF8GeneratorTest.java
@@ -3,9 +3,6 @@ package com.fasterxml.jackson.core.write;
 import java.io.*;
 import java.nio.charset.StandardCharsets;
 
-import com.fasterxml.jackson.core.io.SegmentedStringWriter;
-import com.fasterxml.jackson.core.util.BufferRecycler;
-import com.fasterxml.jackson.core.util.ByteArrayBuilder;
 import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.core.*;

--- a/src/test/java/com/fasterxml/jackson/core/write/UTF8GeneratorTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/write/UTF8GeneratorTest.java
@@ -109,7 +109,7 @@ class UTF8GeneratorTest extends JUnit5TestBase
     @Test
     void surrogateCharSplitInTwoSegments() throws Exception
     {
-        // segments split every 1000 chars.
+        // Segments split every 1000 chars.
         // We need a string with length 1001 where the surrogate is
         // at 1000 and 1001 positions
         int count = 999;
@@ -131,6 +131,8 @@ class UTF8GeneratorTest extends JUnit5TestBase
 
         String result = new String(bb.toByteArray(), StandardCharsets.UTF_8);
 
+        // +2 and -2 to remove array and quotes: result should contain ["xxxx....🫡"]
+        // "\uD83E\uDEE1" is the combined surrogate form of the emoji
         assertEquals("\uD83E\uDEE1", result.substring(count+2, result.length()-2));
     }
 

--- a/src/test/java/com/fasterxml/jackson/core/write/UTF8GeneratorTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/write/UTF8GeneratorTest.java
@@ -1,7 +1,6 @@
 package com.fasterxml.jackson.core.write;
 
 import java.io.*;
-import java.nio.charset.StandardCharsets;
 
 import org.junit.jupiter.api.Test;
 
@@ -104,36 +103,6 @@ class UTF8GeneratorTest extends JUnit5TestBase
         assertEquals((char) 0xDE0C, str.charAt(1));
         assertToken(JsonToken.END_ARRAY, jp.nextToken());
         jp.close();
-    }
-
-    @Test
-    void surrogateCharSplitInTwoSegments() throws Exception
-    {
-        // Segments split every 1000 chars.
-        // We need a string with length 1001 where the surrogate is
-        // at 1000 and 1001 positions
-        int count = 999;
-        char[] chars = new char[count];
-        java.util.Arrays.fill(chars, 'x');
-        String base = new String(chars);
-
-        final String VALUE = base + "\uD83E\uDEE1";
-
-        ByteArrayOutputStream bb = new ByteArrayOutputStream();
-        JsonGenerator g = JSON_F.createGenerator(bb);
-        g.enable(JsonGenerator.Feature.COMBINE_UNICODE_SURROGATES_IN_UTF8);
-
-        g.writeStartArray();
-        g.writeString(VALUE);
-        g.writeEndArray();
-
-        g.close();
-
-        String result = new String(bb.toByteArray(), StandardCharsets.UTF_8);
-
-        // +2 and -2 to remove array and quotes: result should contain ["xxxx....🫡"]
-        // "\uD83E\uDEE1" is the combined surrogate form of the emoji
-        assertEquals("\uD83E\uDEE1", result.substring(count+2, result.length()-2));
     }
 
     @Test

--- a/src/test/java/com/fasterxml/jackson/core/write/UTF8GeneratorTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/write/UTF8GeneratorTest.java
@@ -122,9 +122,7 @@ class UTF8GeneratorTest extends JUnit5TestBase
 
         final String VALUE = base + "\uD83E\uDEE1";
 
-        // alas, we have to pull the recycler directly here...
-        final BufferRecycler br = JSON_F._getBufferRecycler();
-        ByteArrayBuilder bb = new ByteArrayBuilder(br);
+        ByteArrayOutputStream bb = new ByteArrayOutputStream();
         JsonGenerator g = JSON_F.createGenerator(bb);
         g.enable(JsonGenerator.Feature.COMBINE_UNICODE_SURROGATES_IN_UTF8);
 
@@ -135,9 +133,6 @@ class UTF8GeneratorTest extends JUnit5TestBase
         g.close();
 
         String result = new String(bb.toByteArray(), StandardCharsets.UTF_8);
-
-        bb.release();
-        br.releaseToPool();
 
         assertEquals("\uD83E\uDEE1", result.substring(count+2, result.length()-2));
     }


### PR DESCRIPTION
Basically, the `combineSurrogates` logic doesn't run when the two characters of a surrogate are exactly at the end of one segment and the beginning of another.


Fixes https://github.com/FasterXML/jackson-core/issues/1473