### PR TITLE
Revert "Simplify `ObjectReadContext` wrt TreeNode typing"

### DIFF
--- a/src/main/java/tools/jackson/core/JsonParser.java
+++ b/src/main/java/tools/jackson/core/JsonParser.java
@@ -1724,12 +1724,14 @@ public abstract class JsonParser
      * databinding layer above, or by factory method that takes in
      * context object.
      *
+     * @param <T> Nominal type parameter for result node type (to reduce need for casting)
+     *
      * @return root of the document, or null if empty or whitespace.
      *
      * @throws JacksonException if there is either an underlying I/O problem or decoding
      *    issue at format layer
      */
-    public abstract TreeNode readValueAsTree() throws JacksonException;
+    public abstract <T extends TreeNode> T readValueAsTree() throws JacksonException;
 
     /*
     /**********************************************************************

--- a/src/main/java/tools/jackson/core/ObjectReadContext.java
+++ b/src/main/java/tools/jackson/core/ObjectReadContext.java
@@ -74,10 +74,7 @@ public interface ObjectReadContext
 
     // // // Databinding callbacks, tree deserialization
 
-    /**
-     * NOTE: before 3.1, had generic return type
-     */
-    public TreeNode readTree(JsonParser p) throws JacksonException;
+    public <T extends TreeNode> T readTree(JsonParser p) throws JacksonException;
 
     /**
      * Convenience method for traversing over given {@link TreeNode} by exposing
@@ -148,7 +145,7 @@ public interface ObjectReadContext
         // // // Databind integration, trees
 
         @Override
-        public TreeNode readTree(JsonParser p) {
+        public <T extends TreeNode> T readTree(JsonParser p) {
             return _reportUnsupportedOperation();
         }
 

--- a/src/main/java/tools/jackson/core/base/ParserMinimalBase.java
+++ b/src/main/java/tools/jackson/core/base/ParserMinimalBase.java
@@ -821,9 +821,10 @@ public abstract class ParserMinimalBase extends JsonParser
         return (T) _objectReadContext.readValue(this, type);
     }
 
+    @SuppressWarnings("unchecked")
     @Override
-    public TreeNode readValueAsTree() throws JacksonException {
-        return _objectReadContext.readTree(this);
+    public <T extends TreeNode> T readValueAsTree() throws JacksonException {
+        return (T) _objectReadContext.readTree(this);
     }
 
     /*

--- a/src/main/java/tools/jackson/core/util/JsonParserDelegate.java
+++ b/src/main/java/tools/jackson/core/util/JsonParserDelegate.java
@@ -277,7 +277,7 @@ public class JsonParserDelegate extends JsonParser
     }
 
     @Override
-    public TreeNode readValueAsTree() throws JacksonException {
+    public <T extends TreeNode> T readValueAsTree() throws JacksonException {
         return delegate.readValueAsTree();
     }
 


### PR DESCRIPTION
Reverts FasterXML/jackson-core#1536

Turns out this could have serious source-incompatibility issues wrt existing `JsonParser.readValueAsTree()` usage.