### PR TITLE
Number-parsing fix for `UTF8DataInputJsonParser`

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/json/UTF8DataInputJsonParser.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/UTF8DataInputJsonParser.java
@@ -807,6 +807,7 @@ public class UTF8DataInputJsonParser
             break;
         case '.': // as per [core#611]
             t = _parseFloatThatStartsWithPeriod(false, false);
+            break;
         case '0':
         case '1':
         case '2':


### PR DESCRIPTION
I'm submitting a fix for a spot missed in https://github.com/FasterXML/jackson-core/pull/611

There also should be a break after `_parseFloatThatStartsWithPeriod()`