### PR TITLE
Fix #1541: inconsistent handling of UTF-8 surrogates in names

### DIFF
--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -22,3 +22,6 @@ Henri Biström (@hb16)
  * Reported #1527: `TokenStreamFactory.createNonBlockingByteBufferParser()` return type wrong
   (3.1.0)
 
+Afzal Najam (@AfzalivE)
+ * Reported #1541: Unexpected Illegal surrogate character when parsing field names
+  (3.1.0)

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -30,6 +30,8 @@ JSON library.
  (fixed by @pjfanning)
 #1534: Change `TreeCodec` to take type parameter `T extends TreeNode`
 #1538: Increase default `StreamReadConstraints.maxStringLength` to 100M (from 20M)
+#1541: Unexpected Illegal surrogate character when parsing field names
+ (reported by Afzal N)
 - Updated `JsonGenerator.writeNumber(String)` javadocs with more specific info
   on handling by generators that cannot support the method.
 

--- a/src/main/java/tools/jackson/core/json/JsonParserBase.java
+++ b/src/main/java/tools/jackson/core/json/JsonParserBase.java
@@ -410,6 +410,37 @@ public abstract class JsonParserBase
 
     /*
     /**********************************************************************
+    /* Internal/package methods: surrogate handling
+    /**********************************************************************
+     */
+
+    /**
+     * Validate that {@code lo} is a valid low surrogate (DC00-DFFF) and combine
+     * with high surrogate {@code hi} into a supplementary code point.
+     *
+     * @since 3.1
+     */
+    protected int _decodeSurrogate(int hi, int lo) throws StreamReadException {
+        if (lo < 0xDC00 || lo > 0xDFFF) {
+            _reportError(String.format(
+                    "Broken surrogate pair in property name: expected low surrogate (DC00-DFFF), got %04X", lo));
+        }
+        return 0x10000 + ((hi - 0xD800) << 10) + (lo - 0xDC00);
+    }
+
+    /**
+     * Report an error for a lone low surrogate encountered without a preceding
+     * high surrogate.
+     *
+     * @since 3.1
+     */
+    protected <T> T _reportUnexpectedLowSurrogate(int ch) throws StreamReadException {
+        return _reportError(String.format(
+                "Unexpected low surrogate in property name (%04X) without preceding high surrogate", ch));
+    }
+
+    /*
+    /**********************************************************************
     /* Internal/package methods: other
     /**********************************************************************
      */

--- a/src/main/java/tools/jackson/core/json/UTF8DataInputJsonParser.java
+++ b/src/main/java/tools/jackson/core/json/UTF8DataInputJsonParser.java
@@ -1494,11 +1494,26 @@ public class UTF8DataInputJsonParser
                     // Nope, escape sequence
                     ch = _decodeEscaped();
                 }
-                /* Oh crap. May need to UTF-8 (re-)encode it, if it's
-                 * beyond 7-bit ascii. Gets pretty messy.
-                 * If this happens often, may want to use different name
-                 * canonicalization to avoid these hits.
-                 */
+                // [jackson-core#1541]: Handle JSON-escaped surrogate pairs in field names
+                if (ch >= 0xD800 && ch <= 0xDBFF) { // high surrogate
+                    // Must be followed by \\uXXXX low surrogate
+                    int next = _inputData.readUnsignedByte();
+                    if (next != INT_BACKSLASH) {
+                        _reportError("Broken surrogate pair in property name: expected '\\' to start low surrogate, got 0x"
+                                + Integer.toHexString(next));
+                    }
+                    int lo = _decodeEscaped();
+                    if (lo < 0xDC00 || lo > 0xDFFF) {
+                        _reportError(String.format(
+                                "Broken surrogate pair in property name: expected low surrogate (DC00-DFFF), got %04X", lo));
+                    }
+                    ch = 0x10000 + ((ch - 0xD800) << 10) + (lo - 0xDC00);
+                } else if (ch >= 0xDC00 && ch <= 0xDFFF) { // lone low surrogate
+                    _reportError(String.format(
+                            "Unexpected low surrogate in property name (%04X) without preceding high surrogate", ch));
+                }
+                // May need to UTF-8 (re-)encode it, if it's beyond
+                // 7-bit ASCII. Gets pretty messy.
                 if (ch > 127) {
                     // Ok, we'll need room for first byte right away
                     if (currQuadBytes >= 4) {
@@ -1513,10 +1528,33 @@ public class UTF8DataInputJsonParser
                         currQuad = (currQuad << 8) | (0xc0 | (ch >> 6));
                         ++currQuadBytes;
                         // Second byte gets output below:
-                    } else { // 3 bytes; no need to worry about surrogates here
+                    } else if (ch < 0x10000) { // 3 bytes
                         currQuad = (currQuad << 8) | (0xe0 | (ch >> 12));
                         ++currQuadBytes;
                         // need room for middle byte?
+                        if (currQuadBytes >= 4) {
+                            if (qlen >= quads.length) {
+                                _quadBuffer = quads = growArrayBy(quads, quads.length);
+                            }
+                            quads[qlen++] = currQuad;
+                            currQuad = 0;
+                            currQuadBytes = 0;
+                        }
+                        currQuad = (currQuad << 8) | (0x80 | ((ch >> 6) & 0x3f));
+                        ++currQuadBytes;
+                    } else { // 4 bytes (supplementary character)
+                        currQuad = (currQuad << 8) | (0xf0 | (ch >> 18));
+                        ++currQuadBytes;
+                        if (currQuadBytes >= 4) {
+                            if (qlen >= quads.length) {
+                                _quadBuffer = quads = growArrayBy(quads, quads.length);
+                            }
+                            quads[qlen++] = currQuad;
+                            currQuad = 0;
+                            currQuadBytes = 0;
+                        }
+                        currQuad = (currQuad << 8) | (0x80 | ((ch >> 12) & 0x3f));
+                        ++currQuadBytes;
                         if (currQuadBytes >= 4) {
                             if (qlen >= quads.length) {
                                 _quadBuffer = quads = growArrayBy(quads, quads.length);
@@ -1669,10 +1707,25 @@ public class UTF8DataInputJsonParser
                     // Nope, escape sequence
                     ch = _decodeEscaped();
                 }
-                /* Oh crap. May need to UTF-8 (re-)encode it, if it's  beyond
-                 * 7-bit ASCII. Gets pretty messy. If this happens often, may want
-                 * to use different name canonicalization to avoid these hits.
-                 */
+                // [jackson-core#1541]: Handle JSON-escaped surrogate pairs in field names
+                if (ch >= 0xD800 && ch <= 0xDBFF) { // high surrogate
+                    int next = _inputData.readUnsignedByte();
+                    if (next != INT_BACKSLASH) {
+                        _reportError("Broken surrogate pair in property name: expected '\\' to start low surrogate, got 0x"
+                                + Integer.toHexString(next));
+                    }
+                    int lo = _decodeEscaped();
+                    if (lo < 0xDC00 || lo > 0xDFFF) {
+                        _reportError(String.format(
+                                "Broken surrogate pair in property name: expected low surrogate (DC00-DFFF), got %04X", lo));
+                    }
+                    ch = 0x10000 + ((ch - 0xD800) << 10) + (lo - 0xDC00);
+                } else if (ch >= 0xDC00 && ch <= 0xDFFF) { // lone low surrogate
+                    _reportError(String.format(
+                            "Unexpected low surrogate in property name (%04X) without preceding high surrogate", ch));
+                }
+                // May need to UTF-8 (re-)encode it, if it's beyond
+                // 7-bit ASCII. Gets pretty messy.
                 if (ch > 127) {
                     // Ok, we'll need room for first byte right away
                     if (currQuadBytes >= 4) {
@@ -1687,10 +1740,33 @@ public class UTF8DataInputJsonParser
                         currQuad = (currQuad << 8) | (0xc0 | (ch >> 6));
                         ++currQuadBytes;
                         // Second byte gets output below:
-                    } else { // 3 bytes; no need to worry about surrogates here
+                    } else if (ch < 0x10000) { // 3 bytes
                         currQuad = (currQuad << 8) | (0xe0 | (ch >> 12));
                         ++currQuadBytes;
                         // need room for middle byte?
+                        if (currQuadBytes >= 4) {
+                            if (qlen >= quads.length) {
+                                _quadBuffer = quads = growArrayBy(quads, quads.length);
+                            }
+                            quads[qlen++] = currQuad;
+                            currQuad = 0;
+                            currQuadBytes = 0;
+                        }
+                        currQuad = (currQuad << 8) | (0x80 | ((ch >> 6) & 0x3f));
+                        ++currQuadBytes;
+                    } else { // 4 bytes (supplementary character)
+                        currQuad = (currQuad << 8) | (0xf0 | (ch >> 18));
+                        ++currQuadBytes;
+                        if (currQuadBytes >= 4) {
+                            if (qlen >= quads.length) {
+                                _quadBuffer = quads = growArrayBy(quads, quads.length);
+                            }
+                            quads[qlen++] = currQuad;
+                            currQuad = 0;
+                            currQuadBytes = 0;
+                        }
+                        currQuad = (currQuad << 8) | (0x80 | ((ch >> 12) & 0x3f));
+                        ++currQuadBytes;
                         if (currQuadBytes >= 4) {
                             if (qlen >= quads.length) {
                                 _quadBuffer = quads = growArrayBy(quads, quads.length);

--- a/src/main/java/tools/jackson/core/json/UTF8DataInputJsonParser.java
+++ b/src/main/java/tools/jackson/core/json/UTF8DataInputJsonParser.java
@@ -1503,14 +1503,9 @@ public class UTF8DataInputJsonParser
                                 + Integer.toHexString(next));
                     }
                     int lo = _decodeEscaped();
-                    if (lo < 0xDC00 || lo > 0xDFFF) {
-                        _reportError(String.format(
-                                "Broken surrogate pair in property name: expected low surrogate (DC00-DFFF), got %04X", lo));
-                    }
-                    ch = 0x10000 + ((ch - 0xD800) << 10) + (lo - 0xDC00);
+                    ch = _decodeSurrogate(ch, lo);
                 } else if (ch >= 0xDC00 && ch <= 0xDFFF) { // lone low surrogate
-                    _reportError(String.format(
-                            "Unexpected low surrogate in property name (%04X) without preceding high surrogate", ch));
+                    _reportUnexpectedLowSurrogate(ch);
                 }
                 // May need to UTF-8 (re-)encode it, if it's beyond
                 // 7-bit ASCII. Gets pretty messy.
@@ -1715,14 +1710,9 @@ public class UTF8DataInputJsonParser
                                 + Integer.toHexString(next));
                     }
                     int lo = _decodeEscaped();
-                    if (lo < 0xDC00 || lo > 0xDFFF) {
-                        _reportError(String.format(
-                                "Broken surrogate pair in property name: expected low surrogate (DC00-DFFF), got %04X", lo));
-                    }
-                    ch = 0x10000 + ((ch - 0xD800) << 10) + (lo - 0xDC00);
+                    ch = _decodeSurrogate(ch, lo);
                 } else if (ch >= 0xDC00 && ch <= 0xDFFF) { // lone low surrogate
-                    _reportError(String.format(
-                            "Unexpected low surrogate in property name (%04X) without preceding high surrogate", ch));
+                    _reportUnexpectedLowSurrogate(ch);
                 }
                 // May need to UTF-8 (re-)encode it, if it's beyond
                 // 7-bit ASCII. Gets pretty messy.

--- a/src/main/java/tools/jackson/core/json/UTF8StreamJsonParser.java
+++ b/src/main/java/tools/jackson/core/json/UTF8StreamJsonParser.java
@@ -2377,14 +2377,9 @@ public class UTF8StreamJsonParser
                     }
                     ++_inputPtr;
                     int lo = _decodeEscaped();
-                    if (lo < 0xDC00 || lo > 0xDFFF) {
-                        _reportError(String.format(
-                            "Broken surrogate pair in property name: expected low surrogate (DC00-DFFF), got %04X", lo));
-                    }
-                    ch = 0x10000 + ((ch - 0xD800) << 10) + (lo - 0xDC00);
+                    ch = _decodeSurrogate(ch, lo);
                 } else if (ch >= 0xDC00 && ch <= 0xDFFF) { // lone low surrogate
-                    _reportError(String.format(
-                            "Unexpected low surrogate in property name (%04X) without preceding high surrogate", ch));
+                    _reportUnexpectedLowSurrogate(ch);
                 }
                 // Oh crap. May need to UTF-8 (re-)encode it, if it's beyond
                 // 7-bit ASCII. Gets pretty messy. If this happens often, may
@@ -2609,14 +2604,9 @@ public class UTF8StreamJsonParser
                     }
                     ++_inputPtr;
                     int lo = _decodeEscaped();
-                    if (lo < 0xDC00 || lo > 0xDFFF) {
-                        _reportError(String.format(
-                                "Broken surrogate pair in property name: expected low surrogate (DC00-DFFF), got %04X", lo));
-                    }
-                    ch = 0x10000 + ((ch - 0xD800) << 10) + (lo - 0xDC00);
+                    ch = _decodeSurrogate(ch, lo);
                 } else if (ch >= 0xDC00 && ch <= 0xDFFF) { // lone low surrogate
-                    _reportError(String.format(
-                            "Unexpected low surrogate in property name (%04X) without preceding high surrogate", ch));
+                    _reportUnexpectedLowSurrogate(ch);
                 }
                 // as per main code, inefficient but will have to do
                 if (ch > 127) {

--- a/src/main/java/tools/jackson/core/json/UTF8StreamJsonParser.java
+++ b/src/main/java/tools/jackson/core/json/UTF8StreamJsonParser.java
@@ -2363,6 +2363,29 @@ public class UTF8StreamJsonParser
                     // Nope, escape sequence
                     ch = _decodeEscaped();
                 }
+                // [jackson-core#1541]: Handle JSON-escaped surrogate pairs in field names
+                if (ch >= 0xD800 && ch <= 0xDBFF) { // high surrogate
+                    // Must be followed by \\uXXXX low surrogate
+                    if (_inputPtr >= _inputEnd) {
+                        if (!_loadMore()) {
+                            return _reportInvalidEOF(" in property name", JsonToken.PROPERTY_NAME);
+                        }
+                    }
+                    if (_inputBuffer[_inputPtr] != INT_BACKSLASH) {
+                        _reportError("Broken surrogate pair in property name: expected '\\' to start low surrogate, got 0x"
+                                + Integer.toHexString(_inputBuffer[_inputPtr] & 0xFF));
+                    }
+                    ++_inputPtr;
+                    int lo = _decodeEscaped();
+                    if (lo < 0xDC00 || lo > 0xDFFF) {
+                        _reportError(String.format(
+                            "Broken surrogate pair in property name: expected low surrogate (DC00-DFFF), got %04X", lo));
+                    }
+                    ch = 0x10000 + ((ch - 0xD800) << 10) + (lo - 0xDC00);
+                } else if (ch >= 0xDC00 && ch <= 0xDFFF) { // lone low surrogate
+                    _reportError(String.format(
+                            "Unexpected low surrogate in property name (%04X) without preceding high surrogate", ch));
+                }
                 // Oh crap. May need to UTF-8 (re-)encode it, if it's beyond
                 // 7-bit ASCII. Gets pretty messy. If this happens often, may
                 // want to use different name canonicalization to avoid these hits.
@@ -2380,10 +2403,33 @@ public class UTF8StreamJsonParser
                         currQuad = (currQuad << 8) | (0xc0 | (ch >> 6));
                         ++currQuadBytes;
                         // Second byte gets output below:
-                    } else { // 3 bytes; no need to worry about surrogates here
+                    } else if (ch < 0x10000) { // 3 bytes
                         currQuad = (currQuad << 8) | (0xe0 | (ch >> 12));
                         ++currQuadBytes;
                         // need room for middle byte?
+                        if (currQuadBytes >= 4) {
+                            if (qlen >= quads.length) {
+                                _quadBuffer = quads = _growNameDecodeBuffer(quads, quads.length);
+                            }
+                            quads[qlen++] = currQuad;
+                            currQuad = 0;
+                            currQuadBytes = 0;
+                        }
+                        currQuad = (currQuad << 8) | (0x80 | ((ch >> 6) & 0x3f));
+                        ++currQuadBytes;
+                    } else { // 4 bytes (supplementary character)
+                        currQuad = (currQuad << 8) | (0xf0 | (ch >> 18));
+                        ++currQuadBytes;
+                        if (currQuadBytes >= 4) {
+                            if (qlen >= quads.length) {
+                                _quadBuffer = quads = _growNameDecodeBuffer(quads, quads.length);
+                            }
+                            quads[qlen++] = currQuad;
+                            currQuad = 0;
+                            currQuadBytes = 0;
+                        }
+                        currQuad = (currQuad << 8) | (0x80 | ((ch >> 12) & 0x3f));
+                        ++currQuadBytes;
                         if (currQuadBytes >= 4) {
                             if (qlen >= quads.length) {
                                 _quadBuffer = quads = _growNameDecodeBuffer(quads, quads.length);
@@ -2550,6 +2596,28 @@ public class UTF8StreamJsonParser
                     // Nope, escape sequence
                     ch = _decodeEscaped();
                 }
+                // [jackson-core#1541]: Handle JSON-escaped surrogate pairs in field names
+                if (ch >= 0xD800 && ch <= 0xDBFF) { // high surrogate
+                    if (_inputPtr >= _inputEnd) {
+                        if (!_loadMore()) {
+                            return _reportInvalidEOF(" in property name", JsonToken.PROPERTY_NAME);
+                        }
+                    }
+                    if (_inputBuffer[_inputPtr] != INT_BACKSLASH) {
+                        _reportError("Broken surrogate pair in property name: expected '\\' to start low surrogate, got 0x"
+                                + Integer.toHexString(_inputBuffer[_inputPtr] & 0xFF));
+                    }
+                    ++_inputPtr;
+                    int lo = _decodeEscaped();
+                    if (lo < 0xDC00 || lo > 0xDFFF) {
+                        _reportError(String.format(
+                                "Broken surrogate pair in property name: expected low surrogate (DC00-DFFF), got %04X", lo));
+                    }
+                    ch = 0x10000 + ((ch - 0xD800) << 10) + (lo - 0xDC00);
+                } else if (ch >= 0xDC00 && ch <= 0xDFFF) { // lone low surrogate
+                    _reportError(String.format(
+                            "Unexpected low surrogate in property name (%04X) without preceding high surrogate", ch));
+                }
                 // as per main code, inefficient but will have to do
                 if (ch > 127) {
                     // Ok, we'll need room for first byte right away
@@ -2565,10 +2633,33 @@ public class UTF8StreamJsonParser
                         currQuad = (currQuad << 8) | (0xc0 | (ch >> 6));
                         ++currQuadBytes;
                         // Second byte gets output below:
-                    } else { // 3 bytes; no need to worry about surrogates here
+                    } else if (ch < 0x10000) { // 3 bytes
                         currQuad = (currQuad << 8) | (0xe0 | (ch >> 12));
                         ++currQuadBytes;
                         // need room for middle byte?
+                        if (currQuadBytes >= 4) {
+                            if (qlen >= quads.length) {
+                                _quadBuffer = quads = _growNameDecodeBuffer(quads, quads.length);
+                            }
+                            quads[qlen++] = currQuad;
+                            currQuad = 0;
+                            currQuadBytes = 0;
+                        }
+                        currQuad = (currQuad << 8) | (0x80 | ((ch >> 6) & 0x3f));
+                        ++currQuadBytes;
+                    } else { // 4 bytes (supplementary character)
+                        currQuad = (currQuad << 8) | (0xf0 | (ch >> 18));
+                        ++currQuadBytes;
+                        if (currQuadBytes >= 4) {
+                            if (qlen >= quads.length) {
+                                _quadBuffer = quads = _growNameDecodeBuffer(quads, quads.length);
+                            }
+                            quads[qlen++] = currQuad;
+                            currQuad = 0;
+                            currQuadBytes = 0;
+                        }
+                        currQuad = (currQuad << 8) | (0x80 | ((ch >> 12) & 0x3f));
+                        ++currQuadBytes;
                         if (currQuadBytes >= 4) {
                             if (qlen >= quads.length) {
                                 _quadBuffer = quads = _growNameDecodeBuffer(quads, quads.length);

--- a/src/main/java/tools/jackson/core/json/async/NonBlockingJsonParserBase.java
+++ b/src/main/java/tools/jackson/core/json/async/NonBlockingJsonParserBase.java
@@ -164,9 +164,9 @@ public abstract class NonBlockingJsonParserBase
      * High surrogate code point awaiting matching low surrogate during
      * property name parsing, or 0 if none pending.
      *
-     * @since 3.1.1
+     * @since 3.1
      */
-    protected int _pendingSurrogate;
+    protected int _pendingSurrogateInName;
 
     /*
     /**********************************************************************

--- a/src/main/java/tools/jackson/core/json/async/NonBlockingJsonParserBase.java
+++ b/src/main/java/tools/jackson/core/json/async/NonBlockingJsonParserBase.java
@@ -160,6 +160,14 @@ public abstract class NonBlockingJsonParserBase
 
     protected int _quotedDigits;
 
+    /**
+     * High surrogate code point awaiting matching low surrogate during
+     * property name parsing, or 0 if none pending.
+     *
+     * @since 3.1.1
+     */
+    protected int _pendingSurrogate;
+
     /*
     /**********************************************************************
     /* Additional parsing state

--- a/src/main/java/tools/jackson/core/json/async/NonBlockingUtf8JsonParserBase.java
+++ b/src/main/java/tools/jackson/core/json/async/NonBlockingUtf8JsonParserBase.java
@@ -2150,6 +2150,39 @@ public abstract class NonBlockingUtf8JsonParserBase
                 }
             }
 
+            // [jackson-core#1541]: Handle JSON-escaped surrogate pairs in field names
+            if (ch >= 0xD800 && ch <= 0xDBFF) { // high surrogate
+                // Fast path: if we have enough bytes, decode inline
+                int remaining = _inputEnd - _inputPtr;
+                if (remaining >= 6) { // need \\uXXXX = 6 bytes
+                    if (getByteFromBuffer(_inputPtr) != INT_BACKSLASH) {
+                        _reportError("Broken surrogate pair in property name: expected '\\' to start low surrogate, got 0x"
+                                + Integer.toHexString(getByteFromBuffer(_inputPtr) & 0xFF));
+                    }
+                    ++_inputPtr;
+                    int lo = _decodeFastCharEscape();
+                    if (lo < 0xDC00 || lo > 0xDFFF) {
+                        _reportError(String.format(
+                                "Broken surrogate pair in property name: expected low surrogate (DC00-DFFF), got %04X", lo));
+                    }
+                    ch = 0x10000 + ((ch - 0xD800) << 10) + (lo - 0xDC00);
+                } else {
+                    // Slow path: save state and return NOT_AVAILABLE
+                    _pendingSurrogate = ch;
+                    _minorState = MINOR_PROPERTY_NAME_ESCAPE;
+                    _minorStateAfterSplit = MINOR_PROPERTY_NAME;
+                    _quadLength = qlen;
+                    _pending32 = currQuad;
+                    _pendingBytes = currQuadBytes;
+                    _quoted32 = 0;
+                    _quotedDigits = -2; // signal: need backslash for low surrogate
+                    return _updateTokenToNA();
+                }
+            } else if (ch >= 0xDC00 && ch <= 0xDFFF) { // lone low surrogate
+                _reportError(String.format(
+                        "Unexpected low surrogate in property name (%04X) without preceding high surrogate", ch));
+            }
+
             // May need to UTF-8 (re-)encode it, if it's beyond
             // 7-bit ASCII. Gets pretty messy. If this happens often, may
             // want to use different name canonicalization to avoid these hits.
@@ -2167,10 +2200,27 @@ public abstract class NonBlockingUtf8JsonParserBase
                     currQuad = (currQuad << 8) | (0xc0 | (ch >> 6));
                     ++currQuadBytes;
                     // Second byte gets output below:
-                } else { // 3 bytes; no need to worry about surrogates here
+                } else if (ch < 0x10000) { // 3 bytes
                     currQuad = (currQuad << 8) | (0xe0 | (ch >> 12));
                     ++currQuadBytes;
                     // need room for middle byte?
+                    if (currQuadBytes >= 4) {
+                        quads[qlen++] = currQuad;
+                        currQuad = 0;
+                        currQuadBytes = 0;
+                    }
+                    currQuad = (currQuad << 8) | (0x80 | ((ch >> 6) & 0x3f));
+                    ++currQuadBytes;
+                } else { // 4 bytes (supplementary character)
+                    currQuad = (currQuad << 8) | (0xf0 | (ch >> 18));
+                    ++currQuadBytes;
+                    if (currQuadBytes >= 4) {
+                        quads[qlen++] = currQuad;
+                        currQuad = 0;
+                        currQuadBytes = 0;
+                    }
+                    currQuad = (currQuad << 8) | (0x80 | ((ch >> 12) & 0x3f));
+                    ++currQuadBytes;
                     if (currQuadBytes >= 4) {
                         quads[qlen++] = currQuad;
                         currQuad = 0;
@@ -2340,6 +2390,37 @@ public abstract class NonBlockingUtf8JsonParserBase
                         return _updateTokenToNA();
                     }
                 }
+                // [jackson-core#1541]: Handle JSON-escaped surrogate pairs in field names
+                if (ch >= 0xD800 && ch <= 0xDBFF) { // high surrogate
+                    int remaining = _inputEnd - _inputPtr;
+                    if (remaining >= 6) { // need \\uXXXX = 6 bytes
+                        if (getByteFromBuffer(_inputPtr) != INT_BACKSLASH) {
+                            _reportError("Broken surrogate pair in property name: expected '\\' to start low surrogate, got 0x"
+                                    + Integer.toHexString(getByteFromBuffer(_inputPtr) & 0xFF));
+                        }
+                        ++_inputPtr;
+                        int lo = _decodeFastCharEscape();
+                        if (lo < 0xDC00 || lo > 0xDFFF) {
+                            _reportError(String.format(
+                                    "Broken surrogate pair in property name: expected low surrogate (DC00-DFFF), got %04X", lo));
+                        }
+                        ch = 0x10000 + ((ch - 0xD800) << 10) + (lo - 0xDC00);
+                    } else {
+                        // Slow path: save state and return NOT_AVAILABLE
+                        _pendingSurrogate = ch;
+                        _minorState = MINOR_PROPERTY_NAME_ESCAPE;
+                        _minorStateAfterSplit = MINOR_PROPERTY_APOS_NAME;
+                        _quadLength = qlen;
+                        _pending32 = currQuad;
+                        _pendingBytes = currQuadBytes;
+                        _quoted32 = 0;
+                        _quotedDigits = -2; // signal: need backslash for low surrogate
+                        return _updateTokenToNA();
+                    }
+                } else if (ch >= 0xDC00 && ch <= 0xDFFF) { // lone low surrogate
+                    _reportError(String.format(
+                            "Unexpected low surrogate in property name (%04X) without preceding high surrogate", ch));
+                }
                 if (ch > 127) {
                     // Ok, we'll need room for first byte right away
                     if (currQuadBytes >= 4) {
@@ -2354,10 +2435,33 @@ public abstract class NonBlockingUtf8JsonParserBase
                         currQuad = (currQuad << 8) | (0xc0 | (ch >> 6));
                         ++currQuadBytes;
                         // Second byte gets output below:
-                    } else { // 3 bytes; no need to worry about surrogates here
+                    } else if (ch < 0x10000) { // 3 bytes
                         currQuad = (currQuad << 8) | (0xe0 | (ch >> 12));
                         ++currQuadBytes;
                         // need room for middle byte?
+                        if (currQuadBytes >= 4) {
+                            if (qlen >= quads.length) {
+                                _quadBuffer = quads = _growNameDecodeBuffer(quads, quads.length);
+                            }
+                            quads[qlen++] = currQuad;
+                            currQuad = 0;
+                            currQuadBytes = 0;
+                        }
+                        currQuad = (currQuad << 8) | (0x80 | ((ch >> 6) & 0x3f));
+                        ++currQuadBytes;
+                    } else { // 4 bytes (supplementary character)
+                        currQuad = (currQuad << 8) | (0xf0 | (ch >> 18));
+                        ++currQuadBytes;
+                        if (currQuadBytes >= 4) {
+                            if (qlen >= quads.length) {
+                                _quadBuffer = quads = _growNameDecodeBuffer(quads, quads.length);
+                            }
+                            quads[qlen++] = currQuad;
+                            currQuad = 0;
+                            currQuadBytes = 0;
+                        }
+                        currQuad = (currQuad << 8) | (0x80 | ((ch >> 12) & 0x3f));
+                        ++currQuadBytes;
                         if (currQuadBytes >= 4) {
                             if (qlen >= quads.length) {
                                 _quadBuffer = quads = _growNameDecodeBuffer(quads, quads.length);
@@ -2404,12 +2508,56 @@ public abstract class NonBlockingUtf8JsonParserBase
 
     protected final JsonToken _finishPropertyWithEscape() throws JacksonException
     {
-        // First: try finishing what wasn't yet:
-        int ch = _decodeSplitEscaped(_quoted32, _quotedDigits);
-        if (ch < 0) { // ... if possible
-            _minorState = MINOR_PROPERTY_NAME_ESCAPE;
-            return JsonToken.NOT_AVAILABLE;
+        int ch;
+
+        // [jackson-core#1541]: Check if we have a pending high surrogate
+        if (_pendingSurrogate != 0) {
+            // We have a high surrogate saved, now need to decode the low surrogate escape
+            if (_quotedDigits == -2) {
+                // Need to read the backslash first
+                if (_inputPtr >= _inputEnd) {
+                    return JsonToken.NOT_AVAILABLE;
+                }
+                int b = getNextUnsignedByteFromBuffer();
+                if (b != INT_BACKSLASH) {
+                    _reportError("Broken surrogate pair in property name: expected '\\' to start low surrogate, got 0x"
+                            + Integer.toHexString(b));
+                }
+                // Now start decoding the escape sequence
+                _quotedDigits = -1; // signal: expecting char after backslash
+                _quoted32 = 0;
+            }
+            ch = _decodeSplitEscaped(_quoted32, _quotedDigits);
+            if (ch < 0) {
+                _minorState = MINOR_PROPERTY_NAME_ESCAPE;
+                return JsonToken.NOT_AVAILABLE;
+            }
+            if (ch < 0xDC00 || ch > 0xDFFF) {
+                _reportError(String.format(
+                        "Broken surrogate pair in property name: expected low surrogate (DC00-DFFF), got %04X", ch));
+            }
+            ch = 0x10000 + ((_pendingSurrogate - 0xD800) << 10) + (ch - 0xDC00);
+            _pendingSurrogate = 0;
+        } else {
+            // Normal path: finish decoding the escape
+            ch = _decodeSplitEscaped(_quoted32, _quotedDigits);
+            if (ch < 0) { // ... if possible
+                _minorState = MINOR_PROPERTY_NAME_ESCAPE;
+                return JsonToken.NOT_AVAILABLE;
+            }
+            // [jackson-core#1541]: Check if decoded value is a high surrogate
+            if (ch >= 0xD800 && ch <= 0xDBFF) {
+                _pendingSurrogate = ch;
+                _quoted32 = 0;
+                _quotedDigits = -2; // signal: need backslash for low surrogate
+                _minorState = MINOR_PROPERTY_NAME_ESCAPE;
+                return _finishPropertyWithEscape(); // recurse to handle the low surrogate
+            } else if (ch >= 0xDC00 && ch <= 0xDFFF) {
+                _reportError(String.format(
+                        "Unexpected low surrogate in property name (%04X) without preceding high surrogate", ch));
+            }
         }
+
         if (_quadLength >= _quadBuffer.length) {
             _quadBuffer = _growNameDecodeBuffer(_quadBuffer, 32);
         }
@@ -2426,9 +2574,24 @@ public abstract class NonBlockingUtf8JsonParserBase
                 currQuad = (currQuad << 8) | (0xc0 | (ch >> 6));
                 ++currQuadBytes;
                 // Second byte gets output below:
-            } else { // 3 bytes; no need to worry about surrogates here
+            } else if (ch < 0x10000) { // 3 bytes
                 currQuad = (currQuad << 8) | (0xe0 | (ch >> 12));
                 // need room for middle byte?
+                if (++currQuadBytes >= 4) {
+                    _quadBuffer[_quadLength++] = currQuad;
+                    currQuad = 0;
+                    currQuadBytes = 0;
+                }
+                currQuad = (currQuad << 8) | (0x80 | ((ch >> 6) & 0x3f));
+                ++currQuadBytes;
+            } else { // 4 bytes (supplementary character)
+                currQuad = (currQuad << 8) | (0xf0 | (ch >> 18));
+                if (++currQuadBytes >= 4) {
+                    _quadBuffer[_quadLength++] = currQuad;
+                    currQuad = 0;
+                    currQuadBytes = 0;
+                }
+                currQuad = (currQuad << 8) | (0x80 | ((ch >> 12) & 0x3f));
                 if (++currQuadBytes >= 4) {
                     _quadBuffer[_quadLength++] = currQuad;
                     currQuad = 0;

--- a/src/main/java/tools/jackson/core/json/async/NonBlockingUtf8JsonParserBase.java
+++ b/src/main/java/tools/jackson/core/json/async/NonBlockingUtf8JsonParserBase.java
@@ -2168,7 +2168,7 @@ public abstract class NonBlockingUtf8JsonParserBase
                     ch = 0x10000 + ((ch - 0xD800) << 10) + (lo - 0xDC00);
                 } else {
                     // Slow path: save state and return NOT_AVAILABLE
-                    _pendingSurrogate = ch;
+                    _pendingSurrogateInName = ch;
                     _minorState = MINOR_PROPERTY_NAME_ESCAPE;
                     _minorStateAfterSplit = MINOR_PROPERTY_NAME;
                     _quadLength = qlen;
@@ -2407,7 +2407,7 @@ public abstract class NonBlockingUtf8JsonParserBase
                         ch = 0x10000 + ((ch - 0xD800) << 10) + (lo - 0xDC00);
                     } else {
                         // Slow path: save state and return NOT_AVAILABLE
-                        _pendingSurrogate = ch;
+                        _pendingSurrogateInName = ch;
                         _minorState = MINOR_PROPERTY_NAME_ESCAPE;
                         _minorStateAfterSplit = MINOR_PROPERTY_APOS_NAME;
                         _quadLength = qlen;
@@ -2511,7 +2511,7 @@ public abstract class NonBlockingUtf8JsonParserBase
         int ch;
 
         // [jackson-core#1541]: Check if we have a pending high surrogate
-        if (_pendingSurrogate != 0) {
+        if (_pendingSurrogateInName != 0) {
             // We have a high surrogate saved, now need to decode the low surrogate escape
             if (_quotedDigits == -2) {
                 // Need to read the backslash first
@@ -2536,8 +2536,8 @@ public abstract class NonBlockingUtf8JsonParserBase
                 _reportError(String.format(
                         "Broken surrogate pair in property name: expected low surrogate (DC00-DFFF), got %04X", ch));
             }
-            ch = 0x10000 + ((_pendingSurrogate - 0xD800) << 10) + (ch - 0xDC00);
-            _pendingSurrogate = 0;
+            ch = 0x10000 + ((_pendingSurrogateInName - 0xD800) << 10) + (ch - 0xDC00);
+            _pendingSurrogateInName = 0;
         } else {
             // Normal path: finish decoding the escape
             ch = _decodeSplitEscaped(_quoted32, _quotedDigits);
@@ -2547,7 +2547,7 @@ public abstract class NonBlockingUtf8JsonParserBase
             }
             // [jackson-core#1541]: Check if decoded value is a high surrogate
             if (ch >= 0xD800 && ch <= 0xDBFF) {
-                _pendingSurrogate = ch;
+                _pendingSurrogateInName = ch;
                 _quoted32 = 0;
                 _quotedDigits = -2; // signal: need backslash for low surrogate
                 _minorState = MINOR_PROPERTY_NAME_ESCAPE;

--- a/src/main/java/tools/jackson/core/json/async/NonBlockingUtf8JsonParserBase.java
+++ b/src/main/java/tools/jackson/core/json/async/NonBlockingUtf8JsonParserBase.java
@@ -2161,11 +2161,7 @@ public abstract class NonBlockingUtf8JsonParserBase
                     }
                     ++_inputPtr;
                     int lo = _decodeFastCharEscape();
-                    if (lo < 0xDC00 || lo > 0xDFFF) {
-                        _reportError(String.format(
-                                "Broken surrogate pair in property name: expected low surrogate (DC00-DFFF), got %04X", lo));
-                    }
-                    ch = 0x10000 + ((ch - 0xD800) << 10) + (lo - 0xDC00);
+                    ch = _decodeSurrogate(ch, lo);
                 } else {
                     // Slow path: save state and return NOT_AVAILABLE
                     _pendingSurrogateInName = ch;
@@ -2179,8 +2175,7 @@ public abstract class NonBlockingUtf8JsonParserBase
                     return _updateTokenToNA();
                 }
             } else if (ch >= 0xDC00 && ch <= 0xDFFF) { // lone low surrogate
-                _reportError(String.format(
-                        "Unexpected low surrogate in property name (%04X) without preceding high surrogate", ch));
+                _reportUnexpectedLowSurrogate(ch);
             }
 
             // May need to UTF-8 (re-)encode it, if it's beyond
@@ -2418,8 +2413,7 @@ public abstract class NonBlockingUtf8JsonParserBase
                         return _updateTokenToNA();
                     }
                 } else if (ch >= 0xDC00 && ch <= 0xDFFF) { // lone low surrogate
-                    _reportError(String.format(
-                            "Unexpected low surrogate in property name (%04X) without preceding high surrogate", ch));
+                    _reportUnexpectedLowSurrogate(ch);
                 }
                 if (ch > 127) {
                     // Ok, we'll need room for first byte right away
@@ -2532,11 +2526,7 @@ public abstract class NonBlockingUtf8JsonParserBase
                 _minorState = MINOR_PROPERTY_NAME_ESCAPE;
                 return JsonToken.NOT_AVAILABLE;
             }
-            if (ch < 0xDC00 || ch > 0xDFFF) {
-                _reportError(String.format(
-                        "Broken surrogate pair in property name: expected low surrogate (DC00-DFFF), got %04X", ch));
-            }
-            ch = 0x10000 + ((_pendingSurrogateInName - 0xD800) << 10) + (ch - 0xDC00);
+            ch = _decodeSurrogate(_pendingSurrogateInName, ch);
             _pendingSurrogateInName = 0;
         } else {
             // Normal path: finish decoding the escape
@@ -2553,8 +2543,7 @@ public abstract class NonBlockingUtf8JsonParserBase
                 _minorState = MINOR_PROPERTY_NAME_ESCAPE;
                 return _finishPropertyWithEscape(); // recurse to handle the low surrogate
             } else if (ch >= 0xDC00 && ch <= 0xDFFF) {
-                _reportError(String.format(
-                        "Unexpected low surrogate in property name (%04X) without preceding high surrogate", ch));
+                _reportUnexpectedLowSurrogate(ch);
             }
         }
 

--- a/src/test/java/tools/jackson/core/unittest/json/async/AsyncEscapedSurrogateInFieldName1541Test.java
+++ b/src/test/java/tools/jackson/core/unittest/json/async/AsyncEscapedSurrogateInFieldName1541Test.java
@@ -1,0 +1,132 @@
+package tools.jackson.core.unittest.json.async;
+
+import org.junit.jupiter.api.Test;
+
+import tools.jackson.core.*;
+import tools.jackson.core.exc.StreamReadException;
+import tools.jackson.core.json.JsonFactory;
+import tools.jackson.core.unittest.async.AsyncTestBase;
+import tools.jackson.core.unittest.testutil.AsyncReaderWrapper;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Async parser tests for [jackson-core#1541]: JSON-escaped surrogate pairs
+ * (e.g. {@code \ud83d\udc4d}) in field names.
+ */
+class AsyncEscapedSurrogateInFieldName1541Test extends AsyncTestBase
+{
+    private final JsonFactory FACTORY = newStreamFactory();
+
+    // U+1F44D THUMBS UP SIGN = \ud83d\udc4d
+    private static final String THUMBS_UP = "\uD83D\uDC4D";
+
+    // JSON with escaped surrogate pair in field name: {"\\ud83d\\udc4d":"value"}
+    private static final String DOC_FIELD = "{\"\\ud83d\\udc4d\":\"value\"}";
+
+    /*
+    /**********************************************************************
+    /* Test methods, success cases with various bytesPerRead
+    /**********************************************************************
+     */
+
+    @Test
+    void surrogateInFieldNameAsync1Byte() throws Exception
+    {
+        _testSurrogateInFieldNameAsync(1);
+    }
+
+    @Test
+    void surrogateInFieldNameAsync2Bytes() throws Exception
+    {
+        _testSurrogateInFieldNameAsync(2);
+    }
+
+    @Test
+    void surrogateInFieldNameAsync3Bytes() throws Exception
+    {
+        _testSurrogateInFieldNameAsync(3);
+    }
+
+    @Test
+    void surrogateInFieldNameAsync7Bytes() throws Exception
+    {
+        _testSurrogateInFieldNameAsync(7);
+    }
+
+    @Test
+    void surrogateInFieldNameAsync100Bytes() throws Exception
+    {
+        _testSurrogateInFieldNameAsync(100);
+    }
+
+    private void _testSurrogateInFieldNameAsync(int bytesPerRead) throws Exception
+    {
+        byte[] data = _jsonDoc(DOC_FIELD);
+        try (AsyncReaderWrapper r = asyncForBytes(FACTORY, bytesPerRead, data, 0)) {
+            assertToken(JsonToken.START_OBJECT, r.nextToken());
+            assertToken(JsonToken.PROPERTY_NAME, r.nextToken());
+            assertEquals(THUMBS_UP, r.currentName());
+            assertToken(JsonToken.VALUE_STRING, r.nextToken());
+            assertEquals("value", r.currentText());
+            assertToken(JsonToken.END_OBJECT, r.nextToken());
+        }
+    }
+
+    /*
+    /**********************************************************************
+    /* Test methods, multiple surrogate pairs
+    /**********************************************************************
+     */
+
+    @Test
+    void multipleSurrogatePairsAsync1Byte() throws Exception
+    {
+        String doc = "{\"\\ud83d\\udc4d\\ud83d\\udc4d\":\"value\"}";
+        byte[] data = _jsonDoc(doc);
+        String expectedName = THUMBS_UP + THUMBS_UP;
+        try (AsyncReaderWrapper r = asyncForBytes(FACTORY, 1, data, 0)) {
+            assertToken(JsonToken.START_OBJECT, r.nextToken());
+            assertToken(JsonToken.PROPERTY_NAME, r.nextToken());
+            assertEquals(expectedName, r.currentName());
+            assertToken(JsonToken.VALUE_STRING, r.nextToken());
+            assertEquals("value", r.currentText());
+            assertToken(JsonToken.END_OBJECT, r.nextToken());
+        }
+    }
+
+    /*
+    /**********************************************************************
+    /* Test methods, error cases
+    /**********************************************************************
+     */
+
+    @Test
+    void loneHighSurrogateInFieldNameAsync() throws Exception
+    {
+        String doc = "{\"\\ud83d\":\"value\"}";
+        byte[] data = _jsonDoc(doc);
+        try (AsyncReaderWrapper r = asyncForBytes(FACTORY, 1, data, 0)) {
+            assertToken(JsonToken.START_OBJECT, r.nextToken());
+            r.nextToken();
+            fail("Should have thrown for lone high surrogate in field name");
+        } catch (StreamReadException e) {
+            verifyException(e, "surrogate");
+        }
+    }
+
+    @Test
+    void loneLowSurrogateInFieldNameAsync() throws Exception
+    {
+        String doc = "{\"\\udc4d\":\"value\"}";
+        byte[] data = _jsonDoc(doc);
+        try (AsyncReaderWrapper r = asyncForBytes(FACTORY, 1, data, 0)) {
+            assertToken(JsonToken.START_OBJECT, r.nextToken());
+            r.nextToken();
+            fail("Should have thrown for lone low surrogate in field name");
+        } catch (StreamReadException e) {
+            verifyException(e, "surrogate");
+        }
+    }
+}

--- a/src/test/java/tools/jackson/core/unittest/json/async/AsyncEscapedSurrogateInFieldName1541Test.java
+++ b/src/test/java/tools/jackson/core/unittest/json/async/AsyncEscapedSurrogateInFieldName1541Test.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import tools.jackson.core.*;
 import tools.jackson.core.exc.StreamReadException;
 import tools.jackson.core.json.JsonFactory;
+import tools.jackson.core.json.JsonReadFeature;
 import tools.jackson.core.unittest.async.AsyncTestBase;
 import tools.jackson.core.unittest.testutil.AsyncReaderWrapper;
 
@@ -19,11 +20,18 @@ class AsyncEscapedSurrogateInFieldName1541Test extends AsyncTestBase
 {
     private final JsonFactory FACTORY = newStreamFactory();
 
+    private final JsonFactory APOS_FACTORY = JsonFactory.builder()
+            .enable(JsonReadFeature.ALLOW_SINGLE_QUOTES)
+            .build();
+
     // U+1F44D THUMBS UP SIGN = \ud83d\udc4d
     private static final String THUMBS_UP = "\uD83D\uDC4D";
 
     // JSON with escaped surrogate pair in field name: {"\\ud83d\\udc4d":"value"}
     private static final String DOC_FIELD = "{\"\\ud83d\\udc4d\":\"value\"}";
+
+    // Same but with apostrophe-quoted name: {'\\ud83d\\udc4d':'value'}
+    private static final String DOC_FIELD_APOS = "{'\\ud83d\\udc4d':'value'}";
 
     /*
     /**********************************************************************
@@ -68,6 +76,59 @@ class AsyncEscapedSurrogateInFieldName1541Test extends AsyncTestBase
             assertToken(JsonToken.START_OBJECT, r.nextToken());
             assertToken(JsonToken.PROPERTY_NAME, r.nextToken());
             assertEquals(THUMBS_UP, r.currentName());
+            assertToken(JsonToken.VALUE_STRING, r.nextToken());
+            assertEquals("value", r.currentText());
+            assertToken(JsonToken.END_OBJECT, r.nextToken());
+        }
+    }
+
+    /*
+    /**********************************************************************
+    /* Test methods, apostrophe-quoted field names
+    /**********************************************************************
+     */
+
+    @Test
+    void surrogateInAposFieldNameAsync1Byte() throws Exception
+    {
+        _testSurrogateInAposFieldNameAsync(1);
+    }
+
+    @Test
+    void surrogateInAposFieldNameAsync3Bytes() throws Exception
+    {
+        _testSurrogateInAposFieldNameAsync(3);
+    }
+
+    @Test
+    void surrogateInAposFieldNameAsync100Bytes() throws Exception
+    {
+        _testSurrogateInAposFieldNameAsync(100);
+    }
+
+    private void _testSurrogateInAposFieldNameAsync(int bytesPerRead) throws Exception
+    {
+        byte[] data = _jsonDoc(DOC_FIELD_APOS);
+        try (AsyncReaderWrapper r = asyncForBytes(APOS_FACTORY, bytesPerRead, data, 0)) {
+            assertToken(JsonToken.START_OBJECT, r.nextToken());
+            assertToken(JsonToken.PROPERTY_NAME, r.nextToken());
+            assertEquals(THUMBS_UP, r.currentName());
+            assertToken(JsonToken.VALUE_STRING, r.nextToken());
+            assertEquals("value", r.currentText());
+            assertToken(JsonToken.END_OBJECT, r.nextToken());
+        }
+    }
+
+    @Test
+    void multipleSurrogatePairsInAposFieldNameAsync() throws Exception
+    {
+        String doc = "{'\\ud83d\\udc4d\\ud83d\\udc4d':'value'}";
+        byte[] data = _jsonDoc(doc);
+        String expectedName = THUMBS_UP + THUMBS_UP;
+        try (AsyncReaderWrapper r = asyncForBytes(APOS_FACTORY, 1, data, 0)) {
+            assertToken(JsonToken.START_OBJECT, r.nextToken());
+            assertToken(JsonToken.PROPERTY_NAME, r.nextToken());
+            assertEquals(expectedName, r.currentName());
             assertToken(JsonToken.VALUE_STRING, r.nextToken());
             assertEquals("value", r.currentText());
             assertToken(JsonToken.END_OBJECT, r.nextToken());

--- a/src/test/java/tools/jackson/core/unittest/json/async/AsyncEscapedSurrogateInFieldName1541Test.java
+++ b/src/test/java/tools/jackson/core/unittest/json/async/AsyncEscapedSurrogateInFieldName1541Test.java
@@ -24,14 +24,15 @@ class AsyncEscapedSurrogateInFieldName1541Test extends AsyncTestBase
             .enable(JsonReadFeature.ALLOW_SINGLE_QUOTES)
             .build();
 
-    // U+1F44D THUMBS UP SIGN = \ud83d\udc4d
+    // U+1F44D THUMBS UP SIGN = \ud83d\udc4d (UTF-8: F0 9F 91 8D)
     private static final String THUMBS_UP = "\uD83D\uDC4D";
 
-    // JSON with escaped surrogate pair in field name: {"\\ud83d\\udc4d":"value"}
-    private static final String DOC_FIELD = "{\"\\ud83d\\udc4d\":\"value\"}";
+    // U+1D11E MUSICAL SYMBOL G CLEF = \ud834\udd1e (UTF-8: F0 9D 84 9E)
+    private static final String G_CLEF = "\uD834\uDD1E";
 
-    // Same but with apostrophe-quoted name: {'\\ud83d\\udc4d':'value'}
-    private static final String DOC_FIELD_APOS = "{'\\ud83d\\udc4d':'value'}";
+    // Escaped form of surrogate pairs for use in JSON
+    private static final String ESC_THUMBS = "\\ud83d\\udc4d";
+    private static final String ESC_GCLEF = "\\ud834\\udd1e";
 
     /*
     /**********************************************************************
@@ -71,15 +72,7 @@ class AsyncEscapedSurrogateInFieldName1541Test extends AsyncTestBase
 
     private void _testSurrogateInFieldNameAsync(int bytesPerRead) throws Exception
     {
-        byte[] data = _jsonDoc(DOC_FIELD);
-        try (AsyncReaderWrapper r = asyncForBytes(FACTORY, bytesPerRead, data, 0)) {
-            assertToken(JsonToken.START_OBJECT, r.nextToken());
-            assertToken(JsonToken.PROPERTY_NAME, r.nextToken());
-            assertEquals(THUMBS_UP, r.currentName());
-            assertToken(JsonToken.VALUE_STRING, r.nextToken());
-            assertEquals("value", r.currentText());
-            assertToken(JsonToken.END_OBJECT, r.nextToken());
-        }
+        _testFieldNameAsync(FACTORY, bytesPerRead, ESC_THUMBS, THUMBS_UP);
     }
 
     /*
@@ -108,53 +101,122 @@ class AsyncEscapedSurrogateInFieldName1541Test extends AsyncTestBase
 
     private void _testSurrogateInAposFieldNameAsync(int bytesPerRead) throws Exception
     {
-        byte[] data = _jsonDoc(DOC_FIELD_APOS);
-        try (AsyncReaderWrapper r = asyncForBytes(APOS_FACTORY, bytesPerRead, data, 0)) {
-            assertToken(JsonToken.START_OBJECT, r.nextToken());
-            assertToken(JsonToken.PROPERTY_NAME, r.nextToken());
-            assertEquals(THUMBS_UP, r.currentName());
-            assertToken(JsonToken.VALUE_STRING, r.nextToken());
-            assertEquals("value", r.currentText());
-            assertToken(JsonToken.END_OBJECT, r.nextToken());
-        }
-    }
-
-    @Test
-    void multipleSurrogatePairsInAposFieldNameAsync() throws Exception
-    {
-        String doc = "{'\\ud83d\\udc4d\\ud83d\\udc4d':'value'}";
-        byte[] data = _jsonDoc(doc);
-        String expectedName = THUMBS_UP + THUMBS_UP;
-        try (AsyncReaderWrapper r = asyncForBytes(APOS_FACTORY, 1, data, 0)) {
-            assertToken(JsonToken.START_OBJECT, r.nextToken());
-            assertToken(JsonToken.PROPERTY_NAME, r.nextToken());
-            assertEquals(expectedName, r.currentName());
-            assertToken(JsonToken.VALUE_STRING, r.nextToken());
-            assertEquals("value", r.currentText());
-            assertToken(JsonToken.END_OBJECT, r.nextToken());
-        }
+        _testAposFieldNameAsync(bytesPerRead, ESC_THUMBS, THUMBS_UP);
     }
 
     /*
     /**********************************************************************
-    /* Test methods, multiple surrogate pairs
+    /* Test methods, name variations (quad boundaries, long names)
     /**********************************************************************
      */
 
+    // 1-byte-at-a-time exercises the slow (split escape) path;
+    // 100-byte reads exercise the fast (inline) path
+
     @Test
-    void multipleSurrogatePairsAsync1Byte() throws Exception
+    void nameVariationsAsync1Byte() throws Exception
     {
-        String doc = "{\"\\ud83d\\udc4d\\ud83d\\udc4d\":\"value\"}";
-        byte[] data = _jsonDoc(doc);
-        String expectedName = THUMBS_UP + THUMBS_UP;
-        try (AsyncReaderWrapper r = asyncForBytes(FACTORY, 1, data, 0)) {
-            assertToken(JsonToken.START_OBJECT, r.nextToken());
-            assertToken(JsonToken.PROPERTY_NAME, r.nextToken());
-            assertEquals(expectedName, r.currentName());
-            assertToken(JsonToken.VALUE_STRING, r.nextToken());
-            assertEquals("value", r.currentText());
-            assertToken(JsonToken.END_OBJECT, r.nextToken());
-        }
+        _testNameVariationsAsync(1);
+    }
+
+    @Test
+    void nameVariationsAsync3Bytes() throws Exception
+    {
+        _testNameVariationsAsync(3);
+    }
+
+    @Test
+    void nameVariationsAsync100Bytes() throws Exception
+    {
+        _testNameVariationsAsync(100);
+    }
+
+    private void _testNameVariationsAsync(int bytesPerRead) throws Exception
+    {
+        // Prefix lengths 0-5 (varying quad offset when escape is hit)
+        _testFieldNameAsync(FACTORY, bytesPerRead, ESC_THUMBS, THUMBS_UP);
+        _testFieldNameAsync(FACTORY, bytesPerRead, "a" + ESC_THUMBS, "a" + THUMBS_UP);
+        _testFieldNameAsync(FACTORY, bytesPerRead, "ab" + ESC_THUMBS, "ab" + THUMBS_UP);
+        _testFieldNameAsync(FACTORY, bytesPerRead, "abc" + ESC_THUMBS, "abc" + THUMBS_UP);
+        _testFieldNameAsync(FACTORY, bytesPerRead, "abcd" + ESC_THUMBS, "abcd" + THUMBS_UP);
+        _testFieldNameAsync(FACTORY, bytesPerRead, "abcde" + ESC_THUMBS, "abcde" + THUMBS_UP);
+
+        // Suffix after surrogate pair
+        _testFieldNameAsync(FACTORY, bytesPerRead, ESC_THUMBS + "z", THUMBS_UP + "z");
+
+        // Sandwiched: ASCII + surrogate + ASCII
+        _testFieldNameAsync(FACTORY, bytesPerRead,
+                "x" + ESC_THUMBS + "y", "x" + THUMBS_UP + "y");
+
+        // Two consecutive surrogate pairs
+        _testFieldNameAsync(FACTORY, bytesPerRead,
+                ESC_THUMBS + ESC_THUMBS, THUMBS_UP + THUMBS_UP);
+
+        // Two different supplementary characters
+        _testFieldNameAsync(FACTORY, bytesPerRead,
+                ESC_THUMBS + ESC_GCLEF, THUMBS_UP + G_CLEF);
+
+        // Different supplementary character alone
+        _testFieldNameAsync(FACTORY, bytesPerRead, ESC_GCLEF, G_CLEF);
+
+        // Long prefix (>12 bytes)
+        _testFieldNameAsync(FACTORY, bytesPerRead,
+                "abcdefghijklm" + ESC_THUMBS,
+                "abcdefghijklm" + THUMBS_UP);
+
+        // Long prefix + suffix
+        _testFieldNameAsync(FACTORY, bytesPerRead,
+                "abcdefghijklm" + ESC_THUMBS + "n",
+                "abcdefghijklm" + THUMBS_UP + "n");
+
+        // Long name with surrogate in the middle and more ASCII after
+        _testFieldNameAsync(FACTORY, bytesPerRead,
+                "abcdefgh" + ESC_THUMBS + "ijklmnop",
+                "abcdefgh" + THUMBS_UP + "ijklmnop");
+
+        // Long name with multiple different surrogates
+        _testFieldNameAsync(FACTORY, bytesPerRead,
+                "abcdefgh" + ESC_THUMBS + "ij" + ESC_GCLEF + "klmn",
+                "abcdefgh" + THUMBS_UP + "ij" + G_CLEF + "klmn");
+    }
+
+    @Test
+    void nameVariationsAposAsync1Byte() throws Exception
+    {
+        _testNameVariationsAposAsync(1);
+    }
+
+    @Test
+    void nameVariationsAposAsync100Bytes() throws Exception
+    {
+        _testNameVariationsAposAsync(100);
+    }
+
+    private void _testNameVariationsAposAsync(int bytesPerRead) throws Exception
+    {
+        // Prefix lengths 0-4
+        _testAposFieldNameAsync(bytesPerRead, ESC_THUMBS, THUMBS_UP);
+        _testAposFieldNameAsync(bytesPerRead, "a" + ESC_THUMBS, "a" + THUMBS_UP);
+        _testAposFieldNameAsync(bytesPerRead, "ab" + ESC_THUMBS, "ab" + THUMBS_UP);
+        _testAposFieldNameAsync(bytesPerRead, "abc" + ESC_THUMBS, "abc" + THUMBS_UP);
+        _testAposFieldNameAsync(bytesPerRead, "abcd" + ESC_THUMBS, "abcd" + THUMBS_UP);
+
+        // Suffix, sandwiched, multiple
+        _testAposFieldNameAsync(bytesPerRead, ESC_THUMBS + "z", THUMBS_UP + "z");
+        _testAposFieldNameAsync(bytesPerRead,
+                "x" + ESC_THUMBS + "y", "x" + THUMBS_UP + "y");
+        _testAposFieldNameAsync(bytesPerRead,
+                ESC_THUMBS + ESC_GCLEF, THUMBS_UP + G_CLEF);
+
+        // Long prefix
+        _testAposFieldNameAsync(bytesPerRead,
+                "abcdefghijklm" + ESC_THUMBS,
+                "abcdefghijklm" + THUMBS_UP);
+
+        // Long with mixed surrogates
+        _testAposFieldNameAsync(bytesPerRead,
+                "abcdefgh" + ESC_THUMBS + "ij" + ESC_GCLEF + "klmn",
+                "abcdefgh" + THUMBS_UP + "ij" + G_CLEF + "klmn");
     }
 
     /*
@@ -188,6 +250,42 @@ class AsyncEscapedSurrogateInFieldName1541Test extends AsyncTestBase
             fail("Should have thrown for lone low surrogate in field name");
         } catch (StreamReadException e) {
             verifyException(e, "surrogate");
+        }
+    }
+
+    /*
+    /**********************************************************************
+    /* Helper methods
+    /**********************************************************************
+     */
+
+    private void _testFieldNameAsync(JsonFactory f, int bytesPerRead,
+            String escapedName, String expectedName) throws Exception
+    {
+        String doc = "{\"" + escapedName + "\":\"value\"}";
+        byte[] data = _jsonDoc(doc);
+        try (AsyncReaderWrapper r = asyncForBytes(f, bytesPerRead, data, 0)) {
+            assertToken(JsonToken.START_OBJECT, r.nextToken());
+            assertToken(JsonToken.PROPERTY_NAME, r.nextToken());
+            assertEquals(expectedName, r.currentName());
+            assertToken(JsonToken.VALUE_STRING, r.nextToken());
+            assertEquals("value", r.currentText());
+            assertToken(JsonToken.END_OBJECT, r.nextToken());
+        }
+    }
+
+    private void _testAposFieldNameAsync(int bytesPerRead,
+            String escapedName, String expectedName) throws Exception
+    {
+        String doc = "{'" + escapedName + "':'value'}";
+        byte[] data = _jsonDoc(doc);
+        try (AsyncReaderWrapper r = asyncForBytes(APOS_FACTORY, bytesPerRead, data, 0)) {
+            assertToken(JsonToken.START_OBJECT, r.nextToken());
+            assertToken(JsonToken.PROPERTY_NAME, r.nextToken());
+            assertEquals(expectedName, r.currentName());
+            assertToken(JsonToken.VALUE_STRING, r.nextToken());
+            assertEquals("value", r.currentText());
+            assertToken(JsonToken.END_OBJECT, r.nextToken());
         }
     }
 }

--- a/src/test/java/tools/jackson/core/unittest/read/EscapedSurrogateInFieldName1541Test.java
+++ b/src/test/java/tools/jackson/core/unittest/read/EscapedSurrogateInFieldName1541Test.java
@@ -6,8 +6,6 @@ import tools.jackson.core.*;
 import tools.jackson.core.exc.StreamReadException;
 import tools.jackson.core.json.JsonFactory;
 import tools.jackson.core.unittest.JacksonCoreTestBase;
-import tools.jackson.core.unittest.async.AsyncTestBase;
-import tools.jackson.core.unittest.testutil.AsyncReaderWrapper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -15,8 +13,10 @@ import static org.junit.jupiter.api.Assertions.fail;
 /**
  * Tests for [jackson-core#1541]: JSON-escaped surrogate pairs (e.g. {@code \ud83d\udc4d})
  * in field names should work correctly, same as they do in string values.
+ *<p>
+ * See also {@code AsyncEscapedSurrogateInFieldName1541Test} for async parser tests.
  */
-class EscapedSurrogateInFieldName1541Test extends AsyncTestBase
+class EscapedSurrogateInFieldName1541Test extends JacksonCoreTestBase
 {
     private final JsonFactory FACTORY = newStreamFactory();
 
@@ -199,99 +199,6 @@ class EscapedSurrogateInFieldName1541Test extends AsyncTestBase
             assertToken(JsonToken.VALUE_STRING, p.nextToken());
             assertEquals("value", p.getString());
             assertToken(JsonToken.END_OBJECT, p.nextToken());
-        }
-    }
-
-    /*
-    /**********************************************************************
-    /* Test methods, async parser with various bytesPerRead
-    /**********************************************************************
-     */
-
-    @Test
-    void surrogateInFieldNameAsync1Byte() throws Exception
-    {
-        _testSurrogateInFieldNameAsync(1);
-    }
-
-    @Test
-    void surrogateInFieldNameAsync2Bytes() throws Exception
-    {
-        _testSurrogateInFieldNameAsync(2);
-    }
-
-    @Test
-    void surrogateInFieldNameAsync3Bytes() throws Exception
-    {
-        _testSurrogateInFieldNameAsync(3);
-    }
-
-    @Test
-    void surrogateInFieldNameAsync7Bytes() throws Exception
-    {
-        _testSurrogateInFieldNameAsync(7);
-    }
-
-    @Test
-    void surrogateInFieldNameAsync100Bytes() throws Exception
-    {
-        _testSurrogateInFieldNameAsync(100);
-    }
-
-    private void _testSurrogateInFieldNameAsync(int bytesPerRead) throws Exception
-    {
-        byte[] data = _jsonDoc(DOC_FIELD);
-        try (AsyncReaderWrapper r = asyncForBytes(FACTORY, bytesPerRead, data, 0)) {
-            assertToken(JsonToken.START_OBJECT, r.nextToken());
-            assertToken(JsonToken.PROPERTY_NAME, r.nextToken());
-            assertEquals(THUMBS_UP, r.currentName());
-            assertToken(JsonToken.VALUE_STRING, r.nextToken());
-            assertEquals("value", r.currentText());
-            assertToken(JsonToken.END_OBJECT, r.nextToken());
-        }
-    }
-
-    @Test
-    void multipleSurrogatePairsAsync1Byte() throws Exception
-    {
-        String doc = "{\"\\ud83d\\udc4d\\ud83d\\udc4d\":\"value\"}";
-        byte[] data = _jsonDoc(doc);
-        String expectedName = THUMBS_UP + THUMBS_UP;
-        try (AsyncReaderWrapper r = asyncForBytes(FACTORY, 1, data, 0)) {
-            assertToken(JsonToken.START_OBJECT, r.nextToken());
-            assertToken(JsonToken.PROPERTY_NAME, r.nextToken());
-            assertEquals(expectedName, r.currentName());
-            assertToken(JsonToken.VALUE_STRING, r.nextToken());
-            assertEquals("value", r.currentText());
-            assertToken(JsonToken.END_OBJECT, r.nextToken());
-        }
-    }
-
-    @Test
-    void loneHighSurrogateInFieldNameAsync() throws Exception
-    {
-        String doc = "{\"\\ud83d\":\"value\"}";
-        byte[] data = _jsonDoc(doc);
-        try (AsyncReaderWrapper r = asyncForBytes(FACTORY, 1, data, 0)) {
-            assertToken(JsonToken.START_OBJECT, r.nextToken());
-            r.nextToken();
-            fail("Should have thrown for lone high surrogate in field name");
-        } catch (StreamReadException e) {
-            verifyException(e, "surrogate");
-        }
-    }
-
-    @Test
-    void loneLowSurrogateInFieldNameAsync() throws Exception
-    {
-        String doc = "{\"\\udc4d\":\"value\"}";
-        byte[] data = _jsonDoc(doc);
-        try (AsyncReaderWrapper r = asyncForBytes(FACTORY, 1, data, 0)) {
-            assertToken(JsonToken.START_OBJECT, r.nextToken());
-            r.nextToken();
-            fail("Should have thrown for lone low surrogate in field name");
-        } catch (StreamReadException e) {
-            verifyException(e, "surrogate");
         }
     }
 }

--- a/src/test/java/tools/jackson/core/unittest/read/EscapedSurrogateInFieldName1541Test.java
+++ b/src/test/java/tools/jackson/core/unittest/read/EscapedSurrogateInFieldName1541Test.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import tools.jackson.core.*;
 import tools.jackson.core.exc.StreamReadException;
 import tools.jackson.core.json.JsonFactory;
+import tools.jackson.core.json.JsonReadFeature;
 import tools.jackson.core.unittest.JacksonCoreTestBase;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -20,11 +21,18 @@ class EscapedSurrogateInFieldName1541Test extends JacksonCoreTestBase
 {
     private final JsonFactory FACTORY = newStreamFactory();
 
+    private final JsonFactory APOS_FACTORY = JsonFactory.builder()
+            .enable(JsonReadFeature.ALLOW_SINGLE_QUOTES)
+            .build();
+
     // U+1F44D THUMBS UP SIGN = \ud83d\udc4d
     private static final String THUMBS_UP = "\uD83D\uDC4D";
 
     // JSON with escaped surrogate pair in field name: {"\\ud83d\\udc4d":"value"}
     private static final String DOC_FIELD = "{\"\\ud83d\\udc4d\":\"value\"}";
+
+    // Same but with apostrophe-quoted name: {'\\ud83d\\udc4d':'value'}
+    private static final String DOC_FIELD_APOS = "{'\\ud83d\\udc4d':'value'}";
 
     // JSON with escaped surrogate pair in value: {"field":"\\ud83d\\udc4d"}
     private static final String DOC_VALUE = "{\"field\":\"\\ud83d\\udc4d\"}";
@@ -71,6 +79,74 @@ class EscapedSurrogateInFieldName1541Test extends JacksonCoreTestBase
             assertToken(JsonToken.START_OBJECT, p.nextToken());
             assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
             assertEquals(THUMBS_UP, p.currentName());
+            assertToken(JsonToken.VALUE_STRING, p.nextToken());
+            assertEquals("value", p.getString());
+            assertToken(JsonToken.END_OBJECT, p.nextToken());
+        }
+    }
+
+    /*
+    /**********************************************************************
+    /* Test methods, apostrophe-quoted field names
+    /**********************************************************************
+     */
+
+    @Test
+    void surrogateInAposFieldNameStream() throws Exception
+    {
+        _testSurrogateInAposFieldName(MODE_INPUT_STREAM);
+    }
+
+    @Test
+    void surrogateInAposFieldNameStreamThrottled() throws Exception
+    {
+        _testSurrogateInAposFieldName(MODE_INPUT_STREAM_THROTTLED);
+    }
+
+    @Test
+    void surrogateInAposFieldNameReader() throws Exception
+    {
+        _testSurrogateInAposFieldName(MODE_READER);
+    }
+
+    @Test
+    void surrogateInAposFieldNameDataInput() throws Exception
+    {
+        _testSurrogateInAposFieldName(MODE_DATA_INPUT);
+    }
+
+    private void _testSurrogateInAposFieldName(int mode) throws Exception
+    {
+        try (JsonParser p = createParser(APOS_FACTORY, mode, DOC_FIELD_APOS)) {
+            assertToken(JsonToken.START_OBJECT, p.nextToken());
+            assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
+            assertEquals(THUMBS_UP, p.currentName());
+            assertToken(JsonToken.VALUE_STRING, p.nextToken());
+            assertEquals("value", p.getString());
+            assertToken(JsonToken.END_OBJECT, p.nextToken());
+        }
+    }
+
+    @Test
+    void multipleSurrogatePairsInAposFieldNameStream() throws Exception
+    {
+        _testMultipleSurrogatePairsApos(MODE_INPUT_STREAM);
+    }
+
+    @Test
+    void multipleSurrogatePairsInAposFieldNameDataInput() throws Exception
+    {
+        _testMultipleSurrogatePairsApos(MODE_DATA_INPUT);
+    }
+
+    private void _testMultipleSurrogatePairsApos(int mode) throws Exception
+    {
+        String doc = "{'\\ud83d\\udc4d\\ud83d\\udc4d':'value'}";
+        String expectedName = THUMBS_UP + THUMBS_UP;
+        try (JsonParser p = createParser(APOS_FACTORY, mode, doc)) {
+            assertToken(JsonToken.START_OBJECT, p.nextToken());
+            assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
+            assertEquals(expectedName, p.currentName());
             assertToken(JsonToken.VALUE_STRING, p.nextToken());
             assertEquals("value", p.getString());
             assertToken(JsonToken.END_OBJECT, p.nextToken());

--- a/src/test/java/tools/jackson/core/unittest/read/EscapedSurrogateInFieldName1541Test.java
+++ b/src/test/java/tools/jackson/core/unittest/read/EscapedSurrogateInFieldName1541Test.java
@@ -1,0 +1,297 @@
+package tools.jackson.core.unittest.read;
+
+import org.junit.jupiter.api.Test;
+
+import tools.jackson.core.*;
+import tools.jackson.core.exc.StreamReadException;
+import tools.jackson.core.json.JsonFactory;
+import tools.jackson.core.unittest.JacksonCoreTestBase;
+import tools.jackson.core.unittest.async.AsyncTestBase;
+import tools.jackson.core.unittest.testutil.AsyncReaderWrapper;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Tests for [jackson-core#1541]: JSON-escaped surrogate pairs (e.g. {@code \ud83d\udc4d})
+ * in field names should work correctly, same as they do in string values.
+ */
+class EscapedSurrogateInFieldName1541Test extends AsyncTestBase
+{
+    private final JsonFactory FACTORY = newStreamFactory();
+
+    // U+1F44D THUMBS UP SIGN = \ud83d\udc4d
+    private static final String THUMBS_UP = "\uD83D\uDC4D";
+
+    // JSON with escaped surrogate pair in field name: {"\\ud83d\\udc4d":"value"}
+    private static final String DOC_FIELD = "{\"\\ud83d\\udc4d\":\"value\"}";
+
+    // JSON with escaped surrogate pair in value: {"field":"\\ud83d\\udc4d"}
+    private static final String DOC_VALUE = "{\"field\":\"\\ud83d\\udc4d\"}";
+
+    /*
+    /**********************************************************************
+    /* Test methods, success cases across all parser modes
+    /**********************************************************************
+     */
+
+    @Test
+    void surrogateInFieldNameStream() throws Exception
+    {
+        _testSurrogateInFieldName(MODE_INPUT_STREAM);
+    }
+
+    @Test
+    void surrogateInFieldNameStreamThrottled() throws Exception
+    {
+        _testSurrogateInFieldName(MODE_INPUT_STREAM_THROTTLED);
+    }
+
+    @Test
+    void surrogateInFieldNameReader() throws Exception
+    {
+        _testSurrogateInFieldName(MODE_READER);
+    }
+
+    @Test
+    void surrogateInFieldNameReaderThrottled() throws Exception
+    {
+        _testSurrogateInFieldName(MODE_READER_THROTTLED);
+    }
+
+    @Test
+    void surrogateInFieldNameDataInput() throws Exception
+    {
+        _testSurrogateInFieldName(MODE_DATA_INPUT);
+    }
+
+    private void _testSurrogateInFieldName(int mode) throws Exception
+    {
+        try (JsonParser p = createParser(FACTORY, mode, DOC_FIELD)) {
+            assertToken(JsonToken.START_OBJECT, p.nextToken());
+            assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
+            assertEquals(THUMBS_UP, p.currentName());
+            assertToken(JsonToken.VALUE_STRING, p.nextToken());
+            assertEquals("value", p.getString());
+            assertToken(JsonToken.END_OBJECT, p.nextToken());
+        }
+    }
+
+    /*
+    /**********************************************************************
+    /* Test methods, string value sanity check
+    /**********************************************************************
+     */
+
+    @Test
+    void surrogateInStringValueStream() throws Exception
+    {
+        _testSurrogateInStringValue(MODE_INPUT_STREAM);
+    }
+
+    @Test
+    void surrogateInStringValueDataInput() throws Exception
+    {
+        _testSurrogateInStringValue(MODE_DATA_INPUT);
+    }
+
+    private void _testSurrogateInStringValue(int mode) throws Exception
+    {
+        try (JsonParser p = createParser(FACTORY, mode, DOC_VALUE)) {
+            assertToken(JsonToken.START_OBJECT, p.nextToken());
+            assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
+            assertEquals("field", p.currentName());
+            assertToken(JsonToken.VALUE_STRING, p.nextToken());
+            assertEquals(THUMBS_UP, p.getString());
+            assertToken(JsonToken.END_OBJECT, p.nextToken());
+        }
+    }
+
+    /*
+    /**********************************************************************
+    /* Test methods, error cases
+    /**********************************************************************
+     */
+
+    @Test
+    void loneHighSurrogateInFieldNameStream() throws Exception
+    {
+        _testLoneHighSurrogate(MODE_INPUT_STREAM);
+    }
+
+    @Test
+    void loneHighSurrogateInFieldNameDataInput() throws Exception
+    {
+        _testLoneHighSurrogate(MODE_DATA_INPUT);
+    }
+
+    private void _testLoneHighSurrogate(int mode) throws Exception
+    {
+        // Lone high surrogate followed by closing quote: {"\\ud83d":"value"}
+        String doc = "{\"\\ud83d\":\"value\"}";
+        try (JsonParser p = createParser(FACTORY, mode, doc)) {
+            assertToken(JsonToken.START_OBJECT, p.nextToken());
+            p.nextToken();
+            fail("Should have thrown for lone high surrogate in field name");
+        } catch (StreamReadException e) {
+            verifyException(e, "surrogate");
+        }
+    }
+
+    @Test
+    void loneLowSurrogateInFieldNameStream() throws Exception
+    {
+        _testLoneLowSurrogate(MODE_INPUT_STREAM);
+    }
+
+    @Test
+    void loneLowSurrogateInFieldNameDataInput() throws Exception
+    {
+        _testLoneLowSurrogate(MODE_DATA_INPUT);
+    }
+
+    private void _testLoneLowSurrogate(int mode) throws Exception
+    {
+        // Lone low surrogate: {"\\udc4d":"value"}
+        String doc = "{\"\\udc4d\":\"value\"}";
+        try (JsonParser p = createParser(FACTORY, mode, doc)) {
+            assertToken(JsonToken.START_OBJECT, p.nextToken());
+            p.nextToken();
+            fail("Should have thrown for lone low surrogate in field name");
+        } catch (StreamReadException e) {
+            verifyException(e, "surrogate");
+        }
+    }
+
+    /*
+    /**********************************************************************
+    /* Test methods, multiple surrogate pairs
+    /**********************************************************************
+     */
+
+    @Test
+    void multipleSurrogatePairsInFieldNameStream() throws Exception
+    {
+        _testMultipleSurrogatePairs(MODE_INPUT_STREAM);
+    }
+
+    @Test
+    void multipleSurrogatePairsInFieldNameDataInput() throws Exception
+    {
+        _testMultipleSurrogatePairs(MODE_DATA_INPUT);
+    }
+
+    @Test
+    void multipleSurrogatePairsInFieldNameReader() throws Exception
+    {
+        _testMultipleSurrogatePairs(MODE_READER);
+    }
+
+    private void _testMultipleSurrogatePairs(int mode) throws Exception
+    {
+        // Two thumbs up: {"\\ud83d\\udc4d\\ud83d\\udc4d":"value"}
+        String doc = "{\"\\ud83d\\udc4d\\ud83d\\udc4d\":\"value\"}";
+        String expectedName = THUMBS_UP + THUMBS_UP;
+        try (JsonParser p = createParser(FACTORY, mode, doc)) {
+            assertToken(JsonToken.START_OBJECT, p.nextToken());
+            assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
+            assertEquals(expectedName, p.currentName());
+            assertToken(JsonToken.VALUE_STRING, p.nextToken());
+            assertEquals("value", p.getString());
+            assertToken(JsonToken.END_OBJECT, p.nextToken());
+        }
+    }
+
+    /*
+    /**********************************************************************
+    /* Test methods, async parser with various bytesPerRead
+    /**********************************************************************
+     */
+
+    @Test
+    void surrogateInFieldNameAsync1Byte() throws Exception
+    {
+        _testSurrogateInFieldNameAsync(1);
+    }
+
+    @Test
+    void surrogateInFieldNameAsync2Bytes() throws Exception
+    {
+        _testSurrogateInFieldNameAsync(2);
+    }
+
+    @Test
+    void surrogateInFieldNameAsync3Bytes() throws Exception
+    {
+        _testSurrogateInFieldNameAsync(3);
+    }
+
+    @Test
+    void surrogateInFieldNameAsync7Bytes() throws Exception
+    {
+        _testSurrogateInFieldNameAsync(7);
+    }
+
+    @Test
+    void surrogateInFieldNameAsync100Bytes() throws Exception
+    {
+        _testSurrogateInFieldNameAsync(100);
+    }
+
+    private void _testSurrogateInFieldNameAsync(int bytesPerRead) throws Exception
+    {
+        byte[] data = _jsonDoc(DOC_FIELD);
+        try (AsyncReaderWrapper r = asyncForBytes(FACTORY, bytesPerRead, data, 0)) {
+            assertToken(JsonToken.START_OBJECT, r.nextToken());
+            assertToken(JsonToken.PROPERTY_NAME, r.nextToken());
+            assertEquals(THUMBS_UP, r.currentName());
+            assertToken(JsonToken.VALUE_STRING, r.nextToken());
+            assertEquals("value", r.currentText());
+            assertToken(JsonToken.END_OBJECT, r.nextToken());
+        }
+    }
+
+    @Test
+    void multipleSurrogatePairsAsync1Byte() throws Exception
+    {
+        String doc = "{\"\\ud83d\\udc4d\\ud83d\\udc4d\":\"value\"}";
+        byte[] data = _jsonDoc(doc);
+        String expectedName = THUMBS_UP + THUMBS_UP;
+        try (AsyncReaderWrapper r = asyncForBytes(FACTORY, 1, data, 0)) {
+            assertToken(JsonToken.START_OBJECT, r.nextToken());
+            assertToken(JsonToken.PROPERTY_NAME, r.nextToken());
+            assertEquals(expectedName, r.currentName());
+            assertToken(JsonToken.VALUE_STRING, r.nextToken());
+            assertEquals("value", r.currentText());
+            assertToken(JsonToken.END_OBJECT, r.nextToken());
+        }
+    }
+
+    @Test
+    void loneHighSurrogateInFieldNameAsync() throws Exception
+    {
+        String doc = "{\"\\ud83d\":\"value\"}";
+        byte[] data = _jsonDoc(doc);
+        try (AsyncReaderWrapper r = asyncForBytes(FACTORY, 1, data, 0)) {
+            assertToken(JsonToken.START_OBJECT, r.nextToken());
+            r.nextToken();
+            fail("Should have thrown for lone high surrogate in field name");
+        } catch (StreamReadException e) {
+            verifyException(e, "surrogate");
+        }
+    }
+
+    @Test
+    void loneLowSurrogateInFieldNameAsync() throws Exception
+    {
+        String doc = "{\"\\udc4d\":\"value\"}";
+        byte[] data = _jsonDoc(doc);
+        try (AsyncReaderWrapper r = asyncForBytes(FACTORY, 1, data, 0)) {
+            assertToken(JsonToken.START_OBJECT, r.nextToken());
+            r.nextToken();
+            fail("Should have thrown for lone low surrogate in field name");
+        } catch (StreamReadException e) {
+            verifyException(e, "surrogate");
+        }
+    }
+}

--- a/src/test/java/tools/jackson/core/unittest/read/EscapedSurrogateInFieldName1541Test.java
+++ b/src/test/java/tools/jackson/core/unittest/read/EscapedSurrogateInFieldName1541Test.java
@@ -25,17 +25,24 @@ class EscapedSurrogateInFieldName1541Test extends JacksonCoreTestBase
             .enable(JsonReadFeature.ALLOW_SINGLE_QUOTES)
             .build();
 
-    // U+1F44D THUMBS UP SIGN = \ud83d\udc4d
+    // U+1F44D THUMBS UP SIGN = \ud83d\udc4d (UTF-8: F0 9F 91 8D)
     private static final String THUMBS_UP = "\uD83D\uDC4D";
 
+    // U+1D11E MUSICAL SYMBOL G CLEF = \ud834\udd1e (UTF-8: F0 9D 84 9E)
+    private static final String G_CLEF = "\uD834\uDD1E";
+
+    // Escaped form of surrogate pairs for use in JSON
+    private static final String ESC_THUMBS = "\\ud83d\\udc4d";
+    private static final String ESC_GCLEF = "\\ud834\\udd1e";
+
     // JSON with escaped surrogate pair in field name: {"\\ud83d\\udc4d":"value"}
-    private static final String DOC_FIELD = "{\"\\ud83d\\udc4d\":\"value\"}";
+    private static final String DOC_FIELD = "{\"" + ESC_THUMBS + "\":\"value\"}";
 
     // Same but with apostrophe-quoted name: {'\\ud83d\\udc4d':'value'}
-    private static final String DOC_FIELD_APOS = "{'\\ud83d\\udc4d':'value'}";
+    private static final String DOC_FIELD_APOS = "{'" + ESC_THUMBS + "':'value'}";
 
     // JSON with escaped surrogate pair in value: {"field":"\\ud83d\\udc4d"}
-    private static final String DOC_VALUE = "{\"field\":\"\\ud83d\\udc4d\"}";
+    private static final String DOC_VALUE = "{\"field\":\"" + ESC_THUMBS + "\"}";
 
     /*
     /**********************************************************************
@@ -241,34 +248,154 @@ class EscapedSurrogateInFieldName1541Test extends JacksonCoreTestBase
 
     /*
     /**********************************************************************
-    /* Test methods, multiple surrogate pairs
+    /* Test methods, name variations (quad boundary alignment, long names)
     /**********************************************************************
      */
 
+    // Different ASCII prefix lengths exercise different quad boundary
+    // alignments for the 4-byte UTF-8 supplementary character:
+    //   0 bytes -> quad offset 0
+    //   1 byte  -> quad offset 1, straddles boundary
+    //   2 bytes -> quad offset 2, straddles boundary
+    //   3 bytes -> quad offset 3, straddles boundary
+    //   4 bytes -> full quad flushed, offset 0 again
+
     @Test
-    void multipleSurrogatePairsInFieldNameStream() throws Exception
+    void nameVariationsStream() throws Exception
     {
-        _testMultipleSurrogatePairs(MODE_INPUT_STREAM);
+        _testNameVariations(MODE_INPUT_STREAM);
     }
 
     @Test
-    void multipleSurrogatePairsInFieldNameDataInput() throws Exception
+    void nameVariationsStreamThrottled() throws Exception
     {
-        _testMultipleSurrogatePairs(MODE_DATA_INPUT);
+        _testNameVariations(MODE_INPUT_STREAM_THROTTLED);
     }
 
     @Test
-    void multipleSurrogatePairsInFieldNameReader() throws Exception
+    void nameVariationsReader() throws Exception
     {
-        _testMultipleSurrogatePairs(MODE_READER);
+        _testNameVariations(MODE_READER);
     }
 
-    private void _testMultipleSurrogatePairs(int mode) throws Exception
+    @Test
+    void nameVariationsDataInput() throws Exception
     {
-        // Two thumbs up: {"\\ud83d\\udc4d\\ud83d\\udc4d":"value"}
-        String doc = "{\"\\ud83d\\udc4d\\ud83d\\udc4d\":\"value\"}";
-        String expectedName = THUMBS_UP + THUMBS_UP;
-        try (JsonParser p = createParser(FACTORY, mode, doc)) {
+        _testNameVariations(MODE_DATA_INPUT);
+    }
+
+    private void _testNameVariations(int mode) throws Exception
+    {
+        // Prefix lengths 0-5 (varying quad offset when escape is hit)
+        _testFieldName(FACTORY, mode, ESC_THUMBS, THUMBS_UP);
+        _testFieldName(FACTORY, mode, "a" + ESC_THUMBS, "a" + THUMBS_UP);
+        _testFieldName(FACTORY, mode, "ab" + ESC_THUMBS, "ab" + THUMBS_UP);
+        _testFieldName(FACTORY, mode, "abc" + ESC_THUMBS, "abc" + THUMBS_UP);
+        _testFieldName(FACTORY, mode, "abcd" + ESC_THUMBS, "abcd" + THUMBS_UP);
+        _testFieldName(FACTORY, mode, "abcde" + ESC_THUMBS, "abcde" + THUMBS_UP);
+
+        // Suffix after surrogate pair
+        _testFieldName(FACTORY, mode, ESC_THUMBS + "z", THUMBS_UP + "z");
+
+        // Sandwiched: ASCII + surrogate + ASCII
+        _testFieldName(FACTORY, mode, "x" + ESC_THUMBS + "y", "x" + THUMBS_UP + "y");
+
+        // Two consecutive surrogate pairs
+        _testFieldName(FACTORY, mode,
+                ESC_THUMBS + ESC_THUMBS,
+                THUMBS_UP + THUMBS_UP);
+
+        // Two different supplementary characters
+        _testFieldName(FACTORY, mode,
+                ESC_THUMBS + ESC_GCLEF,
+                THUMBS_UP + G_CLEF);
+
+        // Different supplementary character alone
+        _testFieldName(FACTORY, mode, ESC_GCLEF, G_CLEF);
+
+        // Long prefix (>12 bytes to exercise parseLongName path)
+        _testFieldName(FACTORY, mode,
+                "abcdefghijklm" + ESC_THUMBS,
+                "abcdefghijklm" + THUMBS_UP);
+
+        // Long prefix + suffix
+        _testFieldName(FACTORY, mode,
+                "abcdefghijklm" + ESC_THUMBS + "n",
+                "abcdefghijklm" + THUMBS_UP + "n");
+
+        // Long name with surrogate in the middle and more ASCII after
+        _testFieldName(FACTORY, mode,
+                "abcdefgh" + ESC_THUMBS + "ijklmnop",
+                "abcdefgh" + THUMBS_UP + "ijklmnop");
+
+        // Long name with multiple different surrogates
+        _testFieldName(FACTORY, mode,
+                "abcdefgh" + ESC_THUMBS + "ij" + ESC_GCLEF + "klmn",
+                "abcdefgh" + THUMBS_UP + "ij" + G_CLEF + "klmn");
+    }
+
+    @Test
+    void nameVariationsAposStream() throws Exception
+    {
+        _testNameVariationsApos(MODE_INPUT_STREAM);
+    }
+
+    @Test
+    void nameVariationsAposDataInput() throws Exception
+    {
+        _testNameVariationsApos(MODE_DATA_INPUT);
+    }
+
+    private void _testNameVariationsApos(int mode) throws Exception
+    {
+        // Prefix lengths 0-4
+        _testAposFieldName(mode, ESC_THUMBS, THUMBS_UP);
+        _testAposFieldName(mode, "a" + ESC_THUMBS, "a" + THUMBS_UP);
+        _testAposFieldName(mode, "ab" + ESC_THUMBS, "ab" + THUMBS_UP);
+        _testAposFieldName(mode, "abc" + ESC_THUMBS, "abc" + THUMBS_UP);
+        _testAposFieldName(mode, "abcd" + ESC_THUMBS, "abcd" + THUMBS_UP);
+
+        // Suffix, sandwiched, multiple
+        _testAposFieldName(mode, ESC_THUMBS + "z", THUMBS_UP + "z");
+        _testAposFieldName(mode, "x" + ESC_THUMBS + "y", "x" + THUMBS_UP + "y");
+        _testAposFieldName(mode, ESC_THUMBS + ESC_GCLEF, THUMBS_UP + G_CLEF);
+
+        // Long prefix
+        _testAposFieldName(mode,
+                "abcdefghijklm" + ESC_THUMBS,
+                "abcdefghijklm" + THUMBS_UP);
+
+        // Long with mixed surrogates
+        _testAposFieldName(mode,
+                "abcdefgh" + ESC_THUMBS + "ij" + ESC_GCLEF + "klmn",
+                "abcdefgh" + THUMBS_UP + "ij" + G_CLEF + "klmn");
+    }
+
+    /*
+    /**********************************************************************
+    /* Helper methods
+    /**********************************************************************
+     */
+
+    private void _testFieldName(JsonFactory f, int mode,
+            String escapedName, String expectedName) throws Exception
+    {
+        String doc = "{\"" + escapedName + "\":\"value\"}";
+        try (JsonParser p = createParser(f, mode, doc)) {
+            assertToken(JsonToken.START_OBJECT, p.nextToken());
+            assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
+            assertEquals(expectedName, p.currentName());
+            assertToken(JsonToken.VALUE_STRING, p.nextToken());
+            assertEquals("value", p.getString());
+            assertToken(JsonToken.END_OBJECT, p.nextToken());
+        }
+    }
+
+    private void _testAposFieldName(int mode,
+            String escapedName, String expectedName) throws Exception
+    {
+        String doc = "{'" + escapedName + "':'value'}";
+        try (JsonParser p = createParser(APOS_FACTORY, mode, doc)) {
             assertToken(JsonToken.START_OBJECT, p.nextToken());
             assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
             assertEquals(expectedName, p.currentName());


### PR DESCRIPTION
Possible fix for #1541 generated by Claude -- to be carefully reviewed.