### PR TITLE
Add `JsonParser.readString(Writer)` for truly non-buffering string reads

### DIFF
--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -14,6 +14,11 @@ Sven Döring (@sdoeringNew)
  * Contributed #680: Allow use of `java.nio.file.Path` as parser source, generator target
   (3.0.0)
 
+@sri-adarsh-kumar
+ * Contributed #1288: Add new method like `JsonParser.readText(Writer)` (and
+   implementation) for truly non-buffering reads
+  (3.1.0)
+
 Nicholas Rayburn (@nrayburn-tech)
  * Contributed #1514: Additional configuration to closer match Jackson 2 behavior
   (3.1.0)

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -17,6 +17,9 @@ JSON library.
 
 3.1.0 (not yet released)
 
+#1288: Add new method like `JsonParser.readText(Writer)` (and
+  implementation) for truly non-buffering reads
+ (contributed by @sri-adarsh-kumar)
 #1548: `StreamReadConstraints.maxDocumentLength` not checked when
   creating parser with fixed buffer
 #1553: Max Depth validation not working for `DataInput`-backed `JsonParser`s

--- a/src/main/java/tools/jackson/core/JsonParser.java
+++ b/src/main/java/tools/jackson/core/JsonParser.java
@@ -918,8 +918,10 @@ public abstract class JsonParser
      *
      * @throws JacksonIOException for low-level read issues, or failed write using {@link Writer}
      * @throws tools.jackson.core.exc.StreamReadException for decoding problems
+     *
+     * @since 3.1
      */
-    public abstract int readText(Writer writer) throws JacksonException;
+    public abstract long readString(Writer writer) throws JacksonException;
 
     /**
      * Method similar to {@link #getString()}, but that will return

--- a/src/main/java/tools/jackson/core/JsonParser.java
+++ b/src/main/java/tools/jackson/core/JsonParser.java
@@ -897,6 +897,31 @@ public abstract class JsonParser
     public abstract int getString(Writer writer) throws JacksonException;
 
     /**
+     * Method to read the textual representation of the current token in chunks and
+     * pass it to the given Writer, without buffering the whole String value.
+     * Functionally same as calling:
+     *<pre>
+     *  writer.write(parser.getString());
+     *</pre>
+     * but allows implementations to stream the decoded content directly without
+     * storing it in {@link TextBuffer}.
+     *<p>
+     * NOTE: Unlike {@link #getString(Writer)}, this method <b>consumes</b> the
+     * contents of a {@link JsonToken#VALUE_STRING} token, advancing the parser
+     * so that the underlying String value is no longer available via other
+     * {@code getString*} accessors. This method is primarily intended for very
+     * large String values where buffering would be prohibitive.
+     *
+     * @param writer Writer to write String value to
+     *
+     * @return The number of characters written to the Writer
+     *
+     * @throws JacksonIOException for low-level read issues, or failed write using {@link Writer}
+     * @throws tools.jackson.core.exc.StreamReadException for decoding problems
+     */
+    public abstract int readText(Writer writer) throws JacksonException;
+
+    /**
      * Method similar to {@link #getString()}, but that will return
      * underlying (unmodifiable) character array that contains
      * textual value, instead of constructing a String object

--- a/src/main/java/tools/jackson/core/JsonParser.java
+++ b/src/main/java/tools/jackson/core/JsonParser.java
@@ -897,27 +897,45 @@ public abstract class JsonParser
     public abstract int getString(Writer writer) throws JacksonException;
 
     /**
-     * Method to read the textual representation of the current token in chunks and
-     * pass it to the given Writer, without buffering the whole String value.
-     * Functionally same as calling:
+     * Method to read the textual representation of the current {@link JsonToken#VALUE_STRING}
+     * token in chunks and stream it directly to the given Writer, without buffering the entire
+     * String value in memory. Functionally same as calling:
      *<pre>
      *  writer.write(parser.getString());
      *</pre>
-     * but allows implementations to stream the decoded content directly without
-     * storing it in {@link TextBuffer}.
+     * but streams the decoded content directly without storing it in {@link TextBuffer},
+     * making it suitable for arbitrarily large strings without memory constraints.
      *<p>
-     * NOTE: Unlike {@link #getString(Writer)}, this method <b>consumes</b> the
-     * contents of a {@link JsonToken#VALUE_STRING} token, advancing the parser
-     * so that the underlying String value is no longer available via other
-     * {@code getString*} accessors. This method is primarily intended for very
-     * large String values where buffering would be prohibitive.
+     * NOTE: This method <b>consumes</b> the contents of the {@link JsonToken#VALUE_STRING}
+     * token, advancing the parser state so that the underlying String value is <b>no longer
+     * available</b> via {@link #getString()} or other {@code getString*} accessors after
+     * this method completes. This differs from {@link #getString(Writer)} which preserves
+     * the buffered string for subsequent access.
+     *<p>
+     * NOTE: This method is primarily intended for very large JSON string values (megabytes
+     * or larger) where full buffering would be prohibitive. For typical string sizes, prefer
+     * {@link #getString()} or {@link #getString(Writer)} which provide more convenient access.
+     * The implementation uses a 512-character intermediate buffer for efficient bulk writes
+     * to the Writer.
+     *<p>
+     * NOTE: This method <b>does</b> enforce
+     * {@link tools.jackson.core.StreamReadConstraints#maxStringLength()} validation during
+     * streaming, checking the string length at buffer boundaries and at completion. Strings
+     * exceeding the configured limit will result in a {@link tools.jackson.core.exc.StreamConstraintsException}.
+     *<p>
+     * NOTE: This method is <b>NOT supported</b> by non-blocking (async) parsers and will
+     * throw {@link UnsupportedOperationException} if called on such parsers, since content
+     * availability is unpredictable in asynchronous parsing mode.
      *
-     * @param writer Writer to write String value to
+     * @param writer Writer to stream the String value to
      *
-     * @return The number of characters written to the Writer
+     * @return The number of characters written to the Writer (as {@code long} to support
+     *         strings exceeding {@code Integer.MAX_VALUE})
      *
      * @throws JacksonIOException for low-level read issues, or failed write using {@link Writer}
      * @throws tools.jackson.core.exc.StreamReadException for decoding problems
+     * @throws tools.jackson.core.exc.StreamConstraintsException if string length exceeds
+     *         {@link tools.jackson.core.StreamReadConstraints#maxStringLength()}
      *
      * @since 3.1
      */

--- a/src/main/java/tools/jackson/core/JsonParser.java
+++ b/src/main/java/tools/jackson/core/JsonParser.java
@@ -919,7 +919,7 @@ public abstract class JsonParser
      * NOTE: This method is primarily intended for very large JSON string values (megabytes
      * or larger) where full buffering would be prohibitive. For typical string sizes, prefer
      * {@link #getString()} or {@link #getString(Writer)} which provide more convenient access.
-     * The implementation uses a 512-character intermediate buffer for efficient bulk writes
+     * The implementation uses an intermediate buffer for efficient bulk writes
      * to the Writer.
      *<p>
      * NOTE: This method <b>does</b> enforce

--- a/src/main/java/tools/jackson/core/JsonParser.java
+++ b/src/main/java/tools/jackson/core/JsonParser.java
@@ -884,8 +884,9 @@ public abstract class JsonParser
      * other {@code getString()} calls (that is, it will not be consumed).
      * So this accessor only avoids construction of {@link java.lang.String}
      * compared to plain {@link #getString()} method.
+     * Note there is method {@link #readString(Writer)} that may avoid buffering.
      *<p>
-     * NOTE: In Jackson 2.x this method was called {@code getString(Writer)}.
+     * NOTE: In Jackson 2.x this method was called {@code getText(Writer)}.
      *
      * @param writer Writer to write String value to
      *

--- a/src/main/java/tools/jackson/core/JsonParser.java
+++ b/src/main/java/tools/jackson/core/JsonParser.java
@@ -903,8 +903,12 @@ public abstract class JsonParser
      *<pre>
      *  writer.write(parser.getString());
      *</pre>
-     * but streams the decoded content directly without storing it in {@link TextBuffer},
+     * but tries to stream the decoded content directly without storing it in {@link TextBuffer},
      * making it suitable for arbitrarily large strings without memory constraints.
+     *<p>
+     * NOTE: whether streaming happens depends on format-specific implementation of
+     * this method -- the default implementation delegates to
+     * {@link #getString(Writer)} which does not stream content.
      *<p>
      * NOTE: This method <b>consumes</b> the contents of the {@link JsonToken#VALUE_STRING}
      * token, advancing the parser state so that the underlying String value is <b>no longer
@@ -919,7 +923,7 @@ public abstract class JsonParser
      * to the Writer.
      *<p>
      * NOTE: This method <b>does</b> enforce
-     * {@link tools.jackson.core.StreamReadConstraints#maxStringLength()} validation during
+     * {@link tools.jackson.core.StreamReadConstraints#getMaxStringLength()} validation during
      * streaming, checking the string length at buffer boundaries and at completion. Strings
      * exceeding the configured limit will result in a {@link tools.jackson.core.exc.StreamConstraintsException}.
      *<p>
@@ -935,11 +939,14 @@ public abstract class JsonParser
      * @throws JacksonIOException for low-level read issues, or failed write using {@link Writer}
      * @throws tools.jackson.core.exc.StreamReadException for decoding problems
      * @throws tools.jackson.core.exc.StreamConstraintsException if string length exceeds
-     *         {@link tools.jackson.core.StreamReadConstraints#maxStringLength()}
+     *         {@link tools.jackson.core.StreamReadConstraints#getMaxStringLength()}
      *
      * @since 3.1
      */
-    public abstract long readString(Writer writer) throws JacksonException;
+    public long readString(Writer writer) throws JacksonException {
+        // Default implementation simply buffers it all
+        return getString(writer);
+    }
 
     /**
      * Method similar to {@link #getString()}, but that will return

--- a/src/main/java/tools/jackson/core/StreamReadConstraints.java
+++ b/src/main/java/tools/jackson/core/StreamReadConstraints.java
@@ -226,6 +226,9 @@ public class StreamReadConstraints
          *<p>
          * NOTE: Jackson 2.15.0 initially used a lower setting ({@code 5,000,000}); and versions
          * up to 3.0 {@code 20,000,000}.
+         * Jackson 3.1 further raised this to {@code 100,000,000}.
+         *<p>
+         * NOTE: Setting this to {@link Integer#MAX_VALUE} effectively <b>DISABLES</b> limit.
          *
          * @param maxStringLen the maximum string length (in chars or bytes, depending on input context)
          *
@@ -568,6 +571,27 @@ public class StreamReadConstraints
     public void validateStringLength(int length) throws StreamConstraintsException
     {
         if (length > _maxStringLen) {
+            throw _constructException(
+                    "String value length (%d) exceeds the maximum allowed (%d, from %s)",
+                    length, _maxStringLen,
+                    _constrainRef("getMaxStringLength"));
+        }
+    }
+
+    /**
+     * Variant of {@link #validateStringLength} but takes {@code long} instead
+     * {@code int}.
+     *<p>
+     * NOTE: value of {@link Integer#MAX_VALUE} is considered special value
+     * meaning "no limit".
+     *
+     * @param length Length to validate against limit
+     *
+     * @throws StreamConstraintsException
+     */
+    public void validateStringLengthLong(long length) throws StreamConstraintsException
+    {
+        if (length > _maxStringLen && _maxStringLen != Integer.MAX_VALUE) {
             throw _constructException(
                     "String value length (%d) exceeds the maximum allowed (%d, from %s)",
                     length, _maxStringLen,

--- a/src/main/java/tools/jackson/core/base/ParserMinimalBase.java
+++ b/src/main/java/tools/jackson/core/base/ParserMinimalBase.java
@@ -547,8 +547,6 @@ public abstract class ParserMinimalBase extends JsonParser
         return str.length();
     }
 
-//    @Override public long readString(Writer writer) throws JacksonException;
-
     /*
     /**********************************************************************
     /* Public API, access to token information, numeric

--- a/src/main/java/tools/jackson/core/base/ParserMinimalBase.java
+++ b/src/main/java/tools/jackson/core/base/ParserMinimalBase.java
@@ -547,6 +547,12 @@ public abstract class ParserMinimalBase extends JsonParser
         return str.length();
     }
 
+    @Override
+    public int readText(Writer writer) throws JacksonException
+    {
+        return getString(writer);
+    }
+
     /*
     /**********************************************************************
     /* Public API, access to token information, numeric

--- a/src/main/java/tools/jackson/core/base/ParserMinimalBase.java
+++ b/src/main/java/tools/jackson/core/base/ParserMinimalBase.java
@@ -547,12 +547,7 @@ public abstract class ParserMinimalBase extends JsonParser
         return str.length();
     }
 
-    @Override
-    public long readString(Writer writer) throws JacksonException
-    {
-        // Default implementation simply buffers it all
-        return getString(writer);
-    }
+//    @Override public long readString(Writer writer) throws JacksonException;
 
     /*
     /**********************************************************************

--- a/src/main/java/tools/jackson/core/base/ParserMinimalBase.java
+++ b/src/main/java/tools/jackson/core/base/ParserMinimalBase.java
@@ -550,6 +550,7 @@ public abstract class ParserMinimalBase extends JsonParser
     @Override
     public long readString(Writer writer) throws JacksonException
     {
+        // Default implementation simply buffers it all
         return getString(writer);
     }
 

--- a/src/main/java/tools/jackson/core/base/ParserMinimalBase.java
+++ b/src/main/java/tools/jackson/core/base/ParserMinimalBase.java
@@ -548,7 +548,7 @@ public abstract class ParserMinimalBase extends JsonParser
     }
 
     @Override
-    public int readText(Writer writer) throws JacksonException
+    public long readString(Writer writer) throws JacksonException
     {
         return getString(writer);
     }

--- a/src/main/java/tools/jackson/core/json/JsonParserBase.java
+++ b/src/main/java/tools/jackson/core/json/JsonParserBase.java
@@ -69,6 +69,15 @@ public abstract class JsonParserBase
      */
     protected boolean _nameCopied;
 
+    /**
+     * Lazily-allocated intermediate buffer used by {@code _streamString()}
+     * implementations to batch writes to the target {@link java.io.Writer}.
+     * Allocated on first call and reused on subsequent calls to avoid
+     * repeated allocation for parsers that call {@code readString(Writer)}
+     * multiple times.
+     */
+    private char[] _streamStringBuffer;
+
     /*
     /**********************************************************************
     /* Life-cycle
@@ -82,6 +91,27 @@ public abstract class JsonParserBase
         DupDetector dups = StreamReadFeature.STRICT_DUPLICATE_DETECTION.enabledIn(streamReadFeatures)
                 ? DupDetector.rootDetector(this) : null;
         _streamReadContext = JsonReadContext.createRootContext(dups);
+    }
+
+    /*
+    /**********************************************************************
+    /* Helper methods for sub-classes
+    /**********************************************************************
+     */
+
+    /**
+     * Returns the lazily-allocated intermediate buffer used by
+     * {@code _streamString()} to batch-write decoded characters to a
+     * {@link java.io.Writer}. The same buffer is reused across calls.
+     *
+     * @since 3.1
+     */
+    protected char[] _bufferForStringStreaming() {
+        char[] buf = _streamStringBuffer;
+        if (buf == null) {
+            _streamStringBuffer = buf = new char[1024];
+        }
+        return buf;
     }
 
     /*

--- a/src/main/java/tools/jackson/core/json/JsonParserBase.java
+++ b/src/main/java/tools/jackson/core/json/JsonParserBase.java
@@ -75,6 +75,8 @@ public abstract class JsonParserBase
      * Allocated on first call and reused on subsequent calls to avoid
      * repeated allocation for parsers that call {@code readString(Writer)}
      * multiple times.
+     *
+     * @since 3.1
      */
     private char[] _streamStringBuffer;
 
@@ -85,33 +87,13 @@ public abstract class JsonParserBase
      */
 
     protected JsonParserBase(ObjectReadContext readCtxt,
-            IOContext ctxt, int streamReadFeatures, int formatReadFeatures) {
+            IOContext ctxt, int streamReadFeatures, int formatReadFeatures)
+    {
         super(readCtxt, ctxt, streamReadFeatures);
         _formatReadFeatures = formatReadFeatures;
         DupDetector dups = StreamReadFeature.STRICT_DUPLICATE_DETECTION.enabledIn(streamReadFeatures)
                 ? DupDetector.rootDetector(this) : null;
         _streamReadContext = JsonReadContext.createRootContext(dups);
-    }
-
-    /*
-    /**********************************************************************
-    /* Helper methods for sub-classes
-    /**********************************************************************
-     */
-
-    /**
-     * Returns the lazily-allocated intermediate buffer used by
-     * {@code _streamString()} to batch-write decoded characters to a
-     * {@link java.io.Writer}. The same buffer is reused across calls.
-     *
-     * @since 3.1
-     */
-    protected char[] _bufferForStringStreaming() {
-        char[] buf = _streamStringBuffer;
-        if (buf == null) {
-            _streamStringBuffer = buf = new char[1024];
-        }
-        return buf;
     }
 
     /*
@@ -369,6 +351,21 @@ public abstract class JsonParserBase
         return _nameCopyBuffer;
     }
 
+    /**
+     * Returns the lazily-allocated intermediate buffer used by
+     * {@code _streamString()} to batch-write decoded characters to a
+     * {@link java.io.Writer}. The same buffer is reused across calls.
+     *
+     * @since 3.1
+     */
+    protected char[] _bufferForStringStreaming() {
+        char[] buf = _streamStringBuffer;
+        if (buf == null) {
+            _streamStringBuffer = buf = new char[1024];
+        }
+        return buf;
+    }
+    
     /*
     /**********************************************************************
     /* Internal/package methods: Error reporting

--- a/src/main/java/tools/jackson/core/json/ReaderBasedJsonParser.java
+++ b/src/main/java/tools/jackson/core/json/ReaderBasedJsonParser.java
@@ -2301,15 +2301,17 @@ public class ReaderBasedJsonParser
         }
     }
 
-    private long _streamString(Writer writer) throws JacksonException, IOException
+    // @since 3.1
+    private long _streamString(Writer writer)
+        throws IOException, JacksonException
     {
         _tokenIncomplete = false;
 
-        long totalCount = 0;
+        long totalLen = 0;
         int inPtr = _inputPtr;
         int inLen = _inputEnd;
         char[] inBuf = _inputBuffer;
-        final int maxStringLen = _streamReadConstraints.getMaxStringLength();
+        final long maxStringLen = _streamReadConstraints.getMaxStringLength();
 
         // Intermediate buffer for bulk writes to improve performance
         char[] outBuf = new char[512];
@@ -2319,24 +2321,24 @@ public class ReaderBasedJsonParser
             // Flush intermediate buffer when full
             if (outPtr >= outBuf.length) {
                 writer.write(outBuf, 0, outPtr);
-                totalCount += outPtr;
-                // Check constraints only at flush boundaries
-                if (totalCount > maxStringLen) {
-                    _validateStringLength(totalCount);
-                }
+                totalLen += outPtr;
                 outPtr = 0;
+                // Check constraints only at flush boundaries
+                if (totalLen > maxStringLen) {
+                    _validateStringLength(totalLen);
+                }
             }
 
             if (inPtr >= inLen) {
                 // Flush intermediate buffer before loading more
                 if (outPtr > 0) {
                     writer.write(outBuf, 0, outPtr);
-                    totalCount += outPtr;
+                    totalLen += outPtr;
                     outPtr = 0;
-                }
-                // Check constraints at input buffer boundary
-                if (totalCount > maxStringLen) {
-                    _validateStringLength(totalCount);
+                    // Check constraints at input buffer boundary
+                    if (totalLen > maxStringLen) {
+                        _validateStringLength(totalLen);
+                    }
                 }
                 _inputPtr = inPtr;
                 if (!_loadMore()) {
@@ -2369,19 +2371,17 @@ public class ReaderBasedJsonParser
             outBuf[outPtr++] = c;
         }
 
-    // Final flush of remaining characters
+        // Final flush of remaining characters
         if (outPtr > 0) {
             writer.write(outBuf, 0, outPtr);
-            totalCount += outPtr;
+            totalLen += outPtr;
+            // Validate final string length
+            if (totalLen > maxStringLen) {
+                _validateStringLength(totalLen);
+            }
         }
-
-        // Validate final string length
-        if (totalCount > maxStringLen) {
-            _validateStringLength(totalCount);
-        }
-
         _textBuffer.resetWithEmpty();
-        return totalCount;
+        return totalLen;
     }
 
     // Helper method to validate string length with overflow protection

--- a/src/main/java/tools/jackson/core/json/ReaderBasedJsonParser.java
+++ b/src/main/java/tools/jackson/core/json/ReaderBasedJsonParser.java
@@ -339,7 +339,7 @@ public class ReaderBasedJsonParser
     }
 
     @Override
-    public int readText(Writer writer) throws JacksonException
+    public long readString(Writer writer) throws JacksonException
     {
         final JsonToken t = _currToken;
 
@@ -348,7 +348,7 @@ public class ReaderBasedJsonParser
                 if (_tokenIncomplete) {
                     return _streamString(writer);
                 }
-                int len = _textBuffer.contentsToWriter(writer);
+                long len = _textBuffer.contentsToWriter(writer);
                 _textBuffer.resetWithEmpty();
                 return len;
             }
@@ -2301,14 +2301,15 @@ public class ReaderBasedJsonParser
         }
     }
 
-    private int _streamString(Writer writer) throws JacksonException, IOException
+    private long _streamString(Writer writer) throws JacksonException, IOException
     {
         _tokenIncomplete = false;
 
-        int count = 0;
+        long count = 0;
         int inPtr = _inputPtr;
         int inLen = _inputEnd;
         char[] inBuf = _inputBuffer;
+        final int maxStringLen = _streamReadConstraints.getMaxStringLength();
 
         while (true) {
             if (inPtr >= inLen) {
@@ -2340,7 +2341,9 @@ public class ReaderBasedJsonParser
                 }
             }
             writer.write(c);
-            ++count;
+            if (++count > maxStringLen) {
+                _streamReadConstraints.validateStringLength((int) count);
+            }
         }
 
         _textBuffer.resetWithEmpty();

--- a/src/main/java/tools/jackson/core/json/ReaderBasedJsonParser.java
+++ b/src/main/java/tools/jackson/core/json/ReaderBasedJsonParser.java
@@ -2325,7 +2325,7 @@ public class ReaderBasedJsonParser
                 outPtr = 0;
                 // Check constraints only at flush boundaries
                 if (totalLen > maxStringLen) {
-                    _validateStringLength(totalLen);
+                    _streamReadConstraints.validateStringLengthLong(totalLen);
                 }
             }
 
@@ -2337,7 +2337,7 @@ public class ReaderBasedJsonParser
                     outPtr = 0;
                     // Check constraints at input buffer boundary
                     if (totalLen > maxStringLen) {
-                        _validateStringLength(totalLen);
+                        _streamReadConstraints.validateStringLengthLong(totalLen);
                     }
                 }
                 _inputPtr = inPtr;
@@ -2377,18 +2377,11 @@ public class ReaderBasedJsonParser
             totalLen += outPtr;
             // Validate final string length
             if (totalLen > maxStringLen) {
-                _validateStringLength(totalLen);
+                _streamReadConstraints.validateStringLengthLong(totalLen);
             }
         }
         _textBuffer.resetWithEmpty();
         return totalLen;
-    }
-
-    // Helper method to validate string length with overflow protection
-    private void _validateStringLength(long count) throws JacksonException {
-        // Protect against integer overflow when casting to int
-        int len = (int) Math.min(count, Integer.MAX_VALUE);
-        _streamReadConstraints.validateStringLength(len);
     }
 
     /*

--- a/src/main/java/tools/jackson/core/json/ReaderBasedJsonParser.java
+++ b/src/main/java/tools/jackson/core/json/ReaderBasedJsonParser.java
@@ -47,7 +47,7 @@ public class ReaderBasedJsonParser
     protected char[] _inputBuffer;
 
     /**
-     * Flag that indicates whether the input buffer is recycable (and
+     * Flag that indicates whether the input buffer is recyclable (and
      * needs to be returned to recycler once we are done) or not.
      *<p>
      * If it is not, it also means that parser CANNOT modify underlying

--- a/src/main/java/tools/jackson/core/json/ReaderBasedJsonParser.java
+++ b/src/main/java/tools/jackson/core/json/ReaderBasedJsonParser.java
@@ -2305,14 +2305,39 @@ public class ReaderBasedJsonParser
     {
         _tokenIncomplete = false;
 
-        long count = 0;
+        long totalCount = 0;
         int inPtr = _inputPtr;
         int inLen = _inputEnd;
         char[] inBuf = _inputBuffer;
         final int maxStringLen = _streamReadConstraints.getMaxStringLength();
 
+        // Intermediate buffer for bulk writes to improve performance
+        char[] outBuf = new char[512];
+        int outPtr = 0;
+
         while (true) {
+            // Flush intermediate buffer when full
+            if (outPtr >= outBuf.length) {
+                writer.write(outBuf, 0, outPtr);
+                totalCount += outPtr;
+                // Check constraints only at flush boundaries
+                if (totalCount > maxStringLen) {
+                    _validateStringLength(totalCount);
+                }
+                outPtr = 0;
+            }
+
             if (inPtr >= inLen) {
+                // Flush intermediate buffer before loading more
+                if (outPtr > 0) {
+                    writer.write(outBuf, 0, outPtr);
+                    totalCount += outPtr;
+                    outPtr = 0;
+                }
+                // Check constraints at input buffer boundary
+                if (totalCount > maxStringLen) {
+                    _validateStringLength(totalCount);
+                }
                 _inputPtr = inPtr;
                 if (!_loadMore()) {
                     _reportInvalidEOF(": was expecting closing quote for a string value",
@@ -2340,14 +2365,30 @@ public class ReaderBasedJsonParser
                     }
                 }
             }
-            writer.write(c);
-            if (++count > maxStringLen) {
-                _streamReadConstraints.validateStringLength((int) count);
-            }
+            // Accumulate character in intermediate buffer
+            outBuf[outPtr++] = c;
+        }
+
+    // Final flush of remaining characters
+        if (outPtr > 0) {
+            writer.write(outBuf, 0, outPtr);
+            totalCount += outPtr;
+        }
+
+        // Validate final string length
+        if (totalCount > maxStringLen) {
+            _validateStringLength(totalCount);
         }
 
         _textBuffer.resetWithEmpty();
-        return count;
+        return totalCount;
+    }
+
+    // Helper method to validate string length with overflow protection
+    private void _validateStringLength(long count) throws JacksonException {
+        // Protect against integer overflow when casting to int
+        int len = (int) Math.min(count, Integer.MAX_VALUE);
+        _streamReadConstraints.validateStringLength(len);
     }
 
     /*

--- a/src/main/java/tools/jackson/core/json/ReaderBasedJsonParser.java
+++ b/src/main/java/tools/jackson/core/json/ReaderBasedJsonParser.java
@@ -341,8 +341,7 @@ public class ReaderBasedJsonParser
     @Override
     public long readString(Writer writer) throws JacksonException
     {
-        final JsonToken t = _currToken;
-        if (t == JsonToken.VALUE_STRING) {
+        if (_currToken == JsonToken.VALUE_STRING) {
             try {
                 if (_tokenIncomplete) {
                     return _streamString(writer);

--- a/src/main/java/tools/jackson/core/json/ReaderBasedJsonParser.java
+++ b/src/main/java/tools/jackson/core/json/ReaderBasedJsonParser.java
@@ -342,33 +342,19 @@ public class ReaderBasedJsonParser
     public long readString(Writer writer) throws JacksonException
     {
         final JsonToken t = _currToken;
-
-        try {
-            if (t == JsonToken.VALUE_STRING) {
+        if (t == JsonToken.VALUE_STRING) {
+            try {
                 if (_tokenIncomplete) {
                     return _streamString(writer);
                 }
                 long len = _textBuffer.contentsToWriter(writer);
                 _textBuffer.resetWithEmpty();
                 return len;
+            } catch (IOException e) {
+                throw _wrapIOFailure(e);
             }
-            if (t == JsonToken.PROPERTY_NAME) {
-                String n = _streamReadContext.currentName();
-                writer.write(n);
-                return n.length();
-            }
-            if (t != null) {
-                if (t.isNumeric()) {
-                    return _textBuffer.contentsToWriter(writer);
-                }
-                char[] ch = t.asCharArray();
-                writer.write(ch);
-                return ch.length;
-            }
-        } catch (IOException e) {
-            throw _wrapIOFailure(e);
         }
-        return 0;
+        return getString(writer);
     }
 
     // // // Let's override default impls for improved performance
@@ -2313,8 +2299,8 @@ public class ReaderBasedJsonParser
         char[] inBuf = _inputBuffer;
         final long maxStringLen = _streamReadConstraints.getMaxStringLength();
 
-        // Intermediate buffer for bulk writes to improve performance
-        char[] outBuf = new char[512];
+        // Intermediate buffer for bulk writes to improve performance (reused across calls)
+        char[] outBuf = _bufferForStringStreaming();
         int outPtr = 0;
 
         while (true) {

--- a/src/main/java/tools/jackson/core/json/ReaderBasedJsonParser.java
+++ b/src/main/java/tools/jackson/core/json/ReaderBasedJsonParser.java
@@ -338,6 +338,39 @@ public class ReaderBasedJsonParser
         return 0;
     }
 
+    @Override
+    public int readText(Writer writer) throws JacksonException
+    {
+        final JsonToken t = _currToken;
+
+        try {
+            if (t == JsonToken.VALUE_STRING) {
+                if (_tokenIncomplete) {
+                    return _streamString(writer);
+                }
+                int len = _textBuffer.contentsToWriter(writer);
+                _textBuffer.resetWithEmpty();
+                return len;
+            }
+            if (t == JsonToken.PROPERTY_NAME) {
+                String n = _streamReadContext.currentName();
+                writer.write(n);
+                return n.length();
+            }
+            if (t != null) {
+                if (t.isNumeric()) {
+                    return _textBuffer.contentsToWriter(writer);
+                }
+                char[] ch = t.asCharArray();
+                writer.write(ch);
+                return ch.length;
+            }
+        } catch (IOException e) {
+            throw _wrapIOFailure(e);
+        }
+        return 0;
+    }
+
     // // // Let's override default impls for improved performance
 
     @Override
@@ -2266,6 +2299,52 @@ public class ReaderBasedJsonParser
                 }
             }
         }
+    }
+
+    private int _streamString(Writer writer) throws JacksonException, IOException
+    {
+        _tokenIncomplete = false;
+
+        int count = 0;
+        int inPtr = _inputPtr;
+        int inLen = _inputEnd;
+        char[] inBuf = _inputBuffer;
+
+        while (true) {
+            if (inPtr >= inLen) {
+                _inputPtr = inPtr;
+                if (!_loadMore()) {
+                    _reportInvalidEOF(": was expecting closing quote for a string value",
+                            JsonToken.VALUE_STRING);
+                }
+                inPtr = _inputPtr;
+                inLen = _inputEnd;
+            }
+            char c = inBuf[inPtr++];
+            int i = c;
+            if (i <= INT_BACKSLASH) {
+                if (i == INT_BACKSLASH) {
+                    _inputPtr = inPtr;
+                    c = _decodeEscaped();
+                    inPtr = _inputPtr;
+                    inLen = _inputEnd;
+                } else if (i <= INT_QUOTE) {
+                    if (i == INT_QUOTE) {
+                        _inputPtr = inPtr;
+                        break;
+                    }
+                    if (i < INT_SPACE) {
+                        _inputPtr = inPtr;
+                        _throwUnquotedSpace(i, "string value");
+                    }
+                }
+            }
+            writer.write(c);
+            ++count;
+        }
+
+        _textBuffer.resetWithEmpty();
+        return count;
     }
 
     /*

--- a/src/main/java/tools/jackson/core/json/UTF8DataInputJsonParser.java
+++ b/src/main/java/tools/jackson/core/json/UTF8DataInputJsonParser.java
@@ -203,32 +203,19 @@ public class UTF8DataInputJsonParser
     public long readString(Writer writer) throws JacksonException
     {
         JsonToken t = _currToken;
-        try {
-            if (t == JsonToken.VALUE_STRING) {
+        if (t == JsonToken.VALUE_STRING) {
+            try {
                 if (_tokenIncomplete) {
                     return _streamString(writer);
                 }
                 long len = _textBuffer.contentsToWriter(writer);
                 _textBuffer.resetWithEmpty();
                 return len;
+            } catch (IOException e) {
+                throw _wrapIOFailure(e);
             }
-            if (t == JsonToken.PROPERTY_NAME) {
-                String n = _streamReadContext.currentName();
-                writer.write(n);
-                return n.length();
-            }
-            if (t != null) {
-                if (t.isNumeric()) {
-                    return _textBuffer.contentsToWriter(writer);
-                }
-                char[] ch = t.asCharArray();
-                writer.write(ch);
-                return ch.length;
-            }
-        } catch (IOException e) {
-            throw _wrapIOFailure(e);
         }
-        return 0;
+        return getString(writer);
     }
 
     // // // Let's override default impls for improved performance
@@ -2202,8 +2189,8 @@ public class UTF8DataInputJsonParser
         final int[] codes = _icUTF8;
         final long maxStringLen = _streamReadConstraints.getMaxStringLength();
 
-        // Intermediate buffer for bulk writes to improve performance
-        char[] outBuf = new char[512];
+        // Intermediate buffer for bulk writes to improve performance (reused across calls)
+        char[] outBuf = _bufferForStringStreaming();
         int outPtr = 0;
 
         main_loop:

--- a/src/main/java/tools/jackson/core/json/UTF8DataInputJsonParser.java
+++ b/src/main/java/tools/jackson/core/json/UTF8DataInputJsonParser.java
@@ -200,7 +200,7 @@ public class UTF8DataInputJsonParser
     }
 
     @Override
-    public int readText(Writer writer) throws JacksonException
+    public long readString(Writer writer) throws JacksonException
     {
         JsonToken t = _currToken;
         try {
@@ -208,7 +208,7 @@ public class UTF8DataInputJsonParser
                 if (_tokenIncomplete) {
                     return _streamString(writer);
                 }
-                int len = _textBuffer.contentsToWriter(writer);
+                long len = _textBuffer.contentsToWriter(writer);
                 _textBuffer.resetWithEmpty();
                 return len;
             }
@@ -2193,12 +2193,13 @@ public class UTF8DataInputJsonParser
         }
     }
 
-    private int _streamString(Writer writer) throws JacksonException, IOException
+    private long _streamString(Writer writer) throws JacksonException, IOException
     {
         _tokenIncomplete = false;
 
-        int count = 0;
+        long count = 0;
         final int[] codes = _icUTF8;
+        final int maxStringLen = _streamReadConstraints.getMaxStringLength();
 
         main_loop:
         while (true) {
@@ -2211,7 +2212,9 @@ public class UTF8DataInputJsonParser
                     break ascii_loop;
                 }
                 writer.write((char) c);
-                ++count;
+                if (++count > maxStringLen) {
+                    _streamReadConstraints.validateStringLength((int) count);
+                }
             }
             if (c == INT_QUOTE) {
                 break main_loop;
@@ -2220,21 +2223,30 @@ public class UTF8DataInputJsonParser
             switch (codes[c]) {
             case 1:
                 writer.write(_decodeEscaped());
-                ++count;
+                if (++count > maxStringLen) {
+                    _streamReadConstraints.validateStringLength((int) count);
+                }
                 break;
             case 2:
                 writer.write((char) _decodeUtf8_2(c));
-                ++count;
+                if (++count > maxStringLen) {
+                    _streamReadConstraints.validateStringLength((int) count);
+                }
                 break;
             case 3:
                 writer.write((char) _decodeUtf8_3(c));
-                ++count;
+                if (++count > maxStringLen) {
+                    _streamReadConstraints.validateStringLength((int) count);
+                }
                 break;
             case 4: {
                 int ch = _decodeUtf8_4(c);
                 writer.write((char) (0xD800 | (ch >> 10)));
                 writer.write((char) (0xDC00 | (ch & 0x3FF)));
                 count += 2;
+                if (count > maxStringLen) {
+                    _streamReadConstraints.validateStringLength((int) count);
+                }
                 break;
             }
             default:

--- a/src/main/java/tools/jackson/core/json/UTF8DataInputJsonParser.java
+++ b/src/main/java/tools/jackson/core/json/UTF8DataInputJsonParser.java
@@ -199,6 +199,38 @@ public class UTF8DataInputJsonParser
         return 0;
     }
 
+    @Override
+    public int readText(Writer writer) throws JacksonException
+    {
+        JsonToken t = _currToken;
+        try {
+            if (t == JsonToken.VALUE_STRING) {
+                if (_tokenIncomplete) {
+                    return _streamString(writer);
+                }
+                int len = _textBuffer.contentsToWriter(writer);
+                _textBuffer.resetWithEmpty();
+                return len;
+            }
+            if (t == JsonToken.PROPERTY_NAME) {
+                String n = _streamReadContext.currentName();
+                writer.write(n);
+                return n.length();
+            }
+            if (t != null) {
+                if (t.isNumeric()) {
+                    return _textBuffer.contentsToWriter(writer);
+                }
+                char[] ch = t.asCharArray();
+                writer.write(ch);
+                return ch.length;
+            }
+        } catch (IOException e) {
+            throw _wrapIOFailure(e);
+        }
+        return 0;
+    }
+
     // // // Let's override default impls for improved performance
     @Override
     public String getValueAsString() throws JacksonException
@@ -2093,6 +2125,63 @@ public class UTF8DataInputJsonParser
                 }
             }
         }
+    }
+
+    private int _streamString(Writer writer) throws JacksonException, IOException
+    {
+        _tokenIncomplete = false;
+
+        int count = 0;
+        final int[] codes = _icUTF8;
+
+        main_loop:
+        while (true) {
+            int c;
+
+            ascii_loop:
+            while (true) {
+                c = _inputData.readUnsignedByte();
+                if (codes[c] != 0) {
+                    break ascii_loop;
+                }
+                writer.write((char) c);
+                ++count;
+            }
+            if (c == INT_QUOTE) {
+                break main_loop;
+            }
+
+            switch (codes[c]) {
+            case 1:
+                writer.write(_decodeEscaped());
+                ++count;
+                break;
+            case 2:
+                writer.write((char) _decodeUtf8_2(c));
+                ++count;
+                break;
+            case 3:
+                writer.write((char) _decodeUtf8_3(c));
+                ++count;
+                break;
+            case 4: {
+                int ch = _decodeUtf8_4(c);
+                writer.write((char) (0xD800 | (ch >> 10)));
+                writer.write((char) (0xDC00 | (ch & 0x3FF)));
+                count += 2;
+                break;
+            }
+            default:
+                if (c < INT_SPACE) {
+                    _throwUnquotedSpace(c, "string value");
+                } else {
+                    _reportInvalidChar(c);
+                }
+            }
+        }
+
+        _textBuffer.resetWithEmpty();
+        return count;
     }
 
     /**

--- a/src/main/java/tools/jackson/core/json/UTF8DataInputJsonParser.java
+++ b/src/main/java/tools/jackson/core/json/UTF8DataInputJsonParser.java
@@ -2222,7 +2222,7 @@ public class UTF8DataInputJsonParser
                     outPtr = 0;
                     // Check constraints only at flush boundaries
                     if (totalCount > maxStringLen) {
-                        _validateStringLength(totalCount);
+                        _streamReadConstraints.validateStringLengthLong(totalCount);
                     }
                 }
                 // Accumulate character in intermediate buffer
@@ -2251,7 +2251,7 @@ public class UTF8DataInputJsonParser
                     totalCount += outPtr;
                     outPtr = 0;
                     if (totalCount > maxStringLen) {
-                        _validateStringLength(totalCount);
+                        _streamReadConstraints.validateStringLengthLong(totalCount);
                     }
                 }
                 outBuf[outPtr++] = (char) (0xDC00 | (ch & 0x3FF));
@@ -2272,19 +2272,12 @@ public class UTF8DataInputJsonParser
             totalCount += outPtr;
             // Validate final string length
             if (totalCount > maxStringLen) {
-                _validateStringLength(totalCount);
+                _streamReadConstraints.validateStringLengthLong(totalCount);
             }
         }
 
         _textBuffer.resetWithEmpty();
         return totalCount;
-    }
-
-    // Helper method to validate string length with overflow protection
-    private void _validateStringLength(long count) throws JacksonException {
-        // Protect against integer overflow when casting to int
-        int len = (int) Math.min(count, Integer.MAX_VALUE);
-        _streamReadConstraints.validateStringLength(len);
     }
 
     /**

--- a/src/main/java/tools/jackson/core/json/UTF8DataInputJsonParser.java
+++ b/src/main/java/tools/jackson/core/json/UTF8DataInputJsonParser.java
@@ -202,8 +202,7 @@ public class UTF8DataInputJsonParser
     @Override
     public long readString(Writer writer) throws JacksonException
     {
-        JsonToken t = _currToken;
-        if (t == JsonToken.VALUE_STRING) {
+        if (_currToken == JsonToken.VALUE_STRING) {
             try {
                 if (_tokenIncomplete) {
                     return _streamString(writer);

--- a/src/main/java/tools/jackson/core/json/UTF8DataInputJsonParser.java
+++ b/src/main/java/tools/jackson/core/json/UTF8DataInputJsonParser.java
@@ -2197,9 +2197,13 @@ public class UTF8DataInputJsonParser
     {
         _tokenIncomplete = false;
 
-        long count = 0;
+        long totalCount = 0;
         final int[] codes = _icUTF8;
         final int maxStringLen = _streamReadConstraints.getMaxStringLength();
+
+        // Intermediate buffer for bulk writes to improve performance
+        char[] outBuf = new char[512];
+        int outPtr = 0;
 
         main_loop:
         while (true) {
@@ -2211,42 +2215,47 @@ public class UTF8DataInputJsonParser
                 if (codes[c] != 0) {
                     break ascii_loop;
                 }
-                writer.write((char) c);
-                if (++count > maxStringLen) {
-                    _streamReadConstraints.validateStringLength((int) count);
+                // Flush intermediate buffer when full
+                if (outPtr >= outBuf.length) {
+                    writer.write(outBuf, 0, outPtr);
+                    totalCount += outPtr;
+                    // Check constraints only at flush boundaries
+                    if (totalCount > maxStringLen) {
+                        _validateStringLength(totalCount);
+                    }
+                    outPtr = 0;
                 }
+                // Accumulate character in intermediate buffer
+                outBuf[outPtr++] = (char) c;
             }
             if (c == INT_QUOTE) {
                 break main_loop;
             }
 
+            // Flush intermediate buffer when full before writing multi-byte chars
+            if (outPtr >= outBuf.length - 1) { // -1 to ensure space for surrogate pairs
+                writer.write(outBuf, 0, outPtr);
+                totalCount += outPtr;
+                if (totalCount > maxStringLen) {
+                    _validateStringLength(totalCount);
+                }
+                outPtr = 0;
+            }
+
             switch (codes[c]) {
             case 1:
-                writer.write(_decodeEscaped());
-                if (++count > maxStringLen) {
-                    _streamReadConstraints.validateStringLength((int) count);
-                }
+                outBuf[outPtr++] = _decodeEscaped();
                 break;
             case 2:
-                writer.write((char) _decodeUtf8_2(c));
-                if (++count > maxStringLen) {
-                    _streamReadConstraints.validateStringLength((int) count);
-                }
+                outBuf[outPtr++] = (char) _decodeUtf8_2(c);
                 break;
             case 3:
-                writer.write((char) _decodeUtf8_3(c));
-                if (++count > maxStringLen) {
-                    _streamReadConstraints.validateStringLength((int) count);
-                }
+                outBuf[outPtr++] = (char) _decodeUtf8_3(c);
                 break;
             case 4: {
                 int ch = _decodeUtf8_4(c);
-                writer.write((char) (0xD800 | (ch >> 10)));
-                writer.write((char) (0xDC00 | (ch & 0x3FF)));
-                count += 2;
-                if (count > maxStringLen) {
-                    _streamReadConstraints.validateStringLength((int) count);
-                }
+                outBuf[outPtr++] = (char) (0xD800 | (ch >> 10));
+                outBuf[outPtr++] = (char) (0xDC00 | (ch & 0x3FF));
                 break;
             }
             default:
@@ -2258,8 +2267,26 @@ public class UTF8DataInputJsonParser
             }
         }
 
+        // Final flush of remaining characters
+        if (outPtr > 0) {
+            writer.write(outBuf, 0, outPtr);
+            totalCount += outPtr;
+        }
+
+        // Validate final string length
+        if (totalCount > maxStringLen) {
+            _validateStringLength(totalCount);
+        }
+
         _textBuffer.resetWithEmpty();
-        return count;
+        return totalCount;
+    }
+
+    // Helper method to validate string length with overflow protection
+    private void _validateStringLength(long count) throws JacksonException {
+        // Protect against integer overflow when casting to int
+        int len = (int) Math.min(count, Integer.MAX_VALUE);
+        _streamReadConstraints.validateStringLength(len);
     }
 
     /**

--- a/src/main/java/tools/jackson/core/json/UTF8DataInputJsonParser.java
+++ b/src/main/java/tools/jackson/core/json/UTF8DataInputJsonParser.java
@@ -2219,27 +2219,17 @@ public class UTF8DataInputJsonParser
                 if (outPtr >= outBuf.length) {
                     writer.write(outBuf, 0, outPtr);
                     totalCount += outPtr;
+                    outPtr = 0;
                     // Check constraints only at flush boundaries
                     if (totalCount > maxStringLen) {
                         _validateStringLength(totalCount);
                     }
-                    outPtr = 0;
                 }
                 // Accumulate character in intermediate buffer
                 outBuf[outPtr++] = (char) c;
             }
             if (c == INT_QUOTE) {
                 break main_loop;
-            }
-
-            // Flush intermediate buffer when full before writing multi-byte chars
-            if (outPtr >= outBuf.length - 1) { // -1 to ensure space for surrogate pairs
-                writer.write(outBuf, 0, outPtr);
-                totalCount += outPtr;
-                if (totalCount > maxStringLen) {
-                    _validateStringLength(totalCount);
-                }
-                outPtr = 0;
             }
 
             switch (codes[c]) {
@@ -2255,6 +2245,15 @@ public class UTF8DataInputJsonParser
             case 4: {
                 int ch = _decodeUtf8_4(c);
                 outBuf[outPtr++] = (char) (0xD800 | (ch >> 10));
+                // Flush intermediate buffer when full before writing multi-byte chars
+                if (outPtr >= outBuf.length) {
+                    writer.write(outBuf, 0, outPtr);
+                    totalCount += outPtr;
+                    outPtr = 0;
+                    if (totalCount > maxStringLen) {
+                        _validateStringLength(totalCount);
+                    }
+                }
                 outBuf[outPtr++] = (char) (0xDC00 | (ch & 0x3FF));
                 break;
             }
@@ -2271,11 +2270,10 @@ public class UTF8DataInputJsonParser
         if (outPtr > 0) {
             writer.write(outBuf, 0, outPtr);
             totalCount += outPtr;
-        }
-
-        // Validate final string length
-        if (totalCount > maxStringLen) {
-            _validateStringLength(totalCount);
+            // Validate final string length
+            if (totalCount > maxStringLen) {
+                _validateStringLength(totalCount);
+            }
         }
 
         _textBuffer.resetWithEmpty();

--- a/src/main/java/tools/jackson/core/json/UTF8DataInputJsonParser.java
+++ b/src/main/java/tools/jackson/core/json/UTF8DataInputJsonParser.java
@@ -2193,13 +2193,14 @@ public class UTF8DataInputJsonParser
         }
     }
 
-    private long _streamString(Writer writer) throws JacksonException, IOException
+    // @since 3.1
+    private long _streamString(Writer writer) throws IOException, JacksonException
     {
         _tokenIncomplete = false;
 
-        long totalCount = 0;
+        long totalLen = 0;
         final int[] codes = _icUTF8;
-        final int maxStringLen = _streamReadConstraints.getMaxStringLength();
+        final long maxStringLen = _streamReadConstraints.getMaxStringLength();
 
         // Intermediate buffer for bulk writes to improve performance
         char[] outBuf = new char[512];
@@ -2218,11 +2219,11 @@ public class UTF8DataInputJsonParser
                 // Flush intermediate buffer when full
                 if (outPtr >= outBuf.length) {
                     writer.write(outBuf, 0, outPtr);
-                    totalCount += outPtr;
+                    totalLen += outPtr;
                     outPtr = 0;
                     // Check constraints only at flush boundaries
-                    if (totalCount > maxStringLen) {
-                        _streamReadConstraints.validateStringLengthLong(totalCount);
+                    if (totalLen > maxStringLen) {
+                        _streamReadConstraints.validateStringLengthLong(totalLen);
                     }
                 }
                 // Accumulate character in intermediate buffer
@@ -2248,10 +2249,10 @@ public class UTF8DataInputJsonParser
                 // Flush intermediate buffer when full before writing multi-byte chars
                 if (outPtr >= outBuf.length) {
                     writer.write(outBuf, 0, outPtr);
-                    totalCount += outPtr;
+                    totalLen += outPtr;
                     outPtr = 0;
-                    if (totalCount > maxStringLen) {
-                        _streamReadConstraints.validateStringLengthLong(totalCount);
+                    if (totalLen > maxStringLen) {
+                        _streamReadConstraints.validateStringLengthLong(totalLen);
                     }
                 }
                 outBuf[outPtr++] = (char) (0xDC00 | (ch & 0x3FF));
@@ -2269,15 +2270,15 @@ public class UTF8DataInputJsonParser
         // Final flush of remaining characters
         if (outPtr > 0) {
             writer.write(outBuf, 0, outPtr);
-            totalCount += outPtr;
+            totalLen += outPtr;
             // Validate final string length
-            if (totalCount > maxStringLen) {
-                _streamReadConstraints.validateStringLengthLong(totalCount);
+            if (totalLen > maxStringLen) {
+                _streamReadConstraints.validateStringLengthLong(totalLen);
             }
         }
 
         _textBuffer.resetWithEmpty();
-        return totalCount;
+        return totalLen;
     }
 
     /**

--- a/src/main/java/tools/jackson/core/json/UTF8StreamJsonParser.java
+++ b/src/main/java/tools/jackson/core/json/UTF8StreamJsonParser.java
@@ -326,33 +326,20 @@ public class UTF8StreamJsonParser
     @Override
     public long readString(Writer writer) throws JacksonException
     {
-        try {
-            JsonToken t = _currToken;
-            if (t == JsonToken.VALUE_STRING) {
+        JsonToken t = _currToken;
+        if (t == JsonToken.VALUE_STRING) {
+            try {
                 if (_tokenIncomplete) {
                     return _streamString(writer);
                 }
                 long len = _textBuffer.contentsToWriter(writer);
                 _textBuffer.resetWithEmpty();
                 return len;
+            } catch (IOException e) {
+                throw _wrapIOFailure(e);
             }
-            if (t == JsonToken.PROPERTY_NAME) {
-                String n = _streamReadContext.currentName();
-                writer.write(n);
-                return n.length();
-            }
-            if (t != null) {
-                if (t.isNumeric()) {
-                    return _textBuffer.contentsToWriter(writer);
-                }
-                char[] ch = t.asCharArray();
-                writer.write(ch);
-                return ch.length;
-            }
-        } catch (IOException e) {
-            throw _wrapIOFailure(e);
         }
-        return 0;
+        return getString(writer);
     }
 
     // // // Let's override default impls for improved performance
@@ -3150,8 +3137,8 @@ public class UTF8StreamJsonParser
         final byte[] inputBuffer = _inputBuffer;
         final long maxStringLen = _streamReadConstraints.getMaxStringLength();
 
-        // Intermediate buffer for bulk writes to improve performance
-        char[] outBuf = new char[512];
+        // Intermediate buffer for bulk writes to improve performance (reused across calls)
+        char[] outBuf = _bufferForStringStreaming();
         int outPtr = 0;
 
         main_loop:

--- a/src/main/java/tools/jackson/core/json/UTF8StreamJsonParser.java
+++ b/src/main/java/tools/jackson/core/json/UTF8StreamJsonParser.java
@@ -326,8 +326,7 @@ public class UTF8StreamJsonParser
     @Override
     public long readString(Writer writer) throws JacksonException
     {
-        JsonToken t = _currToken;
-        if (t == JsonToken.VALUE_STRING) {
+        if (_currToken == JsonToken.VALUE_STRING) {
             try {
                 if (_tokenIncomplete) {
                     return _streamString(writer);

--- a/src/main/java/tools/jackson/core/json/UTF8StreamJsonParser.java
+++ b/src/main/java/tools/jackson/core/json/UTF8StreamJsonParser.java
@@ -3170,7 +3170,7 @@ public class UTF8StreamJsonParser
                     }
                     // Check constraints at input buffer boundary
                     if (totalCount > maxStringLen) {
-                        _validateStringLength(totalCount);
+                        _streamReadConstraints.validateStringLengthLong(totalCount);
                     }
                     _loadMoreGuaranteed();
                     ptr = _inputPtr;
@@ -3188,7 +3188,7 @@ public class UTF8StreamJsonParser
                         totalCount += outPtr;
                         // Check constraints only at flush boundaries
                         if (totalCount > maxStringLen) {
-                            _validateStringLength(totalCount);
+                            _streamReadConstraints.validateStringLengthLong(totalCount);
                         }
                         outPtr = 0;
                     }
@@ -3207,7 +3207,7 @@ public class UTF8StreamJsonParser
                 writer.write(outBuf, 0, outPtr);
                 totalCount += outPtr;
                 if (totalCount > maxStringLen) {
-                    _validateStringLength(totalCount);
+                    _streamReadConstraints.validateStringLengthLong(totalCount);
                 }
                 outPtr = 0;
             }
@@ -3245,18 +3245,11 @@ public class UTF8StreamJsonParser
 
         // Validate final string length
         if (totalCount > maxStringLen) {
-            _validateStringLength(totalCount);
+            _streamReadConstraints.validateStringLengthLong(totalCount);
         }
 
         _textBuffer.resetWithEmpty();
         return totalCount;
-    }
-
-    // Helper method to validate string length with overflow protection
-    private void _validateStringLength(long count) throws JacksonException {
-        // Protect against integer overflow when casting to int
-        int len = (int) Math.min(count, Integer.MAX_VALUE);
-        _streamReadConstraints.validateStringLength(len);
     }
 
     /**

--- a/src/main/java/tools/jackson/core/json/UTF8StreamJsonParser.java
+++ b/src/main/java/tools/jackson/core/json/UTF8StreamJsonParser.java
@@ -3140,7 +3140,8 @@ public class UTF8StreamJsonParser
         }
     }
 
-    private long _streamString(Writer writer) throws IOException, JacksonException 
+    // @since 3.1
+    private long _streamString(Writer writer) throws IOException, JacksonException
     {
         _tokenIncomplete = false;
 

--- a/src/main/java/tools/jackson/core/json/UTF8StreamJsonParser.java
+++ b/src/main/java/tools/jackson/core/json/UTF8StreamJsonParser.java
@@ -3140,14 +3140,14 @@ public class UTF8StreamJsonParser
         }
     }
 
-    private long _streamString(Writer writer) throws JacksonException, IOException
+    private long _streamString(Writer writer) throws IOException, JacksonException 
     {
         _tokenIncomplete = false;
 
-        long totalCount = 0;
+        long totalLen = 0;
         final int[] codes = _icUTF8;
         final byte[] inputBuffer = _inputBuffer;
-        final int maxStringLen = _streamReadConstraints.getMaxStringLength();
+        final long maxStringLen = _streamReadConstraints.getMaxStringLength();
 
         // Intermediate buffer for bulk writes to improve performance
         char[] outBuf = new char[512];
@@ -3165,12 +3165,12 @@ public class UTF8StreamJsonParser
                     // Flush intermediate buffer before loading more
                     if (outPtr > 0) {
                         writer.write(outBuf, 0, outPtr);
-                        totalCount += outPtr;
+                        totalLen += outPtr;
                         outPtr = 0;
                     }
                     // Check constraints at input buffer boundary
-                    if (totalCount > maxStringLen) {
-                        _streamReadConstraints.validateStringLengthLong(totalCount);
+                    if (totalLen > maxStringLen) {
+                        _streamReadConstraints.validateStringLengthLong(totalLen);
                     }
                     _loadMoreGuaranteed();
                     ptr = _inputPtr;
@@ -3185,10 +3185,10 @@ public class UTF8StreamJsonParser
                     // Flush intermediate buffer when full
                     if (outPtr >= outBuf.length) {
                         writer.write(outBuf, 0, outPtr);
-                        totalCount += outPtr;
+                        totalLen += outPtr;
                         // Check constraints only at flush boundaries
-                        if (totalCount > maxStringLen) {
-                            _streamReadConstraints.validateStringLengthLong(totalCount);
+                        if (totalLen > maxStringLen) {
+                            _streamReadConstraints.validateStringLengthLong(totalLen);
                         }
                         outPtr = 0;
                     }
@@ -3200,16 +3200,6 @@ public class UTF8StreamJsonParser
 
             if (c == INT_QUOTE) {
                 break main_loop;
-            }
-
-            // Flush intermediate buffer when full before writing multi-byte chars
-            if (outPtr >= outBuf.length - 1) { // -1 to ensure space for surrogate pairs
-                writer.write(outBuf, 0, outPtr);
-                totalCount += outPtr;
-                if (totalCount > maxStringLen) {
-                    _streamReadConstraints.validateStringLengthLong(totalCount);
-                }
-                outPtr = 0;
             }
 
             switch (codes[c]) {
@@ -3225,6 +3215,15 @@ public class UTF8StreamJsonParser
             case 4: {
                 int ch = _decodeUtf8_4(c);
                 outBuf[outPtr++] = (char) (0xD800 | (ch >> 10));
+                // Flush intermediate buffer when full before writing multi-byte chars
+                if (outPtr >= outBuf.length) {
+                    writer.write(outBuf, 0, outPtr);
+                    totalLen += outPtr;
+                    if (totalLen > maxStringLen) {
+                        _streamReadConstraints.validateStringLengthLong(totalLen);
+                    }
+                    outPtr = 0;
+                }
                 outBuf[outPtr++] = (char) (0xDC00 | (ch & 0x3FF));
                 break;
             }
@@ -3240,16 +3239,15 @@ public class UTF8StreamJsonParser
         // Final flush of remaining characters
         if (outPtr > 0) {
             writer.write(outBuf, 0, outPtr);
-            totalCount += outPtr;
-        }
-
-        // Validate final string length
-        if (totalCount > maxStringLen) {
-            _streamReadConstraints.validateStringLengthLong(totalCount);
+            totalLen += outPtr;
+            // Validate final string length
+            if (totalLen > maxStringLen) {
+                _streamReadConstraints.validateStringLengthLong(totalLen);
+            }
         }
 
         _textBuffer.resetWithEmpty();
-        return totalCount;
+        return totalLen;
     }
 
     /**

--- a/src/main/java/tools/jackson/core/json/UTF8StreamJsonParser.java
+++ b/src/main/java/tools/jackson/core/json/UTF8StreamJsonParser.java
@@ -324,7 +324,7 @@ public class UTF8StreamJsonParser
     }
 
     @Override
-    public int readText(Writer writer) throws JacksonException
+    public long readString(Writer writer) throws JacksonException
     {
         try {
             JsonToken t = _currToken;
@@ -332,7 +332,7 @@ public class UTF8StreamJsonParser
                 if (_tokenIncomplete) {
                     return _streamString(writer);
                 }
-                int len = _textBuffer.contentsToWriter(writer);
+                long len = _textBuffer.contentsToWriter(writer);
                 _textBuffer.resetWithEmpty();
                 return len;
             }
@@ -3140,13 +3140,14 @@ public class UTF8StreamJsonParser
         }
     }
 
-    private int _streamString(Writer writer) throws JacksonException, IOException
+    private long _streamString(Writer writer) throws JacksonException, IOException
     {
         _tokenIncomplete = false;
 
-        int count = 0;
+        long count = 0;
         final int[] codes = _icUTF8;
         final byte[] inputBuffer = _inputBuffer;
+        final int maxStringLen = _streamReadConstraints.getMaxStringLength();
 
         main_loop:
         while (true) {
@@ -3168,7 +3169,9 @@ public class UTF8StreamJsonParser
                         break ascii_loop;
                     }
                     writer.write((char) c);
-                    ++count;
+                    if (++count > maxStringLen) {
+                        _streamReadConstraints.validateStringLength((int) count);
+                    }
                 }
                 _inputPtr = ptr;
             }
@@ -3180,21 +3183,30 @@ public class UTF8StreamJsonParser
             switch (codes[c]) {
             case 1:
                 writer.write(_decodeEscaped());
-                ++count;
+                if (++count > maxStringLen) {
+                    _streamReadConstraints.validateStringLength((int) count);
+                }
                 break;
             case 2:
                 writer.write((char) _decodeUtf8_2(c));
-                ++count;
+                if (++count > maxStringLen) {
+                    _streamReadConstraints.validateStringLength((int) count);
+                }
                 break;
             case 3:
                 writer.write((char) _decodeUtf8_3(c));
-                ++count;
+                if (++count > maxStringLen) {
+                    _streamReadConstraints.validateStringLength((int) count);
+                }
                 break;
             case 4: {
                 int ch = _decodeUtf8_4(c);
                 writer.write((char) (0xD800 | (ch >> 10)));
                 writer.write((char) (0xDC00 | (ch & 0x3FF)));
                 count += 2;
+                if (count > maxStringLen) {
+                    _streamReadConstraints.validateStringLength((int) count);
+                }
                 break;
             }
             default:

--- a/src/main/java/tools/jackson/core/json/UTF8StreamJsonParser.java
+++ b/src/main/java/tools/jackson/core/json/UTF8StreamJsonParser.java
@@ -3144,10 +3144,14 @@ public class UTF8StreamJsonParser
     {
         _tokenIncomplete = false;
 
-        long count = 0;
+        long totalCount = 0;
         final int[] codes = _icUTF8;
         final byte[] inputBuffer = _inputBuffer;
         final int maxStringLen = _streamReadConstraints.getMaxStringLength();
+
+        // Intermediate buffer for bulk writes to improve performance
+        char[] outBuf = new char[512];
+        int outPtr = 0;
 
         main_loop:
         while (true) {
@@ -3158,6 +3162,16 @@ public class UTF8StreamJsonParser
                 int ptr = _inputPtr;
                 int max = _inputEnd;
                 if (ptr >= max) {
+                    // Flush intermediate buffer before loading more
+                    if (outPtr > 0) {
+                        writer.write(outBuf, 0, outPtr);
+                        totalCount += outPtr;
+                        outPtr = 0;
+                    }
+                    // Check constraints at input buffer boundary
+                    if (totalCount > maxStringLen) {
+                        _validateStringLength(totalCount);
+                    }
                     _loadMoreGuaranteed();
                     ptr = _inputPtr;
                     max = _inputEnd;
@@ -3168,10 +3182,18 @@ public class UTF8StreamJsonParser
                         _inputPtr = ptr;
                         break ascii_loop;
                     }
-                    writer.write((char) c);
-                    if (++count > maxStringLen) {
-                        _streamReadConstraints.validateStringLength((int) count);
+                    // Flush intermediate buffer when full
+                    if (outPtr >= outBuf.length) {
+                        writer.write(outBuf, 0, outPtr);
+                        totalCount += outPtr;
+                        // Check constraints only at flush boundaries
+                        if (totalCount > maxStringLen) {
+                            _validateStringLength(totalCount);
+                        }
+                        outPtr = 0;
                     }
+                    // Accumulate character in intermediate buffer
+                    outBuf[outPtr++] = (char) c;
                 }
                 _inputPtr = ptr;
             }
@@ -3180,33 +3202,30 @@ public class UTF8StreamJsonParser
                 break main_loop;
             }
 
+            // Flush intermediate buffer when full before writing multi-byte chars
+            if (outPtr >= outBuf.length - 1) { // -1 to ensure space for surrogate pairs
+                writer.write(outBuf, 0, outPtr);
+                totalCount += outPtr;
+                if (totalCount > maxStringLen) {
+                    _validateStringLength(totalCount);
+                }
+                outPtr = 0;
+            }
+
             switch (codes[c]) {
             case 1:
-                writer.write(_decodeEscaped());
-                if (++count > maxStringLen) {
-                    _streamReadConstraints.validateStringLength((int) count);
-                }
+                outBuf[outPtr++] = _decodeEscaped();
                 break;
             case 2:
-                writer.write((char) _decodeUtf8_2(c));
-                if (++count > maxStringLen) {
-                    _streamReadConstraints.validateStringLength((int) count);
-                }
+                outBuf[outPtr++] = (char) _decodeUtf8_2(c);
                 break;
             case 3:
-                writer.write((char) _decodeUtf8_3(c));
-                if (++count > maxStringLen) {
-                    _streamReadConstraints.validateStringLength((int) count);
-                }
+                outBuf[outPtr++] = (char) _decodeUtf8_3(c);
                 break;
             case 4: {
                 int ch = _decodeUtf8_4(c);
-                writer.write((char) (0xD800 | (ch >> 10)));
-                writer.write((char) (0xDC00 | (ch & 0x3FF)));
-                count += 2;
-                if (count > maxStringLen) {
-                    _streamReadConstraints.validateStringLength((int) count);
-                }
+                outBuf[outPtr++] = (char) (0xD800 | (ch >> 10));
+                outBuf[outPtr++] = (char) (0xDC00 | (ch & 0x3FF));
                 break;
             }
             default:
@@ -3218,8 +3237,26 @@ public class UTF8StreamJsonParser
             }
         }
 
+        // Final flush of remaining characters
+        if (outPtr > 0) {
+            writer.write(outBuf, 0, outPtr);
+            totalCount += outPtr;
+        }
+
+        // Validate final string length
+        if (totalCount > maxStringLen) {
+            _validateStringLength(totalCount);
+        }
+
         _textBuffer.resetWithEmpty();
-        return count;
+        return totalCount;
+    }
+
+    // Helper method to validate string length with overflow protection
+    private void _validateStringLength(long count) throws JacksonException {
+        // Protect against integer overflow when casting to int
+        int len = (int) Math.min(count, Integer.MAX_VALUE);
+        _streamReadConstraints.validateStringLength(len);
     }
 
     /**

--- a/src/main/java/tools/jackson/core/json/UTF8StreamJsonParser.java
+++ b/src/main/java/tools/jackson/core/json/UTF8StreamJsonParser.java
@@ -323,6 +323,38 @@ public class UTF8StreamJsonParser
         return 0;
     }
 
+    @Override
+    public int readText(Writer writer) throws JacksonException
+    {
+        try {
+            JsonToken t = _currToken;
+            if (t == JsonToken.VALUE_STRING) {
+                if (_tokenIncomplete) {
+                    return _streamString(writer);
+                }
+                int len = _textBuffer.contentsToWriter(writer);
+                _textBuffer.resetWithEmpty();
+                return len;
+            }
+            if (t == JsonToken.PROPERTY_NAME) {
+                String n = _streamReadContext.currentName();
+                writer.write(n);
+                return n.length();
+            }
+            if (t != null) {
+                if (t.isNumeric()) {
+                    return _textBuffer.contentsToWriter(writer);
+                }
+                char[] ch = t.asCharArray();
+                writer.write(ch);
+                return ch.length;
+            }
+        } catch (IOException e) {
+            throw _wrapIOFailure(e);
+        }
+        return 0;
+    }
+
     // // // Let's override default impls for improved performance
 
     @Override
@@ -3025,6 +3057,76 @@ public class UTF8StreamJsonParser
                 }
             }
         }
+    }
+
+    private int _streamString(Writer writer) throws JacksonException, IOException
+    {
+        _tokenIncomplete = false;
+
+        int count = 0;
+        final int[] codes = _icUTF8;
+        final byte[] inputBuffer = _inputBuffer;
+
+        main_loop:
+        while (true) {
+            int c;
+
+            ascii_loop:
+            while (true) {
+                int ptr = _inputPtr;
+                int max = _inputEnd;
+                if (ptr >= max) {
+                    _loadMoreGuaranteed();
+                    ptr = _inputPtr;
+                    max = _inputEnd;
+                }
+                while (ptr < max) {
+                    c = inputBuffer[ptr++] & 0xFF;
+                    if (codes[c] != 0) {
+                        _inputPtr = ptr;
+                        break ascii_loop;
+                    }
+                    writer.write((char) c);
+                    ++count;
+                }
+                _inputPtr = ptr;
+            }
+
+            if (c == INT_QUOTE) {
+                break main_loop;
+            }
+
+            switch (codes[c]) {
+            case 1:
+                writer.write(_decodeEscaped());
+                ++count;
+                break;
+            case 2:
+                writer.write((char) _decodeUtf8_2(c));
+                ++count;
+                break;
+            case 3:
+                writer.write((char) _decodeUtf8_3(c));
+                ++count;
+                break;
+            case 4: {
+                int ch = _decodeUtf8_4(c);
+                writer.write((char) (0xD800 | (ch >> 10)));
+                writer.write((char) (0xDC00 | (ch & 0x3FF)));
+                count += 2;
+                break;
+            }
+            default:
+                if (c < INT_SPACE) {
+                    _throwUnquotedSpace(c, "string value");
+                } else {
+                    _reportInvalidChar(c);
+                }
+            }
+        }
+
+        _textBuffer.resetWithEmpty();
+        return count;
     }
 
     /**

--- a/src/main/java/tools/jackson/core/json/async/NonBlockingJsonParserBase.java
+++ b/src/main/java/tools/jackson/core/json/async/NonBlockingJsonParserBase.java
@@ -437,10 +437,21 @@ public abstract class NonBlockingJsonParserBase
         return 0;
     }
 
+    /**
+     * Non-blocking parsers cannot reliably support streaming string reads
+     * since content availability is unpredictable. This method throws
+     * {@link UnsupportedOperationException} to indicate that it should not
+     * be used with non-blocking parsers.
+     *
+     * @throws UnsupportedOperationException always, as this operation is not
+     *         supported for non-blocking parsers
+     */
     @Override
-    public int readText(Writer writer) throws JacksonException
+    public long readString(Writer writer) throws JacksonException
     {
-        return getString(writer);
+        throw new UnsupportedOperationException(
+            "readString(Writer) not supported for non-blocking parsers: " +
+            "content availability is unpredictable");
     }
 
     // // // Let's override default impls for improved performance

--- a/src/main/java/tools/jackson/core/json/async/NonBlockingJsonParserBase.java
+++ b/src/main/java/tools/jackson/core/json/async/NonBlockingJsonParserBase.java
@@ -450,8 +450,7 @@ public abstract class NonBlockingJsonParserBase
     public long readString(Writer writer) throws JacksonException
     {
         throw new UnsupportedOperationException(
-            "readString(Writer) not supported for non-blocking parsers: " +
-            "content availability is unpredictable");
+"`readString(Writer)` not supported for non-blocking parsers: content availability is unpredictable and `java.io.Writer` itself blocking");
     }
 
     // // // Let's override default impls for improved performance

--- a/src/main/java/tools/jackson/core/json/async/NonBlockingJsonParserBase.java
+++ b/src/main/java/tools/jackson/core/json/async/NonBlockingJsonParserBase.java
@@ -429,6 +429,12 @@ public abstract class NonBlockingJsonParserBase
         return 0;
     }
 
+    @Override
+    public int readText(Writer writer) throws JacksonException
+    {
+        return getString(writer);
+    }
+
     // // // Let's override default impls for improved performance
 
     @Override

--- a/src/main/java/tools/jackson/core/util/JsonParserDelegate.java
+++ b/src/main/java/tools/jackson/core/util/JsonParserDelegate.java
@@ -179,6 +179,7 @@ public class JsonParserDelegate extends JsonParser
     @Override public int getStringLength() throws JacksonException { return delegate.getStringLength(); }
     @Override public int getStringOffset() throws JacksonException { return delegate.getStringOffset(); }
     @Override public int getString(Writer writer) throws JacksonException { return delegate.getString(writer);  }
+    @Override public int readText(Writer writer) throws JacksonException { return delegate.readText(writer);  }
 
     /*
     /**********************************************************************

--- a/src/main/java/tools/jackson/core/util/JsonParserDelegate.java
+++ b/src/main/java/tools/jackson/core/util/JsonParserDelegate.java
@@ -179,7 +179,7 @@ public class JsonParserDelegate extends JsonParser
     @Override public int getStringLength() throws JacksonException { return delegate.getStringLength(); }
     @Override public int getStringOffset() throws JacksonException { return delegate.getStringOffset(); }
     @Override public int getString(Writer writer) throws JacksonException { return delegate.getString(writer);  }
-    @Override public int readText(Writer writer) throws JacksonException { return delegate.readText(writer);  }
+    @Override public long readString(Writer writer) throws JacksonException { return delegate.readString(writer);  }
 
     /*
     /**********************************************************************

--- a/src/test/java/tools/jackson/core/unittest/json/async/AsyncStringObjectTest.java
+++ b/src/test/java/tools/jackson/core/unittest/json/async/AsyncStringObjectTest.java
@@ -1,6 +1,8 @@
 package tools.jackson.core.unittest.json.async;
 
 import java.io.IOException;
+import java.io.StringWriter;
+import java.io.Writer;
 
 import org.junit.jupiter.api.Test;
 
@@ -115,6 +117,116 @@ class AsyncStringObjectTest extends AsyncTestBase
 
                 assertToken(JsonToken.END_OBJECT, r.nextToken());
             }
+        }
+    }
+
+    // [core#1288]: readString(Writer) should not be supported for non-blocking parsers
+    @Test
+    void readStringNotSupported() throws IOException
+    {
+        final String json = a2q("{'name':'value'}");
+        byte[] data = _jsonDoc(json);
+
+        _testReadStringNotSupported(data, 0, 100);
+        _testReadStringNotSupported(data, 0, 3);
+        _testReadStringNotSupported(data, 0, 1);
+    }
+
+    private void _testReadStringNotSupported(byte[] data, int offset, int readSize)
+        throws IOException
+    {
+        try (AsyncReaderWrapper r = asyncForBytes(JSON_F, readSize, data, offset)) {
+            assertToken(JsonToken.START_OBJECT, r.nextToken());
+            assertToken(JsonToken.PROPERTY_NAME, r.nextToken());
+            assertEquals("name", r.currentName());
+            assertToken(JsonToken.VALUE_STRING, r.nextToken());
+            assertEquals("value", r.currentText());
+
+            // readString(Writer) should throw UnsupportedOperationException
+            Writer writer = new StringWriter();
+            UnsupportedOperationException ex = assertThrows(
+                UnsupportedOperationException.class,
+                () -> r.parser().readString(writer),
+                "Should throw UnsupportedOperationException for readString() on non-blocking parser"
+            );
+
+            assertTrue(ex.getMessage().contains("not supported for non-blocking"),
+                "Exception message should mention non-blocking parsers");
+            assertTrue(ex.getMessage().contains("readString"),
+                "Exception message should mention readString method");
+
+            assertToken(JsonToken.END_OBJECT, r.nextToken());
+        }
+    }
+
+    @Test
+    void readStringNotSupportedForVariousTokens() throws IOException
+    {
+        // Test with different token types to ensure consistent behavior
+        final String json = a2q("{'prop':'text','num':42,'flag':true,'nul':null}");
+        byte[] data = _jsonDoc(json);
+
+        try (AsyncReaderWrapper r = asyncForBytes(JSON_F, 100, data, 0)) {
+            assertToken(JsonToken.START_OBJECT, r.nextToken());
+
+            // Property name
+            assertToken(JsonToken.PROPERTY_NAME, r.nextToken());
+            Writer writer = new StringWriter();
+            assertThrows(UnsupportedOperationException.class,
+                () -> r.parser().readString(writer));
+
+            // String value
+            assertToken(JsonToken.VALUE_STRING, r.nextToken());
+            assertThrows(UnsupportedOperationException.class,
+                () -> r.parser().readString(writer));
+
+            // Number
+            assertToken(JsonToken.PROPERTY_NAME, r.nextToken());
+            assertToken(JsonToken.VALUE_NUMBER_INT, r.nextToken());
+            assertThrows(UnsupportedOperationException.class,
+                () -> r.parser().readString(writer));
+
+            // Boolean
+            assertToken(JsonToken.PROPERTY_NAME, r.nextToken());
+            assertToken(JsonToken.VALUE_TRUE, r.nextToken());
+            assertThrows(UnsupportedOperationException.class,
+                () -> r.parser().readString(writer));
+
+            // Null
+            assertToken(JsonToken.PROPERTY_NAME, r.nextToken());
+            assertToken(JsonToken.VALUE_NULL, r.nextToken());
+            assertThrows(UnsupportedOperationException.class,
+                () -> r.parser().readString(writer));
+
+            assertToken(JsonToken.END_OBJECT, r.nextToken());
+        }
+    }
+
+    @Test
+    void readStringNotSupportedWithLongString() throws IOException
+    {
+        // Test with a longer string to ensure it's not a length-related issue
+        final String longValue = "x".repeat(1000);
+        final String json = a2q("{'data':'" + longValue + "'}");
+        byte[] data = _jsonDoc(json);
+
+        try (AsyncReaderWrapper r = asyncForBytes(JSON_F, 100, data, 0)) {
+            assertToken(JsonToken.START_OBJECT, r.nextToken());
+            assertToken(JsonToken.PROPERTY_NAME, r.nextToken());
+            assertToken(JsonToken.VALUE_STRING, r.nextToken());
+
+            // Verify we can still read via getString()
+            assertEquals(longValue, r.currentText());
+
+            // But readString(Writer) should throw
+            Writer writer = new StringWriter();
+            UnsupportedOperationException ex = assertThrows(
+                UnsupportedOperationException.class,
+                () -> r.parser().readString(writer)
+            );
+
+            assertTrue(ex.getMessage().contains("not supported"));
+            assertToken(JsonToken.END_OBJECT, r.nextToken());
         }
     }
 }

--- a/src/test/java/tools/jackson/core/unittest/read/ReadStringStreamingTest.java
+++ b/src/test/java/tools/jackson/core/unittest/read/ReadStringStreamingTest.java
@@ -23,7 +23,7 @@ class ReadStringStreamingTest extends JacksonCoreTestBase
     private static final JsonFactory JSON_FACTORY = new JsonFactory();
 
     // Size of the intermediate output buffer used by _streamString
-    private static final int OUT_BUF_SIZE = 512;
+    private static final int OUT_BUF_SIZE = 1024;
 
     /*
     /**********************************************************
@@ -41,7 +41,7 @@ class ReadStringStreamingTest extends JacksonCoreTestBase
 
     private void _testEmptyString(int mode) throws Exception
     {
-        JsonParser p = createParser(mode, "[\"\"]");
+        JsonParser p = createParser(JSON_FACTORY, mode, "[\"\"]");
         assertToken(JsonToken.START_ARRAY, p.nextToken());
         assertToken(JsonToken.VALUE_STRING, p.nextToken());
 
@@ -64,7 +64,7 @@ class ReadStringStreamingTest extends JacksonCoreTestBase
 
     private void _testSingleCharString(int mode) throws Exception
     {
-        JsonParser p = createParser(mode, "[\"x\"]");
+        JsonParser p = createParser(JSON_FACTORY, mode, "[\"x\"]");
         assertToken(JsonToken.START_ARRAY, p.nextToken());
         assertToken(JsonToken.VALUE_STRING, p.nextToken());
 
@@ -96,7 +96,7 @@ class ReadStringStreamingTest extends JacksonCoreTestBase
         String json = "[\"\\\"  \\\\  \\/  \\b  \\f  \\n  \\r  \\t\"]";
         String expected = "\"  \\  /  \b  \f  \n  \r  \t";
 
-        JsonParser p = createParser(mode, json);
+        JsonParser p = createParser(JSON_FACTORY, mode, json);
         assertToken(JsonToken.START_ARRAY, p.nextToken());
         assertToken(JsonToken.VALUE_STRING, p.nextToken());
 
@@ -122,7 +122,7 @@ class ReadStringStreamingTest extends JacksonCoreTestBase
         String json = "[\"caf\\u00e9 \\u4e2d \\u0000\"]";
         String expected = "caf\u00e9 \u4e2d \u0000";
 
-        JsonParser p = createParser(mode, json);
+        JsonParser p = createParser(JSON_FACTORY, mode, json);
         assertToken(JsonToken.START_ARRAY, p.nextToken());
         assertToken(JsonToken.VALUE_STRING, p.nextToken());
 
@@ -151,7 +151,7 @@ class ReadStringStreamingTest extends JacksonCoreTestBase
         String json = "[\"" + prefix + "\\n\"]";
         String expected = prefix + "\n";
 
-        JsonParser p = createParser(mode, json);
+        JsonParser p = createParser(JSON_FACTORY, mode, json);
         assertToken(JsonToken.START_ARRAY, p.nextToken());
         assertToken(JsonToken.VALUE_STRING, p.nextToken());
 
@@ -217,7 +217,7 @@ class ReadStringStreamingTest extends JacksonCoreTestBase
     private void _testUtf8Value(int mode, String value) throws Exception
     {
         String json = "[" + q(value) + "]";
-        JsonParser p = createParser(mode, json);
+        JsonParser p = createParser(JSON_FACTORY, mode, json);
         assertToken(JsonToken.START_ARRAY, p.nextToken());
         assertToken(JsonToken.VALUE_STRING, p.nextToken());
 
@@ -265,7 +265,7 @@ class ReadStringStreamingTest extends JacksonCoreTestBase
         String value = "a".repeat(length);
         String json = "[" + q(value) + "]";
         for (int mode : ALL_MODES) {
-            JsonParser p = createParser(mode, json);
+            JsonParser p = createParser(JSON_FACTORY, mode, json);
             assertToken(JsonToken.START_ARRAY, p.nextToken());
             assertToken(JsonToken.VALUE_STRING, p.nextToken());
 
@@ -383,7 +383,7 @@ class ReadStringStreamingTest extends JacksonCoreTestBase
 
     private void _testReadStringOnPropertyName(int mode) throws Exception
     {
-        JsonParser p = createParser(mode, "{\"myKey\":\"myValue\"}");
+        JsonParser p = createParser(JSON_FACTORY, mode, "{\"myKey\":\"myValue\"}");
         assertToken(JsonToken.START_OBJECT, p.nextToken());
         assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
 
@@ -405,7 +405,7 @@ class ReadStringStreamingTest extends JacksonCoreTestBase
 
     private void _testReadStringOnNumberTokens(int mode) throws Exception
     {
-        JsonParser p = createParser(mode, "[42, 3.14]");
+        JsonParser p = createParser(JSON_FACTORY, mode, "[42, 3.14]");
         assertToken(JsonToken.START_ARRAY, p.nextToken());
 
         assertToken(JsonToken.VALUE_NUMBER_INT, p.nextToken());
@@ -431,7 +431,7 @@ class ReadStringStreamingTest extends JacksonCoreTestBase
 
     private void _testReadStringOnNullToken(int mode) throws Exception
     {
-        JsonParser p = createParser(mode, "[null]");
+        JsonParser p = createParser(JSON_FACTORY, mode, "[null]");
         assertToken(JsonToken.START_ARRAY, p.nextToken());
         assertToken(JsonToken.VALUE_NULL, p.nextToken());
 
@@ -454,7 +454,7 @@ class ReadStringStreamingTest extends JacksonCoreTestBase
     private void _testReadStringBeforeFirstToken(int mode) throws Exception
     {
         // No nextToken() called yet: current token is null, should return 0
-        JsonParser p = createParser(mode, "[\"x\"]");
+        JsonParser p = createParser(JSON_FACTORY, mode, "[\"x\"]");
         Writer w = new StringWriter();
         long len = p.readString(w);
         assertEquals(0L, len);
@@ -478,7 +478,7 @@ class ReadStringStreamingTest extends JacksonCoreTestBase
 
     private void _testConsumingSemantics(int mode) throws Exception
     {
-        JsonParser p = createParser(mode, "[\"hello\",\"world\"]");
+        JsonParser p = createParser(JSON_FACTORY, mode, "[\"hello\",\"world\"]");
         assertToken(JsonToken.START_ARRAY, p.nextToken());
 
         // First value
@@ -514,7 +514,7 @@ class ReadStringStreamingTest extends JacksonCoreTestBase
         String[] values = {"first", "second", "third"};
         String json = "[\"first\",\"second\",\"third\"]";
 
-        JsonParser p = createParser(mode, json);
+        JsonParser p = createParser(JSON_FACTORY, mode, json);
         assertToken(JsonToken.START_ARRAY, p.nextToken());
         for (String expected : values) {
             assertToken(JsonToken.VALUE_STRING, p.nextToken());
@@ -542,7 +542,7 @@ class ReadStringStreamingTest extends JacksonCoreTestBase
         String json = "[\"Hello \\n\\t\\u00e9 \\u4e2d\\u6587 \\uD83D\\uDE00 end\"]";
 
         for (int mode : ALL_MODES) {
-            JsonParser p = createParser(mode, json);
+            JsonParser p = createParser(JSON_FACTORY, mode, json);
             assertToken(JsonToken.START_ARRAY, p.nextToken());
             assertToken(JsonToken.VALUE_STRING, p.nextToken());
 
@@ -574,7 +574,7 @@ class ReadStringStreamingTest extends JacksonCoreTestBase
         String json = "[" + q(expected) + "]";
 
         for (int mode : ALL_MODES) {
-            JsonParser p = createParser(mode, json);
+            JsonParser p = createParser(JSON_FACTORY, mode, json);
             assertToken(JsonToken.START_ARRAY, p.nextToken());
             assertToken(JsonToken.VALUE_STRING, p.nextToken());
 
@@ -603,7 +603,7 @@ class ReadStringStreamingTest extends JacksonCoreTestBase
         String expected = "\n\t\r\"\\\u00e9";
 
         // Use throttled stream mode (reads 1 byte at a time)
-        JsonParser p = createParser(MODE_INPUT_STREAM_THROTTLED, json);
+        JsonParser p = createParser(JSON_FACTORY, MODE_INPUT_STREAM_THROTTLED, json);
         assertToken(JsonToken.START_ARRAY, p.nextToken());
         assertToken(JsonToken.VALUE_STRING, p.nextToken());
 
@@ -622,7 +622,7 @@ class ReadStringStreamingTest extends JacksonCoreTestBase
         String value = "abcdefghij".repeat(200); // 2000 chars
         String json = "[" + q(value) + "]";
 
-        JsonParser p = createParser(MODE_INPUT_STREAM_THROTTLED, json);
+        JsonParser p = createParser(JSON_FACTORY, MODE_INPUT_STREAM_THROTTLED, json);
         assertToken(JsonToken.START_ARRAY, p.nextToken());
         assertToken(JsonToken.VALUE_STRING, p.nextToken());
 

--- a/src/test/java/tools/jackson/core/unittest/read/ReadStringStreamingTest.java
+++ b/src/test/java/tools/jackson/core/unittest/read/ReadStringStreamingTest.java
@@ -17,6 +17,8 @@ import static org.junit.jupiter.api.Assertions.*;
 /**
  * Tests for {@link JsonParser#readString(Writer)} streaming functionality
  * (added for [core#1288]).
+ *
+ * @since 3.1
  */
 class ReadStringStreamingTest extends JacksonCoreTestBase
 {
@@ -26,9 +28,9 @@ class ReadStringStreamingTest extends JacksonCoreTestBase
     private static final int OUT_BUF_SIZE = 1024;
 
     /*
-    /**********************************************************
+    /**********************************************************************
     /* Empty and trivial strings
-    /**********************************************************
+    /**********************************************************************
      */
 
     @Test
@@ -64,22 +66,20 @@ class ReadStringStreamingTest extends JacksonCoreTestBase
 
     private void _testSingleCharString(int mode) throws Exception
     {
-        JsonParser p = createParser(JSON_FACTORY, mode, "[\"x\"]");
-        assertToken(JsonToken.START_ARRAY, p.nextToken());
-        assertToken(JsonToken.VALUE_STRING, p.nextToken());
-
-        Writer w = new StringWriter();
-        long len = p.readString(w);
-        assertEquals(1L, len);
-        assertEquals("x", w.toString());
-
-        p.close();
+        try (JsonParser p = createParser(JSON_FACTORY, mode, "[\"x\"]")) {
+            assertToken(JsonToken.START_ARRAY, p.nextToken());
+            assertToken(JsonToken.VALUE_STRING, p.nextToken());
+    
+            Writer w = new StringWriter();
+            assertEquals(1L, p.readString(w));
+            assertEquals("x", w.toString());
+        }
     }
 
     /*
-    /**********************************************************
+    /**********************************************************************
     /* Escape sequences
-    /**********************************************************
+    /**********************************************************************
      */
 
     @Test
@@ -96,16 +96,15 @@ class ReadStringStreamingTest extends JacksonCoreTestBase
         String json = "[\"\\\"  \\\\  \\/  \\b  \\f  \\n  \\r  \\t\"]";
         String expected = "\"  \\  /  \b  \f  \n  \r  \t";
 
-        JsonParser p = createParser(JSON_FACTORY, mode, json);
-        assertToken(JsonToken.START_ARRAY, p.nextToken());
-        assertToken(JsonToken.VALUE_STRING, p.nextToken());
-
-        Writer w = new StringWriter();
-        long len = p.readString(w);
-        assertEquals(expected, w.toString());
-        assertEquals((long) expected.length(), len);
-
-        p.close();
+        try (JsonParser p = createParser(JSON_FACTORY, mode, json)) {
+            assertToken(JsonToken.START_ARRAY, p.nextToken());
+            assertToken(JsonToken.VALUE_STRING, p.nextToken());
+        
+            Writer w = new StringWriter();
+            long len = p.readString(w);
+            assertEquals(expected, w.toString());
+            assertEquals((long) expected.length(), len);
+        }
     }
 
     @Test
@@ -122,16 +121,15 @@ class ReadStringStreamingTest extends JacksonCoreTestBase
         String json = "[\"caf\\u00e9 \\u4e2d \\u0000\"]";
         String expected = "caf\u00e9 \u4e2d \u0000";
 
-        JsonParser p = createParser(JSON_FACTORY, mode, json);
-        assertToken(JsonToken.START_ARRAY, p.nextToken());
-        assertToken(JsonToken.VALUE_STRING, p.nextToken());
-
-        Writer w = new StringWriter();
-        long len = p.readString(w);
-        assertEquals(expected, w.toString());
-        assertEquals((long) expected.length(), len);
-
-        p.close();
+        try (JsonParser p = createParser(JSON_FACTORY, mode, json)) {
+            assertToken(JsonToken.START_ARRAY, p.nextToken());
+            assertToken(JsonToken.VALUE_STRING, p.nextToken());
+    
+            Writer w = new StringWriter();
+            long len = p.readString(w);
+            assertEquals(expected, w.toString());
+            assertEquals((long) expected.length(), len);
+        }
     }
 
     @Test
@@ -151,22 +149,21 @@ class ReadStringStreamingTest extends JacksonCoreTestBase
         String json = "[\"" + prefix + "\\n\"]";
         String expected = prefix + "\n";
 
-        JsonParser p = createParser(JSON_FACTORY, mode, json);
-        assertToken(JsonToken.START_ARRAY, p.nextToken());
-        assertToken(JsonToken.VALUE_STRING, p.nextToken());
-
-        Writer w = new StringWriter();
-        long len = p.readString(w);
-        assertEquals(expected, w.toString());
-        assertEquals((long) expected.length(), len);
-
-        p.close();
+        try (JsonParser p = createParser(JSON_FACTORY, mode, json)) {
+            assertToken(JsonToken.START_ARRAY, p.nextToken());
+            assertToken(JsonToken.VALUE_STRING, p.nextToken());
+    
+            Writer w = new StringWriter();
+            long len = p.readString(w);
+            assertEquals(expected, w.toString());
+            assertEquals((long) expected.length(), len);
+        }
     }
 
     /*
-    /**********************************************************
+    /**********************************************************************
     /* Multi-byte UTF-8 (exercises binary-parser code paths)
-    /**********************************************************
+    /**********************************************************************
      */
 
     @Test
@@ -230,9 +227,9 @@ class ReadStringStreamingTest extends JacksonCoreTestBase
     }
 
     /*
-    /**********************************************************
+    /**********************************************************************
     /* Output-buffer boundary sizes
-    /**********************************************************
+    /**********************************************************************
      */
 
     @Test
@@ -279,9 +276,9 @@ class ReadStringStreamingTest extends JacksonCoreTestBase
     }
 
     /*
-    /**********************************************************
+    /**********************************************************************
     /* Constraint enforcement at boundaries
-    /**********************************************************
+    /**********************************************************************
      */
 
     @Test
@@ -368,9 +365,9 @@ class ReadStringStreamingTest extends JacksonCoreTestBase
     }
 
     /*
-    /**********************************************************
+    /**********************************************************************
     /* Other token types
-    /**********************************************************
+    /**********************************************************************
      */
 
     @Test
@@ -463,9 +460,9 @@ class ReadStringStreamingTest extends JacksonCoreTestBase
     }
 
     /*
-    /**********************************************************
+    /**********************************************************************
     /* Consuming semantics and sequential calls
-    /**********************************************************
+    /**********************************************************************
      */
 
     @Test
@@ -528,9 +525,9 @@ class ReadStringStreamingTest extends JacksonCoreTestBase
     }
 
     /*
-    /**********************************************************
+    /**********************************************************************
     /* Mixed content (ASCII + escapes + multi-byte)
-    /**********************************************************
+    /**********************************************************************
      */
 
     @Test
@@ -589,9 +586,9 @@ class ReadStringStreamingTest extends JacksonCoreTestBase
     }
 
     /*
-    /**********************************************************
+    /**********************************************************************
     /* Throttled (input buffer boundary) mode
-    /**********************************************************
+    /**********************************************************************
      */
 
     @Test
@@ -603,16 +600,15 @@ class ReadStringStreamingTest extends JacksonCoreTestBase
         String expected = "\n\t\r\"\\\u00e9";
 
         // Use throttled stream mode (reads 1 byte at a time)
-        JsonParser p = createParser(JSON_FACTORY, MODE_INPUT_STREAM_THROTTLED, json);
-        assertToken(JsonToken.START_ARRAY, p.nextToken());
-        assertToken(JsonToken.VALUE_STRING, p.nextToken());
-
-        Writer w = new StringWriter();
-        long len = p.readString(w);
-        assertEquals(expected, w.toString());
-        assertEquals((long) expected.length(), len);
-
-        p.close();
+        try (JsonParser p = createParser(JSON_FACTORY, MODE_INPUT_STREAM_THROTTLED, json)) {
+            assertToken(JsonToken.START_ARRAY, p.nextToken());
+            assertToken(JsonToken.VALUE_STRING, p.nextToken());
+    
+            Writer w = new StringWriter();
+            long len = p.readString(w);
+            assertEquals(expected, w.toString());
+            assertEquals((long) expected.length(), len);
+        }
     }
 
     @Test
@@ -622,15 +618,14 @@ class ReadStringStreamingTest extends JacksonCoreTestBase
         String value = "abcdefghij".repeat(200); // 2000 chars
         String json = "[" + q(value) + "]";
 
-        JsonParser p = createParser(JSON_FACTORY, MODE_INPUT_STREAM_THROTTLED, json);
-        assertToken(JsonToken.START_ARRAY, p.nextToken());
-        assertToken(JsonToken.VALUE_STRING, p.nextToken());
-
-        Writer w = new StringWriter();
-        long len = p.readString(w);
-        assertEquals(value, w.toString());
-        assertEquals(2000L, len);
-
-        p.close();
+        try (JsonParser p = createParser(JSON_FACTORY, MODE_INPUT_STREAM_THROTTLED, json)) {
+            assertToken(JsonToken.START_ARRAY, p.nextToken());
+            assertToken(JsonToken.VALUE_STRING, p.nextToken());
+    
+            Writer w = new StringWriter();
+            long len = p.readString(w);
+            assertEquals(value, w.toString());
+            assertEquals(2000L, len);
+        }
     }
 }

--- a/src/test/java/tools/jackson/core/unittest/read/ReadStringStreamingTest.java
+++ b/src/test/java/tools/jackson/core/unittest/read/ReadStringStreamingTest.java
@@ -1,0 +1,636 @@
+package tools.jackson.core.unittest.read;
+
+import java.io.StringWriter;
+import java.io.Writer;
+
+import org.junit.jupiter.api.Test;
+
+import tools.jackson.core.JsonParser;
+import tools.jackson.core.JsonToken;
+import tools.jackson.core.StreamReadConstraints;
+import tools.jackson.core.exc.StreamConstraintsException;
+import tools.jackson.core.json.JsonFactory;
+import tools.jackson.core.unittest.JacksonCoreTestBase;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for {@link JsonParser#readString(Writer)} streaming functionality
+ * (added for [core#1288]).
+ */
+class ReadStringStreamingTest extends JacksonCoreTestBase
+{
+    private static final JsonFactory JSON_FACTORY = new JsonFactory();
+
+    // Size of the intermediate output buffer used by _streamString
+    private static final int OUT_BUF_SIZE = 512;
+
+    /*
+    /**********************************************************
+    /* Empty and trivial strings
+    /**********************************************************
+     */
+
+    @Test
+    void emptyString() throws Exception
+    {
+        for (int mode : ALL_MODES) {
+            _testEmptyString(mode);
+        }
+    }
+
+    private void _testEmptyString(int mode) throws Exception
+    {
+        JsonParser p = createParser(mode, "[\"\"]");
+        assertToken(JsonToken.START_ARRAY, p.nextToken());
+        assertToken(JsonToken.VALUE_STRING, p.nextToken());
+
+        Writer w = new StringWriter();
+        long len = p.readString(w);
+        assertEquals(0L, len);
+        assertEquals("", w.toString());
+
+        assertToken(JsonToken.END_ARRAY, p.nextToken());
+        p.close();
+    }
+
+    @Test
+    void singleCharString() throws Exception
+    {
+        for (int mode : ALL_MODES) {
+            _testSingleCharString(mode);
+        }
+    }
+
+    private void _testSingleCharString(int mode) throws Exception
+    {
+        JsonParser p = createParser(mode, "[\"x\"]");
+        assertToken(JsonToken.START_ARRAY, p.nextToken());
+        assertToken(JsonToken.VALUE_STRING, p.nextToken());
+
+        Writer w = new StringWriter();
+        long len = p.readString(w);
+        assertEquals(1L, len);
+        assertEquals("x", w.toString());
+
+        p.close();
+    }
+
+    /*
+    /**********************************************************
+    /* Escape sequences
+    /**********************************************************
+     */
+
+    @Test
+    void commonEscapeSequences() throws Exception
+    {
+        for (int mode : ALL_MODES) {
+            _testCommonEscapeSequences(mode);
+        }
+    }
+
+    private void _testCommonEscapeSequences(int mode) throws Exception
+    {
+        // \", \\, \/, \b, \f, \n, \r, \t
+        String json = "[\"\\\"  \\\\  \\/  \\b  \\f  \\n  \\r  \\t\"]";
+        String expected = "\"  \\  /  \b  \f  \n  \r  \t";
+
+        JsonParser p = createParser(mode, json);
+        assertToken(JsonToken.START_ARRAY, p.nextToken());
+        assertToken(JsonToken.VALUE_STRING, p.nextToken());
+
+        Writer w = new StringWriter();
+        long len = p.readString(w);
+        assertEquals(expected, w.toString());
+        assertEquals((long) expected.length(), len);
+
+        p.close();
+    }
+
+    @Test
+    void unicodeEscapeSequences() throws Exception
+    {
+        for (int mode : ALL_MODES) {
+            _testUnicodeEscapeSequences(mode);
+        }
+    }
+
+    private void _testUnicodeEscapeSequences(int mode) throws Exception
+    {
+        // \u00e9 = é, \u4e2d = 中, \u0000 = NUL
+        String json = "[\"caf\\u00e9 \\u4e2d \\u0000\"]";
+        String expected = "caf\u00e9 \u4e2d \u0000";
+
+        JsonParser p = createParser(mode, json);
+        assertToken(JsonToken.START_ARRAY, p.nextToken());
+        assertToken(JsonToken.VALUE_STRING, p.nextToken());
+
+        Writer w = new StringWriter();
+        long len = p.readString(w);
+        assertEquals(expected, w.toString());
+        assertEquals((long) expected.length(), len);
+
+        p.close();
+    }
+
+    @Test
+    void escapesAtOutputBufferBoundary() throws Exception
+    {
+        // Put an escape sequence right at the 512-char flush boundary to
+        // ensure the flush-and-continue logic handles partially-seen escapes.
+        for (int mode : ALL_MODES) {
+            _testEscapesAtOutputBufferBoundary(mode);
+        }
+    }
+
+    private void _testEscapesAtOutputBufferBoundary(int mode) throws Exception
+    {
+        // Fill to one char before the buffer flush boundary, then place a \n escape
+        String prefix = "x".repeat(OUT_BUF_SIZE - 1);
+        String json = "[\"" + prefix + "\\n\"]";
+        String expected = prefix + "\n";
+
+        JsonParser p = createParser(mode, json);
+        assertToken(JsonToken.START_ARRAY, p.nextToken());
+        assertToken(JsonToken.VALUE_STRING, p.nextToken());
+
+        Writer w = new StringWriter();
+        long len = p.readString(w);
+        assertEquals(expected, w.toString());
+        assertEquals((long) expected.length(), len);
+
+        p.close();
+    }
+
+    /*
+    /**********************************************************
+    /* Multi-byte UTF-8 (exercises binary-parser code paths)
+    /**********************************************************
+     */
+
+    @Test
+    void twoByteUtf8() throws Exception
+    {
+        // é = U+00E9, encoded as 2 bytes in UTF-8
+        String value = "caf\u00e9";
+        for (int mode : ALL_BINARY_MODES) {
+            _testUtf8Value(mode, value);
+        }
+    }
+
+    @Test
+    void threeByteUtf8() throws Exception
+    {
+        // 中 = U+4E2D, encoded as 3 bytes in UTF-8
+        String value = "\u4e2d\u6587";
+        for (int mode : ALL_BINARY_MODES) {
+            _testUtf8Value(mode, value);
+        }
+    }
+
+    @Test
+    void surrogateRoundTrip() throws Exception
+    {
+        // 😀 = U+1F600, encoded as 4 bytes in UTF-8, represented as surrogate pair
+        // in Java: \uD83D\uDE00
+        String value = "\uD83D\uDE00 emoji \uD83D\uDE00";
+        for (int mode : ALL_BINARY_MODES) {
+            _testUtf8Value(mode, value);
+        }
+    }
+
+    @Test
+    void surrogateAtOutputBufferBoundary() throws Exception
+    {
+        // Place a surrogate-pair character right at the output buffer boundary
+        // to exercise the mid-surrogate flush path in _streamString.
+        // Surrogate pair takes 2 Java chars; put one char before flush boundary
+        // so the high surrogate falls exactly at position OUT_BUF_SIZE-1.
+        String prefix = "x".repeat(OUT_BUF_SIZE - 1);
+        String value = prefix + "\uD83D\uDE00" + "tail";
+        for (int mode : ALL_BINARY_MODES) {
+            _testUtf8Value(mode, value);
+        }
+    }
+
+    private void _testUtf8Value(int mode, String value) throws Exception
+    {
+        String json = "[" + q(value) + "]";
+        JsonParser p = createParser(mode, json);
+        assertToken(JsonToken.START_ARRAY, p.nextToken());
+        assertToken(JsonToken.VALUE_STRING, p.nextToken());
+
+        Writer w = new StringWriter();
+        long len = p.readString(w);
+        assertEquals(value, w.toString(), "mode=" + mode);
+        assertEquals((long) value.length(), len, "mode=" + mode);
+
+        p.close();
+    }
+
+    /*
+    /**********************************************************
+    /* Output-buffer boundary sizes
+    /**********************************************************
+     */
+
+    @Test
+    void stringExactlyAtOutputBufferSize() throws Exception
+    {
+        // exactly 512 chars: buffer fills completely, then closing quote arrives
+        _testStringOfLength(OUT_BUF_SIZE);
+    }
+
+    @Test
+    void stringOneOverOutputBufferSize() throws Exception
+    {
+        _testStringOfLength(OUT_BUF_SIZE + 1);
+    }
+
+    @Test
+    void stringTwoFullOutputBuffers() throws Exception
+    {
+        _testStringOfLength(OUT_BUF_SIZE * 2);
+    }
+
+    @Test
+    void stringTwoFullOutputBuffersPlusOne() throws Exception
+    {
+        _testStringOfLength(OUT_BUF_SIZE * 2 + 1);
+    }
+
+    private void _testStringOfLength(int length) throws Exception
+    {
+        String value = "a".repeat(length);
+        String json = "[" + q(value) + "]";
+        for (int mode : ALL_MODES) {
+            JsonParser p = createParser(mode, json);
+            assertToken(JsonToken.START_ARRAY, p.nextToken());
+            assertToken(JsonToken.VALUE_STRING, p.nextToken());
+
+            Writer w = new StringWriter();
+            long len = p.readString(w);
+            assertEquals((long) length, len, "mode=" + mode + ", length=" + length);
+            assertEquals(value, w.toString(), "mode=" + mode + ", length=" + length);
+
+            p.close();
+        }
+    }
+
+    /*
+    /**********************************************************
+    /* Constraint enforcement at boundaries
+    /**********************************************************
+     */
+
+    @Test
+    void constraintAtExactLimit() throws Exception
+    {
+        // A string of exactly maxLen chars must NOT throw
+        for (int mode : ALL_MODES) {
+            _testConstraintAtExactLimit(mode);
+        }
+    }
+
+    private void _testConstraintAtExactLimit(int mode) throws Exception
+    {
+        final int maxLen = 1000;
+        String value = "x".repeat(maxLen);
+        JsonFactory f = JsonFactory.builder()
+                .streamReadConstraints(StreamReadConstraints.builder().maxStringLength(maxLen).build())
+                .build();
+
+        JsonParser p = createParser(f, mode, "[" + q(value) + "]");
+        assertToken(JsonToken.START_ARRAY, p.nextToken());
+        assertToken(JsonToken.VALUE_STRING, p.nextToken());
+
+        Writer w = new StringWriter();
+        long len = p.readString(w);
+        assertEquals((long) maxLen, len, "mode=" + mode);
+        assertEquals(value, w.toString(), "mode=" + mode);
+
+        p.close();
+    }
+
+    @Test
+    void constraintOneLargerThanFlushBoundary() throws Exception
+    {
+        // maxLen set to OUT_BUF_SIZE - 1, so violation is detected at first flush
+        for (int mode : ALL_MODES) {
+            _testConstraintOneLargerThanFlushBoundary(mode);
+        }
+    }
+
+    private void _testConstraintOneLargerThanFlushBoundary(int mode) throws Exception
+    {
+        final int maxLen = OUT_BUF_SIZE - 1;
+        String value = "x".repeat(OUT_BUF_SIZE + 100); // clearly over limit
+        JsonFactory f = JsonFactory.builder()
+                .streamReadConstraints(StreamReadConstraints.builder().maxStringLength(maxLen).build())
+                .build();
+
+        JsonParser p = createParser(f, mode, "[" + q(value) + "]");
+        assertToken(JsonToken.START_ARRAY, p.nextToken());
+        assertToken(JsonToken.VALUE_STRING, p.nextToken());
+
+        Writer w = new StringWriter();
+        assertThrows(StreamConstraintsException.class, () -> p.readString(w), "mode=" + mode);
+
+        p.close();
+    }
+
+    @Test
+    void constraintExactlyAtFlushBoundary() throws Exception
+    {
+        // maxLen set to OUT_BUF_SIZE, so a string of OUT_BUF_SIZE+1 triggers it
+        for (int mode : ALL_MODES) {
+            _testConstraintExactlyAtFlushBoundary(mode);
+        }
+    }
+
+    private void _testConstraintExactlyAtFlushBoundary(int mode) throws Exception
+    {
+        final int maxLen = OUT_BUF_SIZE;
+        String value = "x".repeat(OUT_BUF_SIZE + 1);
+        JsonFactory f = JsonFactory.builder()
+                .streamReadConstraints(StreamReadConstraints.builder().maxStringLength(maxLen).build())
+                .build();
+
+        JsonParser p = createParser(f, mode, "[" + q(value) + "]");
+        assertToken(JsonToken.START_ARRAY, p.nextToken());
+        assertToken(JsonToken.VALUE_STRING, p.nextToken());
+
+        Writer w = new StringWriter();
+        assertThrows(StreamConstraintsException.class, () -> p.readString(w), "mode=" + mode);
+
+        p.close();
+    }
+
+    /*
+    /**********************************************************
+    /* Other token types
+    /**********************************************************
+     */
+
+    @Test
+    void readStringOnPropertyName() throws Exception
+    {
+        for (int mode : ALL_MODES) {
+            _testReadStringOnPropertyName(mode);
+        }
+    }
+
+    private void _testReadStringOnPropertyName(int mode) throws Exception
+    {
+        JsonParser p = createParser(mode, "{\"myKey\":\"myValue\"}");
+        assertToken(JsonToken.START_OBJECT, p.nextToken());
+        assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
+
+        Writer w = new StringWriter();
+        long len = p.readString(w);
+        assertEquals("myKey", w.toString());
+        assertEquals(5L, len);
+
+        p.close();
+    }
+
+    @Test
+    void readStringOnNumberTokens() throws Exception
+    {
+        for (int mode : ALL_MODES) {
+            _testReadStringOnNumberTokens(mode);
+        }
+    }
+
+    private void _testReadStringOnNumberTokens(int mode) throws Exception
+    {
+        JsonParser p = createParser(mode, "[42, 3.14]");
+        assertToken(JsonToken.START_ARRAY, p.nextToken());
+
+        assertToken(JsonToken.VALUE_NUMBER_INT, p.nextToken());
+        Writer w = new StringWriter();
+        p.readString(w);
+        assertEquals("42", w.toString());
+
+        assertToken(JsonToken.VALUE_NUMBER_FLOAT, p.nextToken());
+        w = new StringWriter();
+        p.readString(w);
+        assertEquals("3.14", w.toString());
+
+        p.close();
+    }
+
+    @Test
+    void readStringOnNullToken() throws Exception
+    {
+        for (int mode : ALL_MODES) {
+            _testReadStringOnNullToken(mode);
+        }
+    }
+
+    private void _testReadStringOnNullToken(int mode) throws Exception
+    {
+        JsonParser p = createParser(mode, "[null]");
+        assertToken(JsonToken.START_ARRAY, p.nextToken());
+        assertToken(JsonToken.VALUE_NULL, p.nextToken());
+
+        Writer w = new StringWriter();
+        long len = p.readString(w);
+        assertEquals("null", w.toString());
+        assertEquals(4L, len);
+
+        p.close();
+    }
+
+    @Test
+    void readStringBeforeFirstToken() throws Exception
+    {
+        for (int mode : ALL_MODES) {
+            _testReadStringBeforeFirstToken(mode);
+        }
+    }
+
+    private void _testReadStringBeforeFirstToken(int mode) throws Exception
+    {
+        // No nextToken() called yet: current token is null, should return 0
+        JsonParser p = createParser(mode, "[\"x\"]");
+        Writer w = new StringWriter();
+        long len = p.readString(w);
+        assertEquals(0L, len);
+        assertEquals("", w.toString());
+        p.close();
+    }
+
+    /*
+    /**********************************************************
+    /* Consuming semantics and sequential calls
+    /**********************************************************
+     */
+
+    @Test
+    void consumingSemantics() throws Exception
+    {
+        for (int mode : ALL_MODES) {
+            _testConsumingSemantics(mode);
+        }
+    }
+
+    private void _testConsumingSemantics(int mode) throws Exception
+    {
+        JsonParser p = createParser(mode, "[\"hello\",\"world\"]");
+        assertToken(JsonToken.START_ARRAY, p.nextToken());
+
+        // First value
+        assertToken(JsonToken.VALUE_STRING, p.nextToken());
+        Writer w = new StringWriter();
+        long len = p.readString(w);
+        assertEquals("hello", w.toString());
+        assertEquals(5L, len);
+        // getString() after readString() must return empty
+        assertEquals("", p.getString());
+
+        // Second value -- parser must have advanced past "hello"
+        assertToken(JsonToken.VALUE_STRING, p.nextToken());
+        w = new StringWriter();
+        len = p.readString(w);
+        assertEquals("world", w.toString());
+        assertEquals(5L, len);
+
+        assertToken(JsonToken.END_ARRAY, p.nextToken());
+        p.close();
+    }
+
+    @Test
+    void multipleStringsInArray() throws Exception
+    {
+        for (int mode : ALL_MODES) {
+            _testMultipleStringsInArray(mode);
+        }
+    }
+
+    private void _testMultipleStringsInArray(int mode) throws Exception
+    {
+        String[] values = {"first", "second", "third"};
+        String json = "[\"first\",\"second\",\"third\"]";
+
+        JsonParser p = createParser(mode, json);
+        assertToken(JsonToken.START_ARRAY, p.nextToken());
+        for (String expected : values) {
+            assertToken(JsonToken.VALUE_STRING, p.nextToken());
+            Writer w = new StringWriter();
+            long len = p.readString(w);
+            assertEquals(expected, w.toString(), "mode=" + mode);
+            assertEquals((long) expected.length(), len, "mode=" + mode);
+        }
+        assertToken(JsonToken.END_ARRAY, p.nextToken());
+        p.close();
+    }
+
+    /*
+    /**********************************************************
+    /* Mixed content (ASCII + escapes + multi-byte)
+    /**********************************************************
+     */
+
+    @Test
+    void mixedContent() throws Exception
+    {
+        // ASCII, escape sequences, and non-ASCII chars all in one string
+        String expected = "Hello \n\t\u00e9 \u4e2d\u6587 \uD83D\uDE00 end";
+        // Build the JSON manually so it round-trips correctly
+        String json = "[\"Hello \\n\\t\\u00e9 \\u4e2d\\u6587 \\uD83D\\uDE00 end\"]";
+
+        for (int mode : ALL_MODES) {
+            JsonParser p = createParser(mode, json);
+            assertToken(JsonToken.START_ARRAY, p.nextToken());
+            assertToken(JsonToken.VALUE_STRING, p.nextToken());
+
+            Writer w = new StringWriter();
+            long len = p.readString(w);
+            assertEquals(expected, w.toString(), "mode=" + mode);
+            assertEquals((long) expected.length(), len, "mode=" + mode);
+
+            p.close();
+        }
+    }
+
+    @Test
+    void longMixedContent() throws Exception
+    {
+        // Long string (> OUT_BUF_SIZE) with interspersed non-ASCII chars.
+        // Control characters are excluded since q() doesn't escape them;
+        // those code paths are covered by the dedicated escape tests.
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < 50; i++) {
+            sb.append("ASCII_block_");
+            sb.append("\u00e9"); // 2-byte UTF-8
+            sb.append("\u4e2d"); // 3-byte UTF-8
+            sb.append("\uD83D\uDE00"); // surrogate pair (4-byte UTF-8)
+        }
+        String expected = sb.toString();
+        // Use getString() to get the parser's own encoding of the value,
+        // then verify readString() produces identical output.
+        String json = "[" + q(expected) + "]";
+
+        for (int mode : ALL_MODES) {
+            JsonParser p = createParser(mode, json);
+            assertToken(JsonToken.START_ARRAY, p.nextToken());
+            assertToken(JsonToken.VALUE_STRING, p.nextToken());
+
+            Writer w = new StringWriter();
+            long len = p.readString(w);
+            assertEquals(expected.length(), w.toString().length(), "mode=" + mode);
+            assertEquals(expected, w.toString(), "mode=" + mode);
+            assertEquals((long) expected.length(), len, "mode=" + mode);
+
+            p.close();
+        }
+    }
+
+    /*
+    /**********************************************************
+    /* Throttled (input buffer boundary) mode
+    /**********************************************************
+     */
+
+    @Test
+    void escapeSplitAcrossInputChunks() throws Exception
+    {
+        // In throttled mode (1 byte at a time), escape sequences will be split
+        // across input loads. Verify correctness with all escape types.
+        String json = "[\"\\n\\t\\r\\\"\\\\\\u00e9\"]";
+        String expected = "\n\t\r\"\\\u00e9";
+
+        // Use throttled stream mode (reads 1 byte at a time)
+        JsonParser p = createParser(MODE_INPUT_STREAM_THROTTLED, json);
+        assertToken(JsonToken.START_ARRAY, p.nextToken());
+        assertToken(JsonToken.VALUE_STRING, p.nextToken());
+
+        Writer w = new StringWriter();
+        long len = p.readString(w);
+        assertEquals(expected, w.toString());
+        assertEquals((long) expected.length(), len);
+
+        p.close();
+    }
+
+    @Test
+    void longStringThrottled() throws Exception
+    {
+        // Long string in throttled mode: stresses input-buffer-boundary logic
+        String value = "abcdefghij".repeat(200); // 2000 chars
+        String json = "[" + q(value) + "]";
+
+        JsonParser p = createParser(MODE_INPUT_STREAM_THROTTLED, json);
+        assertToken(JsonToken.START_ARRAY, p.nextToken());
+        assertToken(JsonToken.VALUE_STRING, p.nextToken());
+
+        Writer w = new StringWriter();
+        long len = p.readString(w);
+        assertEquals(value, w.toString());
+        assertEquals(2000L, len);
+
+        p.close();
+    }
+}

--- a/src/test/java/tools/jackson/core/unittest/read/SimpleParserTest.java
+++ b/src/test/java/tools/jackson/core/unittest/read/SimpleParserTest.java
@@ -13,6 +13,7 @@ import tools.jackson.core.ObjectReadContext;
 import tools.jackson.core.ObjectWriteContext;
 import tools.jackson.core.TokenStreamContext;
 import tools.jackson.core.TokenStreamLocation;
+import tools.jackson.core.StreamReadConstraints;
 import tools.jackson.core.exc.StreamReadException;
 import tools.jackson.core.json.JsonFactory;
 import tools.jackson.core.unittest.*;
@@ -635,6 +636,91 @@ class SimpleParserTest extends JacksonCoreTestBase
         String resultString = writer.toString();
         assertEquals(len, resultString.length());
         assertEquals(longText, resultString);
+        parser.close();
+    }
+
+    @Test
+    void readTextConsumesString() throws Exception
+    {
+        for (int mode : ALL_MODES) {
+            _testReadTextConsumesString(mode);
+        }
+    }
+
+    private void _testReadTextConsumesString(int mode) throws Exception
+    {
+        final String INPUT_TEXT = "this is a sample text for json parsing using readText() method";
+        final String JSON = "{\"a\":\""+INPUT_TEXT+"\",\"b\":true,\"c\":null,\"d\":\"foobar!\"}";
+        JsonParser parser = createParser(mode, JSON);
+
+        assertToken(JsonToken.START_OBJECT, parser.nextToken());
+        assertToken(JsonToken.PROPERTY_NAME, parser.nextToken());
+        assertEquals("a", parser.currentName());
+        assertToken(JsonToken.VALUE_STRING, parser.nextToken());
+
+        Writer writer = new StringWriter();
+        int len = parser.readText(writer);
+        String resultString = writer.toString();
+        assertEquals(len, resultString.length());
+        assertEquals(INPUT_TEXT, resultString);
+
+        assertEquals("", parser.getString());
+
+        assertToken(JsonToken.PROPERTY_NAME, parser.nextToken());
+        assertEquals("b", parser.currentName());
+        assertToken(JsonToken.VALUE_TRUE, parser.nextToken());
+        writer = new StringWriter();
+        len = parser.readText(writer);
+        assertEquals("true", writer.toString());
+        assertEquals(len, writer.toString().length());
+
+        assertToken(JsonToken.PROPERTY_NAME, parser.nextToken());
+        assertEquals("c", parser.currentName());
+        assertToken(JsonToken.VALUE_NULL, parser.nextToken());
+        writer = new StringWriter();
+        len = parser.readText(writer);
+        assertEquals("null", writer.toString());
+        assertEquals(len, writer.toString().length());
+
+        assertToken(JsonToken.PROPERTY_NAME, parser.nextToken());
+        assertEquals("d", parser.currentName());
+        assertToken(JsonToken.VALUE_STRING, parser.nextToken());
+        writer = new StringWriter();
+        len = parser.readText(writer);
+        assertEquals("foobar!", writer.toString());
+        assertEquals(len, writer.toString().length());
+
+        parser.close();
+    }
+
+    @Test
+    void readTextOverMaxStringLength() throws Exception
+    {
+        for (int mode : ALL_MODES) {
+            _testReadTextOverMaxStringLength(mode);
+        }
+    }
+
+    private void _testReadTextOverMaxStringLength(int mode) throws Exception
+    {
+        final int maxLen = 1000;
+        final String longText = "x".repeat(100_000);
+        final String JSON = "{\"a\":\""+longText+"\"}";
+
+        JsonFactory factory = JsonFactory.builder()
+                .streamReadConstraints(StreamReadConstraints.builder().maxStringLength(maxLen).build())
+                .build();
+
+        JsonParser parser = createParser(factory, mode, JSON);
+        assertToken(JsonToken.START_OBJECT, parser.nextToken());
+        assertToken(JsonToken.PROPERTY_NAME, parser.nextToken());
+        assertEquals("a", parser.currentName());
+        assertToken(JsonToken.VALUE_STRING, parser.nextToken());
+
+        Writer writer = new StringWriter();
+        assertDoesNotThrow(() -> parser.readText(writer));
+        assertEquals(longText, writer.toString());
+
         parser.close();
     }
 

--- a/src/test/java/tools/jackson/core/unittest/read/SimpleParserTest.java
+++ b/src/test/java/tools/jackson/core/unittest/read/SimpleParserTest.java
@@ -14,6 +14,7 @@ import tools.jackson.core.ObjectWriteContext;
 import tools.jackson.core.TokenStreamContext;
 import tools.jackson.core.TokenStreamLocation;
 import tools.jackson.core.StreamReadConstraints;
+import tools.jackson.core.exc.StreamConstraintsException;
 import tools.jackson.core.exc.StreamReadException;
 import tools.jackson.core.json.JsonFactory;
 import tools.jackson.core.unittest.*;
@@ -575,7 +576,7 @@ class SimpleParserTest extends JacksonCoreTestBase
 
     private void _testGetTextViaWriter(int mode)
     {
-        final String INPUT_TEXT = "this is a sample text for json parsing using readText() method";
+        final String INPUT_TEXT = "this is a sample text for json parsing using readString() method";
         final String JSON = "{\"a\":\""+INPUT_TEXT+"\",\"b\":true,\"c\":null,\"d\":\"foobar!\"}";
         JsonParser parser = createParser(mode, JSON);
         assertToken(JsonToken.START_OBJECT, parser.nextToken());
@@ -640,16 +641,16 @@ class SimpleParserTest extends JacksonCoreTestBase
     }
 
     @Test
-    void readTextConsumesString() throws Exception
+    void readStringConsumesString() throws Exception
     {
         for (int mode : ALL_MODES) {
-            _testReadTextConsumesString(mode);
+            _testReadStringConsumesString(mode);
         }
     }
 
-    private void _testReadTextConsumesString(int mode) throws Exception
+    private void _testReadStringConsumesString(int mode) throws Exception
     {
-        final String INPUT_TEXT = "this is a sample text for json parsing using readText() method";
+        final String INPUT_TEXT = "this is a sample text for json parsing using readString() method";
         final String JSON = "{\"a\":\""+INPUT_TEXT+"\",\"b\":true,\"c\":null,\"d\":\"foobar!\"}";
         JsonParser parser = createParser(mode, JSON);
 
@@ -659,7 +660,7 @@ class SimpleParserTest extends JacksonCoreTestBase
         assertToken(JsonToken.VALUE_STRING, parser.nextToken());
 
         Writer writer = new StringWriter();
-        int len = parser.readText(writer);
+        long len = parser.readString(writer);
         String resultString = writer.toString();
         assertEquals(len, resultString.length());
         assertEquals(INPUT_TEXT, resultString);
@@ -670,7 +671,7 @@ class SimpleParserTest extends JacksonCoreTestBase
         assertEquals("b", parser.currentName());
         assertToken(JsonToken.VALUE_TRUE, parser.nextToken());
         writer = new StringWriter();
-        len = parser.readText(writer);
+        len = parser.readString(writer);
         assertEquals("true", writer.toString());
         assertEquals(len, writer.toString().length());
 
@@ -678,7 +679,7 @@ class SimpleParserTest extends JacksonCoreTestBase
         assertEquals("c", parser.currentName());
         assertToken(JsonToken.VALUE_NULL, parser.nextToken());
         writer = new StringWriter();
-        len = parser.readText(writer);
+        len = parser.readString(writer);
         assertEquals("null", writer.toString());
         assertEquals(len, writer.toString().length());
 
@@ -686,7 +687,7 @@ class SimpleParserTest extends JacksonCoreTestBase
         assertEquals("d", parser.currentName());
         assertToken(JsonToken.VALUE_STRING, parser.nextToken());
         writer = new StringWriter();
-        len = parser.readText(writer);
+        len = parser.readString(writer);
         assertEquals("foobar!", writer.toString());
         assertEquals(len, writer.toString().length());
 
@@ -694,14 +695,14 @@ class SimpleParserTest extends JacksonCoreTestBase
     }
 
     @Test
-    void readTextOverMaxStringLength() throws Exception
+    void readStringEnforcesMaxStringLength() throws Exception
     {
         for (int mode : ALL_MODES) {
-            _testReadTextOverMaxStringLength(mode);
+            _testReadStringEnforcesMaxStringLength(mode);
         }
     }
 
-    private void _testReadTextOverMaxStringLength(int mode) throws Exception
+    private void _testReadStringEnforcesMaxStringLength(int mode) throws Exception
     {
         final int maxLen = 1000;
         final String longText = "x".repeat(100_000);
@@ -718,7 +719,40 @@ class SimpleParserTest extends JacksonCoreTestBase
         assertToken(JsonToken.VALUE_STRING, parser.nextToken());
 
         Writer writer = new StringWriter();
-        assertDoesNotThrow(() -> parser.readText(writer));
+        StreamConstraintsException ex = assertThrows(StreamConstraintsException.class,
+                () -> parser.readString(writer));
+        assertTrue(ex.getMessage().contains("String value length"));
+        assertTrue(ex.getMessage().contains("exceeds the maximum allowed"));
+
+        parser.close();
+    }
+
+    @Test
+    void readStringWithIncreasedLimit() throws Exception
+    {
+        for (int mode : ALL_MODES) {
+            _testReadStringWithIncreasedLimit(mode);
+        }
+    }
+
+    private void _testReadStringWithIncreasedLimit(int mode) throws Exception
+    {
+        final String longText = "x".repeat(100_000);
+        final String JSON = "{\"a\":\""+longText+"\"}";
+
+        JsonFactory factory = JsonFactory.builder()
+                .streamReadConstraints(StreamReadConstraints.builder().maxStringLength(200_000).build())
+                .build();
+
+        JsonParser parser = createParser(factory, mode, JSON);
+        assertToken(JsonToken.START_OBJECT, parser.nextToken());
+        assertToken(JsonToken.PROPERTY_NAME, parser.nextToken());
+        assertEquals("a", parser.currentName());
+        assertToken(JsonToken.VALUE_STRING, parser.nextToken());
+
+        Writer writer = new StringWriter();
+        long len = parser.readString(writer);
+        assertEquals(100_000L, len);
         assertEquals(longText, writer.toString());
 
         parser.close();


### PR DESCRIPTION
Implements #1288 (originally #15) to support streaming large JSON string values without buffering entire content in memory.
