### PR TITLE
Add test for nesting for `DataInput`-backed `JsonParser`

### DIFF
--- a/src/test/java/com/fasterxml/jackson/core/constraints/DeeplyNestedContentReadTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/constraints/DeeplyNestedContentReadTest.java
@@ -10,10 +10,12 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Unit test(s) for verifying handling of new (in 2.15) StreamReadConstraints
- * wrt maximum nesting depth.
+ * wrt maximum nesting depth, for all streaming (InputStream,
+ * Reader; regular/throttled) inputs and {@link DataInput}.
+ * 
  */
 class DeeplyNestedContentReadTest
-        extends com.fasterxml.jackson.core.JUnit5TestBase
+    extends com.fasterxml.jackson.core.JUnit5TestBase
 {
     private final JsonFactory JSON_F = newStreamFactory();
 
@@ -32,6 +34,15 @@ class DeeplyNestedContentReadTest
         }
     }
 
+    @Test
+    void deepNestingDataInput() throws Exception
+    {
+        final String DOC = createDeepNestedDoc(TESTED_NESTING);
+        try (JsonParser p = createParser(JSON_F, MODE_DATA_INPUT, DOC)) {
+            _testDeepNesting(p);
+        }
+    }
+
     private void _testDeepNesting(JsonParser p) throws Exception
     {
         try {
@@ -44,7 +55,7 @@ class DeeplyNestedContentReadTest
     }
 
     @Test
-    void legacyConstraintSettingTest() throws Exception
+    void legacyConstraintSettingStreaming() throws Exception
     {
         final int LOWER_MAX = 40;
         
@@ -56,6 +67,20 @@ class DeeplyNestedContentReadTest
             try (JsonParser p = createParser(f, mode, DOC)) {
                 _testLegacyConstraintSettingTest(p, LOWER_MAX);
             }
+        }
+    }
+
+    @Test
+    void legacyConstraintSettingDataInput() throws Exception
+    {
+        final int LOWER_MAX = 40;
+        
+        final String DOC = createDeepNestedDoc(LOWER_MAX + 10);
+        JsonFactory f = new JsonFactory();
+        f.setStreamReadConstraints(StreamReadConstraints.builder()
+                .maxNestingDepth(LOWER_MAX).build());
+        try (JsonParser p = createParser(f, MODE_DATA_INPUT, DOC)) {
+            _testLegacyConstraintSettingTest(p, LOWER_MAX);
         }
     }
 

--- a/src/test/java/com/fasterxml/jackson/core/constraints/DeeplyNestedContentViaDataInputTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/constraints/DeeplyNestedContentViaDataInputTest.java
@@ -1,6 +1,7 @@
 package com.fasterxml.jackson.core.constraints;
 
 import java.io.*;
+import java.nio.charset.StandardCharsets;
 
 import org.junit.jupiter.api.Test;
 
@@ -12,7 +13,7 @@ import static org.junit.jupiter.api.Assertions.*;
 /**
  * Nesting Depth Constraint Bypass in UTF8DataInputJsonParser
  */
-class NestingDepthBypassDataInputTest {
+class DeeplyNestedContentViaDataInputTest {
 
     private static final int TEST_NESTING_DEPTH = 5000;
 
@@ -23,15 +24,14 @@ class NestingDepthBypassDataInputTest {
         byte[] data = buildNestedArrays(TEST_NESTING_DEPTH);
         DataInput di = new DataInputStream(new ByteArrayInputStream(data));
 
-        //Output to console
+        int maxDepth = 0;
         try (JsonParser p = factory.createParser(di)) {
-            int maxDepth = 0;
             while (p.nextToken() != null) {
                 if (p.currentToken() == JsonToken.START_ARRAY) {
                     maxDepth++;
                 }
             }
-            fail("DataInput parser must reject nesting depth " + TEST_NESTING_DEPTH);
+            fail("DataInput parser must reject nesting depth " + TEST_NESTING_DEPTH+", got "+maxDepth);
         } catch (StreamConstraintsException e) {
             assertTrue(e.getMessage().contains("Document nesting depth"),
                     "Unexpected exception message: " + e.getMessage());
@@ -42,6 +42,6 @@ class NestingDepthBypassDataInputTest {
         StringBuilder sb = new StringBuilder(depth * 2);
         for (int i = 0; i < depth; i++) sb.append('[');
         for (int i = 0; i < depth; i++) sb.append(']');
-        return sb.toString().getBytes(java.nio.charset.StandardCharsets.UTF_8);
+        return sb.toString().getBytes(StandardCharsets.UTF_8);
     }
 }

--- a/src/test/java/com/fasterxml/jackson/core/constraints/NestingDepthBypassDataInputTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/constraints/NestingDepthBypassDataInputTest.java
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.core.*;
 import com.fasterxml.jackson.core.exc.StreamConstraintsException;
-import com.fasterxml.jackson.core.json.JsonFactory;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -25,7 +24,7 @@ class NestingDepthBypassDataInputTest {
         DataInput di = new DataInputStream(new ByteArrayInputStream(data));
 
         //Output to console
-        try (JsonParser p = factory.createParser(ObjectReadContext.empty(), di)) {
+        try (JsonParser p = factory.createParser(di)) {
             int maxDepth = 0;
             while (p.nextToken() != null) {
                 if (p.currentToken() == JsonToken.START_ARRAY) {

--- a/src/test/java/com/fasterxml/jackson/core/constraints/NestingDepthBypassDataInputTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/constraints/NestingDepthBypassDataInputTest.java
@@ -33,7 +33,8 @@ class NestingDepthBypassDataInputTest {
             }
             fail("DataInput parser must reject nesting depth " + TEST_NESTING_DEPTH);
         } catch (StreamConstraintsException e) {
-            //expected
+            assertTrue(e.getMessage().contains("Document nesting depth"),
+                    "Unexpected exception message: " + e.getMessage());
         }
     }
 

--- a/src/test/java/com/fasterxml/jackson/core/constraints/NestingDepthBypassDataInputTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/constraints/NestingDepthBypassDataInputTest.java
@@ -1,0 +1,47 @@
+package com.fasterxml.jackson.core.constraints;
+
+import java.io.*;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.core.*;
+import com.fasterxml.jackson.core.exc.StreamConstraintsException;
+import com.fasterxml.jackson.core.json.JsonFactory;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Nesting Depth Constraint Bypass in UTF8DataInputJsonParser
+ */
+class NestingDepthBypassDataInputTest {
+
+    private static final int TEST_NESTING_DEPTH = 5000;
+
+    private final JsonFactory factory = new JsonFactory();
+
+    @Test
+    void dataInputParserBypassesNestingDepth() throws Exception {
+        byte[] data = buildNestedArrays(TEST_NESTING_DEPTH);
+        DataInput di = new DataInputStream(new ByteArrayInputStream(data));
+
+        //Output to console
+        try (JsonParser p = factory.createParser(ObjectReadContext.empty(), di)) {
+            int maxDepth = 0;
+            while (p.nextToken() != null) {
+                if (p.currentToken() == JsonToken.START_ARRAY) {
+                    maxDepth++;
+                }
+            }
+            fail("DataInput parser must reject nesting depth " + TEST_NESTING_DEPTH);
+        } catch (StreamConstraintsException e) {
+            //expected
+        }
+    }
+
+    private byte[] buildNestedArrays(int depth) {
+        StringBuilder sb = new StringBuilder(depth * 2);
+        for (int i = 0; i < depth; i++) sb.append('[');
+        for (int i = 0; i < depth; i++) sb.append(']');
+        return sb.toString().getBytes(java.nio.charset.StandardCharsets.UTF_8);
+    }
+}


### PR DESCRIPTION
I tried this against 2.18 but ran into issues with missing snapshots in central.sonatype.com.

We have already discussed the 3.x version of this which turns out to be different. This test passes as is in 2.21.