### PR TITLE
Fix #1570: fail on DataInput parsing if max-doc-length set

### DIFF
--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -23,6 +23,9 @@ JSON library.
  (implemented by @pjfanning)
 #1545: Increase Android baseline from 26 to 34 in Jackson 3.2
 #1564: Add `SimpleStreamReadContext.rollbackValueRead()` method
+#1570: Fail parsing from `DataInput` if
+ `StreamReadConstraints.getMaxDocumentLength()` set
+ (fix by @cowtowncoder, w/ Claude code)
 
 3.1.1 (not yet released)
 

--- a/src/main/java/tools/jackson/core/json/JsonFactory.java
+++ b/src/main/java/tools/jackson/core/json/JsonFactory.java
@@ -10,6 +10,7 @@ import java.util.Locale;
 
 import tools.jackson.core.*;
 import tools.jackson.core.base.TextualTSFactory;
+import tools.jackson.core.exc.StreamConstraintsException;
 import tools.jackson.core.io.*;
 import tools.jackson.core.json.async.NonBlockingByteArrayJsonParser;
 import tools.jackson.core.json.async.NonBlockingByteBufferJsonParser;
@@ -452,6 +453,13 @@ public class JsonFactory
             DataInput input)
         throws JacksonException
     {
+        // [core#1570] DataInput reads byte-by-byte so we cannot efficiently enforce
+        //   maxDocumentLength. Fail fast if the limit has been configured.
+        if (_streamReadConstraints.hasMaxDocumentLength()) {
+            throw new StreamConstraintsException(
+                    "Can not enforce `StreamReadConstraints.getMaxDocumentLength()` limit with `DataInput`-backed parser: "
+                    +"use other input source types, or remove the max-document-length limit");
+        }
         // Also: while we can't do full bootstrapping (due to read-ahead limitations), should
         // at least handle possible UTF-8 BOM
         int firstByte = ByteSourceJsonBootstrapper.skipUTF8BOM(input);

--- a/src/test/java/tools/jackson/core/unittest/constraints/LargeDocReadTest.java
+++ b/src/test/java/tools/jackson/core/unittest/constraints/LargeDocReadTest.java
@@ -11,6 +11,7 @@ import tools.jackson.core.exc.StreamConstraintsException;
 import tools.jackson.core.json.JsonFactory;
 import tools.jackson.core.unittest.async.AsyncTestBase;
 import tools.jackson.core.unittest.testutil.AsyncReaderWrapper;
+import tools.jackson.core.unittest.testutil.MockDataInput;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -104,6 +105,31 @@ class LargeDocReadTest extends AsyncTestBase
             fail("expected StreamConstraintsException");
         } catch (StreamConstraintsException e) {
             verifyMaxDocLen(JSON_F_DOC_10K, e);
+        }
+    }
+
+    // [core#1570] Should fail fast when DataInput used with maxDocumentLength set
+    @Test
+    void dataInputWithDocLengthLimitFails() throws Exception
+    {
+        final String doc = generateJSON(100);
+        try (JsonParser p = JSON_F_DOC_10K.createParser(ObjectReadContext.empty(),
+                new MockDataInput(doc))) {
+            fail("expected StreamConstraintsException");
+        } catch (StreamConstraintsException e) {
+            verifyException(e, "DataInput");
+            verifyException(e, "maxDocumentLength");
+        }
+    }
+
+    // [core#1570] DataInput without maxDocumentLength should still work
+    @Test
+    void dataInputWithoutDocLengthLimitWorks() throws Exception
+    {
+        final String doc = generateJSON(100);
+        try (JsonParser p = JSON_F_DEFAULT.createParser(ObjectReadContext.empty(),
+                new MockDataInput(doc))) {
+            consumeTokens(p);
         }
     }
 


### PR DESCRIPTION
Implements #1570.