### PR TITLE
Implement document length tracking for DataInput-backed JSON parsers via subclass

### DIFF
--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -26,6 +26,9 @@ JSON library.
 #1570: Fail parsing from `DataInput` if
  `StreamReadConstraints.getMaxDocumentLength()` set
  (fix by @cowtowncoder, w/ Claude code)
+#1575: Implement document length tracking for `DataInput`-backed
+  JSON parsers via subclass
+ (implemented by @pjfanning)
 #1576: Use Java 17 intrinstics for long multiplication
  (contributed by @xtonik)
 

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -23,9 +23,6 @@ JSON library.
  (implemented by @pjfanning)
 #1545: Increase Android baseline from 26 to 34 in Jackson 3.2
 #1564: Add `SimpleStreamReadContext.rollbackValueRead()` method
-#1570: Fail parsing from `DataInput` if
- `StreamReadConstraints.getMaxDocumentLength()` set
- (fix by @cowtowncoder, w/ Claude code)
 #1575: Implement document length tracking for `DataInput`-backed
   JSON parsers via subclass
  (implemented by @pjfanning)

--- a/src/main/java/tools/jackson/core/json/JsonFactory.java
+++ b/src/main/java/tools/jackson/core/json/JsonFactory.java
@@ -456,6 +456,12 @@ public class JsonFactory
         // at least handle possible UTF-8 BOM
         int firstByte = ByteSourceJsonBootstrapper.skipUTF8BOM(input);
         ByteQuadsCanonicalizer can = _byteSymbolCanonicalizer.makeChildOrPlaceholder(_factoryFeatures);
+        if (_streamReadConstraints.hasMaxDocumentLength()) {
+            return new UTF8DataInputWithDocLengthJsonParser(readCtxt, ioCtxt,
+                    readCtxt.getStreamReadFeatures(_streamReadFeatures),
+                    readCtxt.getFormatReadFeatures(_formatReadFeatures),
+                    input, can, firstByte);
+        }
         return new UTF8DataInputJsonParser(readCtxt, ioCtxt,
                 readCtxt.getStreamReadFeatures(_streamReadFeatures),
                 readCtxt.getFormatReadFeatures(_formatReadFeatures),

--- a/src/main/java/tools/jackson/core/json/JsonFactory.java
+++ b/src/main/java/tools/jackson/core/json/JsonFactory.java
@@ -10,7 +10,6 @@ import java.util.Locale;
 
 import tools.jackson.core.*;
 import tools.jackson.core.base.TextualTSFactory;
-import tools.jackson.core.exc.StreamConstraintsException;
 import tools.jackson.core.io.*;
 import tools.jackson.core.json.async.NonBlockingByteArrayJsonParser;
 import tools.jackson.core.json.async.NonBlockingByteBufferJsonParser;
@@ -453,13 +452,6 @@ public class JsonFactory
             DataInput input)
         throws JacksonException
     {
-        // [core#1570] DataInput reads byte-by-byte so we cannot efficiently enforce
-        //   maxDocumentLength. Fail fast if the limit has been configured.
-        if (_streamReadConstraints.hasMaxDocumentLength()) {
-            throw new StreamConstraintsException(
-                    "Can not enforce `StreamReadConstraints.getMaxDocumentLength()` limit with `DataInput`-backed parser: "
-                    +"use other input source types, or remove the max-document-length limit");
-        }
         // Also: while we can't do full bootstrapping (due to read-ahead limitations), should
         // at least handle possible UTF-8 BOM
         int firstByte = ByteSourceJsonBootstrapper.skipUTF8BOM(input);

--- a/src/main/java/tools/jackson/core/json/JsonFactory.java
+++ b/src/main/java/tools/jackson/core/json/JsonFactory.java
@@ -456,6 +456,7 @@ public class JsonFactory
         // at least handle possible UTF-8 BOM
         int firstByte = ByteSourceJsonBootstrapper.skipUTF8BOM(input);
         ByteQuadsCanonicalizer can = _byteSymbolCanonicalizer.makeChildOrPlaceholder(_factoryFeatures);
+        // [core#1575]: Support max doc length constraints with separate impl
         if (_streamReadConstraints.hasMaxDocumentLength()) {
             return new UTF8DataInputWithDocLengthJsonParser(readCtxt, ioCtxt,
                     readCtxt.getStreamReadFeatures(_streamReadFeatures),

--- a/src/main/java/tools/jackson/core/json/UTF8DataInputJsonParser.java
+++ b/src/main/java/tools/jackson/core/json/UTF8DataInputJsonParser.java
@@ -136,6 +136,14 @@ public class UTF8DataInputJsonParser
     protected void _closeInput() { }
 
     /**
+     * Read the next unsigned byte from the input.
+     * Subclasses may override to track byte counts for document length enforcement.
+     */
+    protected int readUnsignedByte() throws IOException {
+        return _inputData.readUnsignedByte();
+    }
+
+    /**
      * Method called to release internal buffers owned by the base
      * reader. This may be called along with {@link #_closeInput} (for
      * example, when explicitly closing this reader instance), or
@@ -445,7 +453,7 @@ public class UTF8DataInputJsonParser
             // first, we'll skip preceding white space, if any
             int ch;
             do {
-                ch = _inputData.readUnsignedByte();
+                ch = readUnsignedByte();
             } while (ch <= INT_SPACE);
             int bits = b64variant.decodeBase64Char(ch);
             if (bits < 0) { // reached the end, fair and square?
@@ -468,7 +476,7 @@ public class UTF8DataInputJsonParser
             int decodedData = bits;
 
             // then second base64 char; can't get padding yet, nor ws
-            ch = _inputData.readUnsignedByte();
+            ch = readUnsignedByte();
             bits = b64variant.decodeBase64Char(ch);
             if (bits < 0) {
                 bits = _decodeBase64Escape(b64variant, ch, 1);
@@ -476,7 +484,7 @@ public class UTF8DataInputJsonParser
             decodedData = (decodedData << 6) | bits;
 
             // third base64 char; can be padding, but not ws
-            ch = _inputData.readUnsignedByte();
+            ch = readUnsignedByte();
             bits = b64variant.decodeBase64Char(ch);
 
             // First branch: can get padding (-> 1 byte)
@@ -495,7 +503,7 @@ public class UTF8DataInputJsonParser
                 }
                 if (bits == Base64Variant.BASE64_VALUE_PADDING) {
                     // Ok, must get padding
-                    ch = _inputData.readUnsignedByte();
+                    ch = readUnsignedByte();
                     if (!b64variant.usesPaddingChar(ch)) {
                         if ((ch != INT_BACKSLASH)
                                 || _decodeBase64Escape(b64variant, ch, 3) != Base64Variant.BASE64_VALUE_PADDING) {
@@ -511,7 +519,7 @@ public class UTF8DataInputJsonParser
             // Nope, 2 or 3 bytes
             decodedData = (decodedData << 6) | bits;
             // fourth and last base64 char; can be padding, but not ws
-            ch = _inputData.readUnsignedByte();
+            ch = readUnsignedByte();
             bits = b64variant.decodeBase64Char(ch);
             if (bits < 0) {
                 if (bits != Base64Variant.BASE64_VALUE_PADDING) {
@@ -1056,7 +1064,7 @@ public class UTF8DataInputJsonParser
             }
         } else {
             outBuf[0] = (char) c;
-            c = _inputData.readUnsignedByte();
+            c = readUnsignedByte();
             outPtr = 1;
         }
         int intLen = outPtr;
@@ -1069,7 +1077,7 @@ public class UTF8DataInputJsonParser
                 outPtr = 0;
             }
             outBuf[outPtr++] = (char) c;
-            c = _inputData.readUnsignedByte();
+            c = readUnsignedByte();
         }
         if (c == '.' || (c | 0x20) == INT_e) { // ~ '.eE'
             return _parseFloat(outBuf, outPtr, c, false, intLen);
@@ -1101,7 +1109,7 @@ public class UTF8DataInputJsonParser
 
         // [core#784]: Include sign character ('+' or '-') in textual representation
         outBuf[outPtr++] = negative ? '-' : '+';
-        int c = _inputData.readUnsignedByte();
+        int c = readUnsignedByte();
         outBuf[outPtr++] = (char) c;
         // Note: must be followed by a digit
         if (c <= INT_0) {
@@ -1117,7 +1125,7 @@ public class UTF8DataInputJsonParser
             if (c > INT_9) {
                 return _handleInvalidNumberStart(c, negative, true);
             }
-            c = _inputData.readUnsignedByte();
+            c = readUnsignedByte();
         }
         // Ok: we can first just add digit we saw first:
         int intLen = 1;
@@ -1130,7 +1138,7 @@ public class UTF8DataInputJsonParser
                 outPtr = 0;
             }
             outBuf[outPtr++] = (char) c;
-            c = _inputData.readUnsignedByte();
+            c = readUnsignedByte();
         }
         if (c == '.' || (c | 0x20) == INT_e) { // ~ '.eE'
             return _parseFloat(outBuf, outPtr, c, negative, intLen);
@@ -1157,7 +1165,7 @@ public class UTF8DataInputJsonParser
      */
     private final int _handleLeadingZeroes() throws IOException
     {
-        int ch = _inputData.readUnsignedByte();
+        int ch = readUnsignedByte();
         // if not followed by a number (probably '.'); return zero as is, to be included
         if (ch < INT_0 || ch > INT_9) {
             return ch;
@@ -1168,7 +1176,7 @@ public class UTF8DataInputJsonParser
         }
         // if so, just need to skip either all zeroes (if followed by number); or all but one (if non-number)
         while (ch == INT_0) {
-            ch = _inputData.readUnsignedByte();
+            ch = readUnsignedByte();
         }
         return ch;
     }
@@ -1189,7 +1197,7 @@ public class UTF8DataInputJsonParser
 
             fract_loop:
             while (true) {
-                c = _inputData.readUnsignedByte();
+                c = readUnsignedByte();
                 if (c < INT_0 || c > INT_9) {
                     break fract_loop;
                 }
@@ -1217,7 +1225,7 @@ public class UTF8DataInputJsonParser
                 outPtr = 0;
             }
             outBuf[outPtr++] = (char) c;
-            c = _inputData.readUnsignedByte();
+            c = readUnsignedByte();
             // Sign indicator?
             if (c == '-' || c == '+') {
                 if (outPtr >= outBuf.length) {
@@ -1225,7 +1233,7 @@ public class UTF8DataInputJsonParser
                     outPtr = 0;
                 }
                 outBuf[outPtr++] = (char) c;
-                c = _inputData.readUnsignedByte();
+                c = readUnsignedByte();
             }
             while (c <= INT_9 && c >= INT_0) {
                 ++expLen;
@@ -1234,7 +1242,7 @@ public class UTF8DataInputJsonParser
                     outPtr = 0;
                 }
                 outBuf[outPtr++] = (char) c;
-                c = _inputData.readUnsignedByte();
+                c = readUnsignedByte();
             }
             // must be followed by sequence of ints, one minimum
             if (expLen == 0) {
@@ -1294,19 +1302,19 @@ public class UTF8DataInputJsonParser
          */
         final int[] codes = _icLatin1;
 
-        int q = _inputData.readUnsignedByte();
+        int q = readUnsignedByte();
 
         if (codes[q] == 0) {
-            i = _inputData.readUnsignedByte();
+            i = readUnsignedByte();
             if (codes[i] == 0) {
                 q = (q << 8) | i;
-                i = _inputData.readUnsignedByte();
+                i = readUnsignedByte();
                 if (codes[i] == 0) {
                     q = (q << 8) | i;
-                    i = _inputData.readUnsignedByte();
+                    i = readUnsignedByte();
                     if (codes[i] == 0) {
                         q = (q << 8) | i;
-                        i = _inputData.readUnsignedByte();
+                        i = readUnsignedByte();
                         if (codes[i] == 0) {
                             _quad1 = q;
                             return _parseMediumName(i);
@@ -1342,7 +1350,7 @@ public class UTF8DataInputJsonParser
         final int[] codes = _icLatin1;
 
         // Ok, got 5 name bytes so far
-        int i = _inputData.readUnsignedByte();
+        int i = readUnsignedByte();
         if (codes[i] != 0) {
             if (i == INT_QUOTE) { // 5 bytes
                 return findName(_quad1, q2, 1);
@@ -1350,7 +1358,7 @@ public class UTF8DataInputJsonParser
             return parseName(_quad1, q2, i, 1); // quoting or invalid char
         }
         q2 = (q2 << 8) | i;
-        i = _inputData.readUnsignedByte();
+        i = readUnsignedByte();
         if (codes[i] != 0) {
             if (i == INT_QUOTE) { // 6 bytes
                 return findName(_quad1, q2, 2);
@@ -1358,7 +1366,7 @@ public class UTF8DataInputJsonParser
             return parseName(_quad1, q2, i, 2);
         }
         q2 = (q2 << 8) | i;
-        i = _inputData.readUnsignedByte();
+        i = readUnsignedByte();
         if (codes[i] != 0) {
             if (i == INT_QUOTE) { // 7 bytes
                 return findName(_quad1, q2, 3);
@@ -1366,7 +1374,7 @@ public class UTF8DataInputJsonParser
             return parseName(_quad1, q2, i, 3);
         }
         q2 = (q2 << 8) | i;
-        i = _inputData.readUnsignedByte();
+        i = readUnsignedByte();
         if (codes[i] != 0) {
             if (i == INT_QUOTE) { // 8 bytes
                 return findName(_quad1, q2, 4);
@@ -1381,7 +1389,7 @@ public class UTF8DataInputJsonParser
         final int[] codes = _icLatin1;
 
         // Got 9 name bytes so far
-        int i = _inputData.readUnsignedByte();
+        int i = readUnsignedByte();
         if (codes[i] != 0) {
             if (i == INT_QUOTE) { // 9 bytes
                 return findName(_quad1, q2, q3, 1);
@@ -1389,7 +1397,7 @@ public class UTF8DataInputJsonParser
             return parseName(_quad1, q2, q3, i, 1);
         }
         q3 = (q3 << 8) | i;
-        i = _inputData.readUnsignedByte();
+        i = readUnsignedByte();
         if (codes[i] != 0) {
             if (i == INT_QUOTE) { // 10 bytes
                 return findName(_quad1, q2, q3, 2);
@@ -1397,7 +1405,7 @@ public class UTF8DataInputJsonParser
             return parseName(_quad1, q2, q3, i, 2);
         }
         q3 = (q3 << 8) | i;
-        i = _inputData.readUnsignedByte();
+        i = readUnsignedByte();
         if (codes[i] != 0) {
             if (i == INT_QUOTE) { // 11 bytes
                 return findName(_quad1, q2, q3, 3);
@@ -1405,7 +1413,7 @@ public class UTF8DataInputJsonParser
             return parseName(_quad1, q2, q3, i, 3);
         }
         q3 = (q3 << 8) | i;
-        i = _inputData.readUnsignedByte();
+        i = readUnsignedByte();
         if (codes[i] != 0) {
             if (i == INT_QUOTE) { // 12 bytes
                 return findName(_quad1, q2, q3, 4);
@@ -1427,7 +1435,7 @@ public class UTF8DataInputJsonParser
         int qlen = 3;
 
         while (true) {
-            int i = _inputData.readUnsignedByte();
+            int i = readUnsignedByte();
             if (codes[i] != 0) {
                 if (i == INT_QUOTE) {
                     return findName(_quadBuffer, qlen, q, 1);
@@ -1436,7 +1444,7 @@ public class UTF8DataInputJsonParser
             }
 
             q = (q << 8) | i;
-            i = _inputData.readUnsignedByte();
+            i = readUnsignedByte();
             if (codes[i] != 0) {
                 if (i == INT_QUOTE) {
                     return findName(_quadBuffer, qlen, q, 2);
@@ -1445,7 +1453,7 @@ public class UTF8DataInputJsonParser
             }
 
             q = (q << 8) | i;
-            i = _inputData.readUnsignedByte();
+            i = readUnsignedByte();
             if (codes[i] != 0) {
                 if (i == INT_QUOTE) {
                     return findName(_quadBuffer, qlen, q, 3);
@@ -1454,7 +1462,7 @@ public class UTF8DataInputJsonParser
             }
 
             q = (q << 8) | i;
-            i = _inputData.readUnsignedByte();
+            i = readUnsignedByte();
             if (codes[i] != 0) {
                 if (i == INT_QUOTE) {
                     return findName(_quadBuffer, qlen, q, 4);
@@ -1517,7 +1525,7 @@ public class UTF8DataInputJsonParser
                 // [jackson-core#1541]: Handle JSON-escaped surrogate pairs in field names
                 if (ch >= 0xD800 && ch <= 0xDBFF) { // high surrogate
                     // Must be followed by \\uXXXX low surrogate
-                    int next = _inputData.readUnsignedByte();
+                    int next = readUnsignedByte();
                     if (next != INT_BACKSLASH) {
                         _reportError("Broken surrogate pair in property name: expected '\\' to start low surrogate, got 0x"
                                 + Integer.toHexString(next));
@@ -1597,7 +1605,7 @@ public class UTF8DataInputJsonParser
                 currQuad = ch;
                 currQuadBytes = 1;
             }
-            ch = _inputData.readUnsignedByte();
+            ch = readUnsignedByte();
         }
 
         if (currQuadBytes > 0) {
@@ -1667,7 +1675,7 @@ public class UTF8DataInputJsonParser
                 currQuad = ch;
                 currQuadBytes = 1;
             }
-            ch = _inputData.readUnsignedByte();
+            ch = readUnsignedByte();
             if (codes[ch] != 0) {
                 break;
             }
@@ -1695,7 +1703,7 @@ public class UTF8DataInputJsonParser
      */
     protected String _parseAposName() throws IOException
     {
-        int ch = _inputData.readUnsignedByte();
+        int ch = readUnsignedByte();
         if (ch == '\'') { // special case, ''
             return "";
         }
@@ -1724,7 +1732,7 @@ public class UTF8DataInputJsonParser
                 }
                 // [jackson-core#1541]: Handle JSON-escaped surrogate pairs in field names
                 if (ch >= 0xD800 && ch <= 0xDBFF) { // high surrogate
-                    int next = _inputData.readUnsignedByte();
+                    int next = readUnsignedByte();
                     if (next != INT_BACKSLASH) {
                         _reportError("Broken surrogate pair in property name: expected '\\' to start low surrogate, got 0x"
                                 + Integer.toHexString(next));
@@ -1804,7 +1812,7 @@ public class UTF8DataInputJsonParser
                 currQuad = ch;
                 currQuadBytes = 1;
             }
-            ch = _inputData.readUnsignedByte();
+            ch = readUnsignedByte();
         }
 
         if (currQuadBytes > 0) {
@@ -2018,7 +2026,7 @@ public class UTF8DataInputJsonParser
 
         try {
             do {
-                int c = _inputData.readUnsignedByte();
+                int c = readUnsignedByte();
                 if (codes[c] != 0) {
                     if (c == INT_QUOTE) {
                         _textBuffer.setCurrentLength(outPtr);
@@ -2029,7 +2037,7 @@ public class UTF8DataInputJsonParser
                 }
                 outBuf[outPtr++] = (char) c;
             } while (outPtr < outEnd);
-            _finishString2(outBuf, outPtr, _inputData.readUnsignedByte());
+            _finishString2(outBuf, outPtr, readUnsignedByte());
         } catch (IOException e) {
             throw _wrapIOFailure(e);
         }
@@ -2044,7 +2052,7 @@ public class UTF8DataInputJsonParser
 
         try {
             do {
-                int c = _inputData.readUnsignedByte();
+                int c = readUnsignedByte();
                 if (codes[c] != 0) {
                     if (c == INT_QUOTE) {
                         return _textBuffer.setCurrentAndReturn(outPtr);
@@ -2054,7 +2062,7 @@ public class UTF8DataInputJsonParser
                 }
                 outBuf[outPtr++] = (char) c;
             } while (outPtr < outEnd);
-            _finishString2(outBuf, outPtr, _inputData.readUnsignedByte());
+            _finishString2(outBuf, outPtr, readUnsignedByte());
         } catch (IOException e) {
             throw _wrapIOFailure(e);
         }
@@ -2069,7 +2077,7 @@ public class UTF8DataInputJsonParser
         int outEnd = outBuf.length;
 
         main_loop:
-        for (;; c = _inputData.readUnsignedByte()) {
+        for (;; c = readUnsignedByte()) {
             // Then the tight ASCII non-funny-char loop:
             while (codes[c] == 0) {
                 if (outPtr >= outEnd) {
@@ -2078,7 +2086,7 @@ public class UTF8DataInputJsonParser
                     outEnd = outBuf.length;
                 }
                 outBuf[outPtr++] = (char) c;
-                c = _inputData.readUnsignedByte();
+                c = readUnsignedByte();
             }
             // Ok: end marker, escape or multi-byte?
             if (c == INT_QUOTE) {
@@ -2147,7 +2155,7 @@ public class UTF8DataInputJsonParser
 
             ascii_loop:
             while (true) {
-                c = _inputData.readUnsignedByte();
+                c = readUnsignedByte();
                 if (codes[c] != 0) {
                     break ascii_loop;
                 }
@@ -2200,7 +2208,7 @@ public class UTF8DataInputJsonParser
 
             ascii_loop:
             while (true) {
-                c = _inputData.readUnsignedByte();
+                c = readUnsignedByte();
                 if (codes[c] != 0) {
                     break ascii_loop;
                 }
@@ -2324,7 +2332,7 @@ public class UTF8DataInputJsonParser
             _reportError("Non-standard token 'Infinity': enable `JsonReadFeature.ALLOW_NON_NUMERIC_NUMBERS` to allow");
             break;
         case '+': // note: '-' is taken as number
-            return _handleInvalidNumberStart(_inputData.readUnsignedByte(), false, true);
+            return _handleInvalidNumberStart(readUnsignedByte(), false, true);
         }
         // [core#77] Try to decode most likely token
         if (Character.isJavaIdentifierStart(c)) {
@@ -2357,7 +2365,7 @@ public class UTF8DataInputJsonParser
                     outEnd = outBuf.length;
                 }
                 do {
-                    c = _inputData.readUnsignedByte();
+                    c = readUnsignedByte();
                     if (c == '\'') {
                         break main_loop;
                     }
@@ -2423,7 +2431,7 @@ public class UTF8DataInputJsonParser
     protected JsonToken _handleInvalidNumberStart(int ch, final boolean neg, final boolean hasSign) throws IOException
     {
         while (ch == 'I') {
-            ch = _inputData.readUnsignedByte();
+            ch = readUnsignedByte();
             String match;
             if (ch == 'N') {
                 match = neg ? "-INF" :"+INF";
@@ -2452,13 +2460,13 @@ public class UTF8DataInputJsonParser
     {
         final int len = matchStr.length();
         do {
-            int ch = _inputData.readUnsignedByte();
+            int ch = readUnsignedByte();
             if (ch != matchStr.charAt(i)) {
                 _reportInvalidToken(ch, matchStr.substring(0, i));
             }
         } while (++i < len);
 
-        int ch = _inputData.readUnsignedByte();
+        int ch = readUnsignedByte();
         if (ch >= '0' && ch != ']' && ch != '}') { // expected/allowed chars
             _checkMatchEnd(matchStr, i, ch);
         }
@@ -2483,7 +2491,7 @@ public class UTF8DataInputJsonParser
     {
         int i = _nextByte;
         if (i < 0) {
-            i = _inputData.readUnsignedByte();
+            i = readUnsignedByte();
         } else {
             _nextByte = -1;
         }
@@ -2500,7 +2508,7 @@ public class UTF8DataInputJsonParser
                     ++_currInputRow;
                 }
             }
-            i = _inputData.readUnsignedByte();
+            i = readUnsignedByte();
         }
     }
 
@@ -2513,7 +2521,7 @@ public class UTF8DataInputJsonParser
         int i = _nextByte;
         if (i < 0) {
             try {
-                i = _inputData.readUnsignedByte();
+                i = readUnsignedByte();
             } catch (EOFException e) {
                 return _eofAsNextChar();
             }
@@ -2534,7 +2542,7 @@ public class UTF8DataInputJsonParser
                 }
             }
             try {
-                i = _inputData.readUnsignedByte();
+                i = readUnsignedByte();
             } catch (EOFException e) {
                 return _eofAsNextChar();
             }
@@ -2566,7 +2574,7 @@ public class UTF8DataInputJsonParser
                 }
                 */
             }
-            i = _inputData.readUnsignedByte();
+            i = readUnsignedByte();
         }
     }
 
@@ -2574,13 +2582,13 @@ public class UTF8DataInputJsonParser
     {
         int i = _nextByte;
         if (i < 0) {
-            i = _inputData.readUnsignedByte();
+            i = readUnsignedByte();
         } else {
             _nextByte = -1;
         }
         // Fast path: colon with optional single-space/tab before and/or after:
         if (i == INT_COLON) { // common case, no leading space
-            i = _inputData.readUnsignedByte();
+            i = readUnsignedByte();
             if (i > INT_SPACE) { // nor trailing
                 if (i == INT_SLASH || i == INT_HASH) {
                     return _skipColon2(i, true);
@@ -2588,7 +2596,7 @@ public class UTF8DataInputJsonParser
                 return i;
             }
             if (i == INT_SPACE || i == INT_TAB) {
-                i = _inputData.readUnsignedByte();
+                i = readUnsignedByte();
                 if (i > INT_SPACE) {
                     if (i == INT_SLASH || i == INT_HASH) {
                         return _skipColon2(i, true);
@@ -2599,10 +2607,10 @@ public class UTF8DataInputJsonParser
             return _skipColon2(i, true); // true -> skipped colon
         }
         if (i == INT_SPACE || i == INT_TAB) {
-            i = _inputData.readUnsignedByte();
+            i = readUnsignedByte();
         }
         if (i == INT_COLON) {
-            i = _inputData.readUnsignedByte();
+            i = readUnsignedByte();
             if (i > INT_SPACE) {
                 if (i == INT_SLASH || i == INT_HASH) {
                     return _skipColon2(i, true);
@@ -2610,7 +2618,7 @@ public class UTF8DataInputJsonParser
                 return i;
             }
             if (i == INT_SPACE || i == INT_TAB) {
-                i = _inputData.readUnsignedByte();
+                i = readUnsignedByte();
                 if (i > INT_SPACE) {
                     if (i == INT_SLASH || i == INT_HASH) {
                         return _skipColon2(i, true);
@@ -2625,7 +2633,7 @@ public class UTF8DataInputJsonParser
 
     private final int _skipColon2(int i, boolean gotColon) throws IOException
     {
-        for (;; i = _inputData.readUnsignedByte()) {
+        for (;; i = readUnsignedByte()) {
             if (i > INT_SPACE) {
                 if (i == INT_SLASH) {
                     _skipComment();
@@ -2658,7 +2666,7 @@ public class UTF8DataInputJsonParser
         if (!isEnabled(JsonReadFeature.ALLOW_JAVA_COMMENTS)) {
             _reportUnexpectedChar('/', "maybe a (non-standard) comment? (not recognized as one since Feature 'ALLOW_COMMENTS' not enabled for parser)");
         }
-        int c = _inputData.readUnsignedByte();
+        int c = readUnsignedByte();
         if (c == '/') {
             _skipLine();
         } else if (c == '*') {
@@ -2672,7 +2680,7 @@ public class UTF8DataInputJsonParser
     {
         // Need to be UTF-8 aware here to decode content (for skipping)
         final int[] codes = CharTypes.getInputCodeComment();
-        int i = _inputData.readUnsignedByte();
+        int i = readUnsignedByte();
 
         // Ok: need the matching '*/'
         main_loop:
@@ -2681,7 +2689,7 @@ public class UTF8DataInputJsonParser
             if (code != 0) {
                 switch (code) {
                 case '*':
-                    i = _inputData.readUnsignedByte();
+                    i = readUnsignedByte();
                     if (i == INT_SLASH) {
                         return;
                     }
@@ -2704,7 +2712,7 @@ public class UTF8DataInputJsonParser
                     _reportInvalidChar(i);
                 }
             }
-            i = _inputData.readUnsignedByte();
+            i = readUnsignedByte();
         }
     }
 
@@ -2726,7 +2734,7 @@ public class UTF8DataInputJsonParser
         // Ok: need to find EOF or linefeed
         final int[] codes = CharTypes.getInputCodeComment();
         while (true) {
-            int i = _inputData.readUnsignedByte();
+            int i = readUnsignedByte();
             int code = codes[i];
             if (code != 0) {
                 switch (code) {
@@ -2766,7 +2774,7 @@ public class UTF8DataInputJsonParser
 
     private char _decodeEscaped2() throws IOException
     {
-        int c = _inputData.readUnsignedByte();
+        int c = readUnsignedByte();
 
         switch (c) {
             // First, ones that are mapped
@@ -2797,7 +2805,7 @@ public class UTF8DataInputJsonParser
         // Ok, a hex escape. Need 4 characters
         int value = 0;
         for (int i = 0; i < 4; ++i) {
-            int ch = _inputData.readUnsignedByte();
+            int ch = readUnsignedByte();
             int digit = CharTypes.charToHex(ch);
             if (digit < 0) {
                 _reportUnexpectedChar(ch, "expected a hex-digit for character escape sequence");
@@ -2829,20 +2837,20 @@ public class UTF8DataInputJsonParser
                 needed = 1; // never gets here
             }
 
-            int d = _inputData.readUnsignedByte();
+            int d = readUnsignedByte();
             if ((d & 0xC0) != 0x080) {
                 _reportInvalidOther(d & 0xFF);
             }
             c = (c << 6) | (d & 0x3F);
 
             if (needed > 1) { // needed == 1 means 2 bytes total
-                d = _inputData.readUnsignedByte(); // 3rd byte
+                d = readUnsignedByte(); // 3rd byte
                 if ((d & 0xC0) != 0x080) {
                     _reportInvalidOther(d & 0xFF);
                 }
                 c = (c << 6) | (d & 0x3F);
                 if (needed > 2) { // 4 bytes? (need surrogates)
-                    d = _inputData.readUnsignedByte();
+                    d = readUnsignedByte();
                     if ((d & 0xC0) != 0x080) {
                         _reportInvalidOther(d & 0xFF);
                     }
@@ -2861,7 +2869,7 @@ public class UTF8DataInputJsonParser
 
     private final int _decodeUtf8_2(int c) throws IOException
     {
-        int d = _inputData.readUnsignedByte();
+        int d = readUnsignedByte();
         if ((d & 0xC0) != 0x080) {
             _reportInvalidOther(d & 0xFF);
         }
@@ -2871,12 +2879,12 @@ public class UTF8DataInputJsonParser
     private final int _decodeUtf8_3(int c1) throws IOException
     {
         c1 &= 0x0F;
-        int d = _inputData.readUnsignedByte();
+        int d = readUnsignedByte();
         if ((d & 0xC0) != 0x080) {
             _reportInvalidOther(d & 0xFF);
         }
         int c = (c1 << 6) | (d & 0x3F);
-        d = _inputData.readUnsignedByte();
+        d = readUnsignedByte();
         if ((d & 0xC0) != 0x080) {
             _reportInvalidOther(d & 0xFF);
         }
@@ -2894,17 +2902,17 @@ public class UTF8DataInputJsonParser
      */
     private final int _decodeUtf8_4(int c) throws IOException
     {
-        int d = _inputData.readUnsignedByte();
+        int d = readUnsignedByte();
         if ((d & 0xC0) != 0x080) {
             _reportInvalidOther(d & 0xFF);
         }
         c = ((c & 0x07) << 6) | (d & 0x3F);
-        d = _inputData.readUnsignedByte();
+        d = readUnsignedByte();
         if ((d & 0xC0) != 0x080) {
             _reportInvalidOther(d & 0xFF);
         }
         c = (c << 6) | (d & 0x3F);
-        d = _inputData.readUnsignedByte();
+        d = readUnsignedByte();
         if ((d & 0xC0) != 0x080) {
             _reportInvalidOther(d & 0xFF);
         }
@@ -2917,7 +2925,7 @@ public class UTF8DataInputJsonParser
 
     private final void _skipUtf8_2() throws IOException
     {
-        int c = _inputData.readUnsignedByte();
+        int c = readUnsignedByte();
         if ((c & 0xC0) != 0x080) {
             _reportInvalidOther(c & 0xFF);
         }
@@ -2929,11 +2937,11 @@ public class UTF8DataInputJsonParser
     private final void _skipUtf8_3() throws IOException
     {
         //c &= 0x0F;
-        int c = _inputData.readUnsignedByte();
+        int c = readUnsignedByte();
         if ((c & 0xC0) != 0x080) {
             _reportInvalidOther(c & 0xFF);
         }
-        c = _inputData.readUnsignedByte();
+        c = readUnsignedByte();
         if ((c & 0xC0) != 0x080) {
             _reportInvalidOther(c & 0xFF);
         }
@@ -2941,15 +2949,15 @@ public class UTF8DataInputJsonParser
 
     private final void _skipUtf8_4() throws IOException
     {
-        int d = _inputData.readUnsignedByte();
+        int d = readUnsignedByte();
         if ((d & 0xC0) != 0x080) {
             _reportInvalidOther(d & 0xFF);
         }
-        d = _inputData.readUnsignedByte();
+        d = readUnsignedByte();
         if ((d & 0xC0) != 0x080) {
             _reportInvalidOther(d & 0xFF);
         }
-        d = _inputData.readUnsignedByte();
+        d = readUnsignedByte();
         if ((d & 0xC0) != 0x080) {
             _reportInvalidOther(d & 0xFF);
         }
@@ -2980,7 +2988,7 @@ public class UTF8DataInputJsonParser
                      break;
                  }
                  sb.append(c);
-                 ch = _inputData.readUnsignedByte();
+                 ch = readUnsignedByte();
              }
          } catch (IOException e) {
              ; // ok since we are just trying to get token for diagnostics
@@ -3036,7 +3044,7 @@ public class UTF8DataInputJsonParser
             // first, we'll skip preceding white space, if any
             int ch;
             do {
-                ch = _inputData.readUnsignedByte();
+                ch = readUnsignedByte();
             } while (ch <= INT_SPACE);
             int bits = b64variant.decodeBase64Char(ch);
             if (bits < 0) { // reached the end, fair and square?
@@ -3051,14 +3059,14 @@ public class UTF8DataInputJsonParser
             int decodedData = bits;
 
             // then second base64 char; can't get padding yet, nor ws
-            ch = _inputData.readUnsignedByte();
+            ch = readUnsignedByte();
             bits = b64variant.decodeBase64Char(ch);
             if (bits < 0) {
                 bits = _decodeBase64Escape(b64variant, ch, 1);
             }
             decodedData = (decodedData << 6) | bits;
             // third base64 char; can be padding, but not ws
-            ch = _inputData.readUnsignedByte();
+            ch = readUnsignedByte();
             bits = b64variant.decodeBase64Char(ch);
 
             // First branch: can get padding (-> 1 byte)
@@ -3076,7 +3084,7 @@ public class UTF8DataInputJsonParser
                     bits = _decodeBase64Escape(b64variant, ch, 2);
                 }
                 if (bits == Base64Variant.BASE64_VALUE_PADDING) {
-                    ch = _inputData.readUnsignedByte();
+                    ch = readUnsignedByte();
                     if (!b64variant.usesPaddingChar(ch)) {
                         if ((ch != INT_BACKSLASH)
                                 || _decodeBase64Escape(b64variant, ch, 3) != Base64Variant.BASE64_VALUE_PADDING) {
@@ -3092,7 +3100,7 @@ public class UTF8DataInputJsonParser
             // Nope, 2 or 3 bytes
             decodedData = (decodedData << 6) | bits;
             // fourth and last base64 char; can be padding, but not ws
-            ch = _inputData.readUnsignedByte();
+            ch = readUnsignedByte();
             bits = b64variant.decodeBase64Char(ch);
             if (bits < 0) {
                 if (bits != Base64Variant.BASE64_VALUE_PADDING) {

--- a/src/main/java/tools/jackson/core/json/UTF8DataInputJsonParser.java
+++ b/src/main/java/tools/jackson/core/json/UTF8DataInputJsonParser.java
@@ -93,6 +93,18 @@ public class UTF8DataInputJsonParser
      */
     protected int _nextByte = -1;
 
+    /**
+     * Whether a maximum document length limit has been configured.
+     * Used to decide whether to track {@link #_inputProcessed}.
+     */
+    private final boolean _hasMaxDocumentLength;
+
+    /**
+     * Number of bytes read from {@link #_inputData}, used to enforce
+     * the maximum document length constraint when configured.
+     */
+    protected long _inputProcessed = 0L;
+
     /*
     /**********************************************************************
     /* Life-cycle
@@ -108,6 +120,7 @@ public class UTF8DataInputJsonParser
         _symbols = sym;
         _inputData = inputData;
         _nextByte = firstByte;
+        _hasMaxDocumentLength = _streamReadConstraints.hasMaxDocumentLength();
     }
 
     /*
@@ -147,6 +160,18 @@ public class UTF8DataInputJsonParser
         super._releaseBuffers();
         // Merge found symbols, if any:
         _symbols.release();
+    }
+
+    /**
+     * Helper method that reads one unsigned byte from {@link #_inputData},
+     * incrementing {@link #_inputProcessed} when max-document-length tracking
+     * is active.
+     */
+    private int _inputRead() throws IOException {
+        if (_hasMaxDocumentLength) {
+            ++_inputProcessed;
+        }
+        return _inputData.readUnsignedByte();
     }
 
     /*
@@ -445,7 +470,7 @@ public class UTF8DataInputJsonParser
             // first, we'll skip preceding white space, if any
             int ch;
             do {
-                ch = _inputData.readUnsignedByte();
+                ch = _inputRead();
             } while (ch <= INT_SPACE);
             int bits = b64variant.decodeBase64Char(ch);
             if (bits < 0) { // reached the end, fair and square?
@@ -468,7 +493,7 @@ public class UTF8DataInputJsonParser
             int decodedData = bits;
 
             // then second base64 char; can't get padding yet, nor ws
-            ch = _inputData.readUnsignedByte();
+            ch = _inputRead();
             bits = b64variant.decodeBase64Char(ch);
             if (bits < 0) {
                 bits = _decodeBase64Escape(b64variant, ch, 1);
@@ -476,7 +501,7 @@ public class UTF8DataInputJsonParser
             decodedData = (decodedData << 6) | bits;
 
             // third base64 char; can be padding, but not ws
-            ch = _inputData.readUnsignedByte();
+            ch = _inputRead();
             bits = b64variant.decodeBase64Char(ch);
 
             // First branch: can get padding (-> 1 byte)
@@ -495,7 +520,7 @@ public class UTF8DataInputJsonParser
                 }
                 if (bits == Base64Variant.BASE64_VALUE_PADDING) {
                     // Ok, must get padding
-                    ch = _inputData.readUnsignedByte();
+                    ch = _inputRead();
                     if (!b64variant.usesPaddingChar(ch)) {
                         if ((ch != INT_BACKSLASH)
                                 || _decodeBase64Escape(b64variant, ch, 3) != Base64Variant.BASE64_VALUE_PADDING) {
@@ -511,7 +536,7 @@ public class UTF8DataInputJsonParser
             // Nope, 2 or 3 bytes
             decodedData = (decodedData << 6) | bits;
             // fourth and last base64 char; can be padding, but not ws
-            ch = _inputData.readUnsignedByte();
+            ch = _inputRead();
             bits = b64variant.decodeBase64Char(ch);
             if (bits < 0) {
                 if (bits != Base64Variant.BASE64_VALUE_PADDING) {
@@ -595,6 +620,9 @@ public class UTF8DataInputJsonParser
             // Close/release things like input source, symbol table and recyclable buffers
             close();
             return _updateTokenToNull();
+        }
+        if (_hasMaxDocumentLength) {
+            _streamReadConstraints.validateDocumentLength(_inputProcessed);
         }
         // clear any data retained so far
         _binaryValue = null;
@@ -796,6 +824,9 @@ public class UTF8DataInputJsonParser
             _skipString();
         }
         int i = _skipWS();
+        if (_hasMaxDocumentLength) {
+            _streamReadConstraints.validateDocumentLength(_inputProcessed);
+        }
         _binaryValue = null;
         _tokenInputRow = _currInputRow;
 
@@ -1056,7 +1087,7 @@ public class UTF8DataInputJsonParser
             }
         } else {
             outBuf[0] = (char) c;
-            c = _inputData.readUnsignedByte();
+            c = _inputRead();
             outPtr = 1;
         }
         int intLen = outPtr;
@@ -1069,7 +1100,7 @@ public class UTF8DataInputJsonParser
                 outPtr = 0;
             }
             outBuf[outPtr++] = (char) c;
-            c = _inputData.readUnsignedByte();
+            c = _inputRead();
         }
         if (c == '.' || (c | 0x20) == INT_e) { // ~ '.eE'
             return _parseFloat(outBuf, outPtr, c, false, intLen);
@@ -1101,7 +1132,7 @@ public class UTF8DataInputJsonParser
 
         // [core#784]: Include sign character ('+' or '-') in textual representation
         outBuf[outPtr++] = negative ? '-' : '+';
-        int c = _inputData.readUnsignedByte();
+        int c = _inputRead();
         outBuf[outPtr++] = (char) c;
         // Note: must be followed by a digit
         if (c <= INT_0) {
@@ -1117,7 +1148,7 @@ public class UTF8DataInputJsonParser
             if (c > INT_9) {
                 return _handleInvalidNumberStart(c, negative, true);
             }
-            c = _inputData.readUnsignedByte();
+            c = _inputRead();
         }
         // Ok: we can first just add digit we saw first:
         int intLen = 1;
@@ -1130,7 +1161,7 @@ public class UTF8DataInputJsonParser
                 outPtr = 0;
             }
             outBuf[outPtr++] = (char) c;
-            c = _inputData.readUnsignedByte();
+            c = _inputRead();
         }
         if (c == '.' || (c | 0x20) == INT_e) { // ~ '.eE'
             return _parseFloat(outBuf, outPtr, c, negative, intLen);
@@ -1157,7 +1188,7 @@ public class UTF8DataInputJsonParser
      */
     private final int _handleLeadingZeroes() throws IOException
     {
-        int ch = _inputData.readUnsignedByte();
+        int ch = _inputRead();
         // if not followed by a number (probably '.'); return zero as is, to be included
         if (ch < INT_0 || ch > INT_9) {
             return ch;
@@ -1168,7 +1199,7 @@ public class UTF8DataInputJsonParser
         }
         // if so, just need to skip either all zeroes (if followed by number); or all but one (if non-number)
         while (ch == INT_0) {
-            ch = _inputData.readUnsignedByte();
+            ch = _inputRead();
         }
         return ch;
     }
@@ -1189,7 +1220,7 @@ public class UTF8DataInputJsonParser
 
             fract_loop:
             while (true) {
-                c = _inputData.readUnsignedByte();
+                c = _inputRead();
                 if (c < INT_0 || c > INT_9) {
                     break fract_loop;
                 }
@@ -1217,7 +1248,7 @@ public class UTF8DataInputJsonParser
                 outPtr = 0;
             }
             outBuf[outPtr++] = (char) c;
-            c = _inputData.readUnsignedByte();
+            c = _inputRead();
             // Sign indicator?
             if (c == '-' || c == '+') {
                 if (outPtr >= outBuf.length) {
@@ -1225,7 +1256,7 @@ public class UTF8DataInputJsonParser
                     outPtr = 0;
                 }
                 outBuf[outPtr++] = (char) c;
-                c = _inputData.readUnsignedByte();
+                c = _inputRead();
             }
             while (c <= INT_9 && c >= INT_0) {
                 ++expLen;
@@ -1234,7 +1265,7 @@ public class UTF8DataInputJsonParser
                     outPtr = 0;
                 }
                 outBuf[outPtr++] = (char) c;
-                c = _inputData.readUnsignedByte();
+                c = _inputRead();
             }
             // must be followed by sequence of ints, one minimum
             if (expLen == 0) {
@@ -1294,19 +1325,19 @@ public class UTF8DataInputJsonParser
          */
         final int[] codes = _icLatin1;
 
-        int q = _inputData.readUnsignedByte();
+        int q = _inputRead();
 
         if (codes[q] == 0) {
-            i = _inputData.readUnsignedByte();
+            i = _inputRead();
             if (codes[i] == 0) {
                 q = (q << 8) | i;
-                i = _inputData.readUnsignedByte();
+                i = _inputRead();
                 if (codes[i] == 0) {
                     q = (q << 8) | i;
-                    i = _inputData.readUnsignedByte();
+                    i = _inputRead();
                     if (codes[i] == 0) {
                         q = (q << 8) | i;
-                        i = _inputData.readUnsignedByte();
+                        i = _inputRead();
                         if (codes[i] == 0) {
                             _quad1 = q;
                             return _parseMediumName(i);
@@ -1342,7 +1373,7 @@ public class UTF8DataInputJsonParser
         final int[] codes = _icLatin1;
 
         // Ok, got 5 name bytes so far
-        int i = _inputData.readUnsignedByte();
+        int i = _inputRead();
         if (codes[i] != 0) {
             if (i == INT_QUOTE) { // 5 bytes
                 return findName(_quad1, q2, 1);
@@ -1350,7 +1381,7 @@ public class UTF8DataInputJsonParser
             return parseName(_quad1, q2, i, 1); // quoting or invalid char
         }
         q2 = (q2 << 8) | i;
-        i = _inputData.readUnsignedByte();
+        i = _inputRead();
         if (codes[i] != 0) {
             if (i == INT_QUOTE) { // 6 bytes
                 return findName(_quad1, q2, 2);
@@ -1358,7 +1389,7 @@ public class UTF8DataInputJsonParser
             return parseName(_quad1, q2, i, 2);
         }
         q2 = (q2 << 8) | i;
-        i = _inputData.readUnsignedByte();
+        i = _inputRead();
         if (codes[i] != 0) {
             if (i == INT_QUOTE) { // 7 bytes
                 return findName(_quad1, q2, 3);
@@ -1366,7 +1397,7 @@ public class UTF8DataInputJsonParser
             return parseName(_quad1, q2, i, 3);
         }
         q2 = (q2 << 8) | i;
-        i = _inputData.readUnsignedByte();
+        i = _inputRead();
         if (codes[i] != 0) {
             if (i == INT_QUOTE) { // 8 bytes
                 return findName(_quad1, q2, 4);
@@ -1381,7 +1412,7 @@ public class UTF8DataInputJsonParser
         final int[] codes = _icLatin1;
 
         // Got 9 name bytes so far
-        int i = _inputData.readUnsignedByte();
+        int i = _inputRead();
         if (codes[i] != 0) {
             if (i == INT_QUOTE) { // 9 bytes
                 return findName(_quad1, q2, q3, 1);
@@ -1389,7 +1420,7 @@ public class UTF8DataInputJsonParser
             return parseName(_quad1, q2, q3, i, 1);
         }
         q3 = (q3 << 8) | i;
-        i = _inputData.readUnsignedByte();
+        i = _inputRead();
         if (codes[i] != 0) {
             if (i == INT_QUOTE) { // 10 bytes
                 return findName(_quad1, q2, q3, 2);
@@ -1397,7 +1428,7 @@ public class UTF8DataInputJsonParser
             return parseName(_quad1, q2, q3, i, 2);
         }
         q3 = (q3 << 8) | i;
-        i = _inputData.readUnsignedByte();
+        i = _inputRead();
         if (codes[i] != 0) {
             if (i == INT_QUOTE) { // 11 bytes
                 return findName(_quad1, q2, q3, 3);
@@ -1405,7 +1436,7 @@ public class UTF8DataInputJsonParser
             return parseName(_quad1, q2, q3, i, 3);
         }
         q3 = (q3 << 8) | i;
-        i = _inputData.readUnsignedByte();
+        i = _inputRead();
         if (codes[i] != 0) {
             if (i == INT_QUOTE) { // 12 bytes
                 return findName(_quad1, q2, q3, 4);
@@ -1427,7 +1458,7 @@ public class UTF8DataInputJsonParser
         int qlen = 3;
 
         while (true) {
-            int i = _inputData.readUnsignedByte();
+            int i = _inputRead();
             if (codes[i] != 0) {
                 if (i == INT_QUOTE) {
                     return findName(_quadBuffer, qlen, q, 1);
@@ -1436,7 +1467,7 @@ public class UTF8DataInputJsonParser
             }
 
             q = (q << 8) | i;
-            i = _inputData.readUnsignedByte();
+            i = _inputRead();
             if (codes[i] != 0) {
                 if (i == INT_QUOTE) {
                     return findName(_quadBuffer, qlen, q, 2);
@@ -1445,7 +1476,7 @@ public class UTF8DataInputJsonParser
             }
 
             q = (q << 8) | i;
-            i = _inputData.readUnsignedByte();
+            i = _inputRead();
             if (codes[i] != 0) {
                 if (i == INT_QUOTE) {
                     return findName(_quadBuffer, qlen, q, 3);
@@ -1454,7 +1485,7 @@ public class UTF8DataInputJsonParser
             }
 
             q = (q << 8) | i;
-            i = _inputData.readUnsignedByte();
+            i = _inputRead();
             if (codes[i] != 0) {
                 if (i == INT_QUOTE) {
                     return findName(_quadBuffer, qlen, q, 4);
@@ -1517,7 +1548,7 @@ public class UTF8DataInputJsonParser
                 // [jackson-core#1541]: Handle JSON-escaped surrogate pairs in field names
                 if (ch >= 0xD800 && ch <= 0xDBFF) { // high surrogate
                     // Must be followed by \\uXXXX low surrogate
-                    int next = _inputData.readUnsignedByte();
+                    int next = _inputRead();
                     if (next != INT_BACKSLASH) {
                         _reportError("Broken surrogate pair in property name: expected '\\' to start low surrogate, got 0x"
                                 + Integer.toHexString(next));
@@ -1597,7 +1628,7 @@ public class UTF8DataInputJsonParser
                 currQuad = ch;
                 currQuadBytes = 1;
             }
-            ch = _inputData.readUnsignedByte();
+            ch = _inputRead();
         }
 
         if (currQuadBytes > 0) {
@@ -1667,7 +1698,7 @@ public class UTF8DataInputJsonParser
                 currQuad = ch;
                 currQuadBytes = 1;
             }
-            ch = _inputData.readUnsignedByte();
+            ch = _inputRead();
             if (codes[ch] != 0) {
                 break;
             }
@@ -1695,7 +1726,7 @@ public class UTF8DataInputJsonParser
      */
     protected String _parseAposName() throws IOException
     {
-        int ch = _inputData.readUnsignedByte();
+        int ch = _inputRead();
         if (ch == '\'') { // special case, ''
             return "";
         }
@@ -1724,7 +1755,7 @@ public class UTF8DataInputJsonParser
                 }
                 // [jackson-core#1541]: Handle JSON-escaped surrogate pairs in field names
                 if (ch >= 0xD800 && ch <= 0xDBFF) { // high surrogate
-                    int next = _inputData.readUnsignedByte();
+                    int next = _inputRead();
                     if (next != INT_BACKSLASH) {
                         _reportError("Broken surrogate pair in property name: expected '\\' to start low surrogate, got 0x"
                                 + Integer.toHexString(next));
@@ -1804,7 +1835,7 @@ public class UTF8DataInputJsonParser
                 currQuad = ch;
                 currQuadBytes = 1;
             }
-            ch = _inputData.readUnsignedByte();
+            ch = _inputRead();
         }
 
         if (currQuadBytes > 0) {
@@ -2018,7 +2049,7 @@ public class UTF8DataInputJsonParser
 
         try {
             do {
-                int c = _inputData.readUnsignedByte();
+                int c = _inputRead();
                 if (codes[c] != 0) {
                     if (c == INT_QUOTE) {
                         _textBuffer.setCurrentLength(outPtr);
@@ -2029,7 +2060,7 @@ public class UTF8DataInputJsonParser
                 }
                 outBuf[outPtr++] = (char) c;
             } while (outPtr < outEnd);
-            _finishString2(outBuf, outPtr, _inputData.readUnsignedByte());
+            _finishString2(outBuf, outPtr, _inputRead());
         } catch (IOException e) {
             throw _wrapIOFailure(e);
         }
@@ -2044,7 +2075,7 @@ public class UTF8DataInputJsonParser
 
         try {
             do {
-                int c = _inputData.readUnsignedByte();
+                int c = _inputRead();
                 if (codes[c] != 0) {
                     if (c == INT_QUOTE) {
                         return _textBuffer.setCurrentAndReturn(outPtr);
@@ -2054,7 +2085,7 @@ public class UTF8DataInputJsonParser
                 }
                 outBuf[outPtr++] = (char) c;
             } while (outPtr < outEnd);
-            _finishString2(outBuf, outPtr, _inputData.readUnsignedByte());
+            _finishString2(outBuf, outPtr, _inputRead());
         } catch (IOException e) {
             throw _wrapIOFailure(e);
         }
@@ -2069,7 +2100,7 @@ public class UTF8DataInputJsonParser
         int outEnd = outBuf.length;
 
         main_loop:
-        for (;; c = _inputData.readUnsignedByte()) {
+        for (;; c = _inputRead()) {
             // Then the tight ASCII non-funny-char loop:
             while (codes[c] == 0) {
                 if (outPtr >= outEnd) {
@@ -2078,7 +2109,7 @@ public class UTF8DataInputJsonParser
                     outEnd = outBuf.length;
                 }
                 outBuf[outPtr++] = (char) c;
-                c = _inputData.readUnsignedByte();
+                c = _inputRead();
             }
             // Ok: end marker, escape or multi-byte?
             if (c == INT_QUOTE) {
@@ -2147,7 +2178,7 @@ public class UTF8DataInputJsonParser
 
             ascii_loop:
             while (true) {
-                c = _inputData.readUnsignedByte();
+                c = _inputRead();
                 if (codes[c] != 0) {
                     break ascii_loop;
                 }
@@ -2200,7 +2231,7 @@ public class UTF8DataInputJsonParser
 
             ascii_loop:
             while (true) {
-                c = _inputData.readUnsignedByte();
+                c = _inputRead();
                 if (codes[c] != 0) {
                     break ascii_loop;
                 }
@@ -2324,7 +2355,7 @@ public class UTF8DataInputJsonParser
             _reportError("Non-standard token 'Infinity': enable `JsonReadFeature.ALLOW_NON_NUMERIC_NUMBERS` to allow");
             break;
         case '+': // note: '-' is taken as number
-            return _handleInvalidNumberStart(_inputData.readUnsignedByte(), false, true);
+            return _handleInvalidNumberStart(_inputRead(), false, true);
         }
         // [core#77] Try to decode most likely token
         if (Character.isJavaIdentifierStart(c)) {
@@ -2357,7 +2388,7 @@ public class UTF8DataInputJsonParser
                     outEnd = outBuf.length;
                 }
                 do {
-                    c = _inputData.readUnsignedByte();
+                    c = _inputRead();
                     if (c == '\'') {
                         break main_loop;
                     }
@@ -2423,7 +2454,7 @@ public class UTF8DataInputJsonParser
     protected JsonToken _handleInvalidNumberStart(int ch, final boolean neg, final boolean hasSign) throws IOException
     {
         while (ch == 'I') {
-            ch = _inputData.readUnsignedByte();
+            ch = _inputRead();
             String match;
             if (ch == 'N') {
                 match = neg ? "-INF" :"+INF";
@@ -2452,13 +2483,13 @@ public class UTF8DataInputJsonParser
     {
         final int len = matchStr.length();
         do {
-            int ch = _inputData.readUnsignedByte();
+            int ch = _inputRead();
             if (ch != matchStr.charAt(i)) {
                 _reportInvalidToken(ch, matchStr.substring(0, i));
             }
         } while (++i < len);
 
-        int ch = _inputData.readUnsignedByte();
+        int ch = _inputRead();
         if (ch >= '0' && ch != ']' && ch != '}') { // expected/allowed chars
             _checkMatchEnd(matchStr, i, ch);
         }
@@ -2483,7 +2514,7 @@ public class UTF8DataInputJsonParser
     {
         int i = _nextByte;
         if (i < 0) {
-            i = _inputData.readUnsignedByte();
+            i = _inputRead();
         } else {
             _nextByte = -1;
         }
@@ -2500,7 +2531,7 @@ public class UTF8DataInputJsonParser
                     ++_currInputRow;
                 }
             }
-            i = _inputData.readUnsignedByte();
+            i = _inputRead();
         }
     }
 
@@ -2513,7 +2544,7 @@ public class UTF8DataInputJsonParser
         int i = _nextByte;
         if (i < 0) {
             try {
-                i = _inputData.readUnsignedByte();
+                i = _inputRead();
             } catch (EOFException e) {
                 return _eofAsNextChar();
             }
@@ -2534,7 +2565,7 @@ public class UTF8DataInputJsonParser
                 }
             }
             try {
-                i = _inputData.readUnsignedByte();
+                i = _inputRead();
             } catch (EOFException e) {
                 return _eofAsNextChar();
             }
@@ -2566,7 +2597,7 @@ public class UTF8DataInputJsonParser
                 }
                 */
             }
-            i = _inputData.readUnsignedByte();
+            i = _inputRead();
         }
     }
 
@@ -2574,13 +2605,13 @@ public class UTF8DataInputJsonParser
     {
         int i = _nextByte;
         if (i < 0) {
-            i = _inputData.readUnsignedByte();
+            i = _inputRead();
         } else {
             _nextByte = -1;
         }
         // Fast path: colon with optional single-space/tab before and/or after:
         if (i == INT_COLON) { // common case, no leading space
-            i = _inputData.readUnsignedByte();
+            i = _inputRead();
             if (i > INT_SPACE) { // nor trailing
                 if (i == INT_SLASH || i == INT_HASH) {
                     return _skipColon2(i, true);
@@ -2588,7 +2619,7 @@ public class UTF8DataInputJsonParser
                 return i;
             }
             if (i == INT_SPACE || i == INT_TAB) {
-                i = _inputData.readUnsignedByte();
+                i = _inputRead();
                 if (i > INT_SPACE) {
                     if (i == INT_SLASH || i == INT_HASH) {
                         return _skipColon2(i, true);
@@ -2599,10 +2630,10 @@ public class UTF8DataInputJsonParser
             return _skipColon2(i, true); // true -> skipped colon
         }
         if (i == INT_SPACE || i == INT_TAB) {
-            i = _inputData.readUnsignedByte();
+            i = _inputRead();
         }
         if (i == INT_COLON) {
-            i = _inputData.readUnsignedByte();
+            i = _inputRead();
             if (i > INT_SPACE) {
                 if (i == INT_SLASH || i == INT_HASH) {
                     return _skipColon2(i, true);
@@ -2610,7 +2641,7 @@ public class UTF8DataInputJsonParser
                 return i;
             }
             if (i == INT_SPACE || i == INT_TAB) {
-                i = _inputData.readUnsignedByte();
+                i = _inputRead();
                 if (i > INT_SPACE) {
                     if (i == INT_SLASH || i == INT_HASH) {
                         return _skipColon2(i, true);
@@ -2625,7 +2656,7 @@ public class UTF8DataInputJsonParser
 
     private final int _skipColon2(int i, boolean gotColon) throws IOException
     {
-        for (;; i = _inputData.readUnsignedByte()) {
+        for (;; i = _inputRead()) {
             if (i > INT_SPACE) {
                 if (i == INT_SLASH) {
                     _skipComment();
@@ -2658,7 +2689,7 @@ public class UTF8DataInputJsonParser
         if (!isEnabled(JsonReadFeature.ALLOW_JAVA_COMMENTS)) {
             _reportUnexpectedChar('/', "maybe a (non-standard) comment? (not recognized as one since Feature 'ALLOW_COMMENTS' not enabled for parser)");
         }
-        int c = _inputData.readUnsignedByte();
+        int c = _inputRead();
         if (c == '/') {
             _skipLine();
         } else if (c == '*') {
@@ -2672,7 +2703,7 @@ public class UTF8DataInputJsonParser
     {
         // Need to be UTF-8 aware here to decode content (for skipping)
         final int[] codes = CharTypes.getInputCodeComment();
-        int i = _inputData.readUnsignedByte();
+        int i = _inputRead();
 
         // Ok: need the matching '*/'
         main_loop:
@@ -2681,7 +2712,7 @@ public class UTF8DataInputJsonParser
             if (code != 0) {
                 switch (code) {
                 case '*':
-                    i = _inputData.readUnsignedByte();
+                    i = _inputRead();
                     if (i == INT_SLASH) {
                         return;
                     }
@@ -2704,7 +2735,7 @@ public class UTF8DataInputJsonParser
                     _reportInvalidChar(i);
                 }
             }
-            i = _inputData.readUnsignedByte();
+            i = _inputRead();
         }
     }
 
@@ -2726,7 +2757,7 @@ public class UTF8DataInputJsonParser
         // Ok: need to find EOF or linefeed
         final int[] codes = CharTypes.getInputCodeComment();
         while (true) {
-            int i = _inputData.readUnsignedByte();
+            int i = _inputRead();
             int code = codes[i];
             if (code != 0) {
                 switch (code) {
@@ -2766,7 +2797,7 @@ public class UTF8DataInputJsonParser
 
     private char _decodeEscaped2() throws IOException
     {
-        int c = _inputData.readUnsignedByte();
+        int c = _inputRead();
 
         switch (c) {
             // First, ones that are mapped
@@ -2797,7 +2828,7 @@ public class UTF8DataInputJsonParser
         // Ok, a hex escape. Need 4 characters
         int value = 0;
         for (int i = 0; i < 4; ++i) {
-            int ch = _inputData.readUnsignedByte();
+            int ch = _inputRead();
             int digit = CharTypes.charToHex(ch);
             if (digit < 0) {
                 _reportUnexpectedChar(ch, "expected a hex-digit for character escape sequence");
@@ -2829,20 +2860,20 @@ public class UTF8DataInputJsonParser
                 needed = 1; // never gets here
             }
 
-            int d = _inputData.readUnsignedByte();
+            int d = _inputRead();
             if ((d & 0xC0) != 0x080) {
                 _reportInvalidOther(d & 0xFF);
             }
             c = (c << 6) | (d & 0x3F);
 
             if (needed > 1) { // needed == 1 means 2 bytes total
-                d = _inputData.readUnsignedByte(); // 3rd byte
+                d = _inputRead(); // 3rd byte
                 if ((d & 0xC0) != 0x080) {
                     _reportInvalidOther(d & 0xFF);
                 }
                 c = (c << 6) | (d & 0x3F);
                 if (needed > 2) { // 4 bytes? (need surrogates)
-                    d = _inputData.readUnsignedByte();
+                    d = _inputRead();
                     if ((d & 0xC0) != 0x080) {
                         _reportInvalidOther(d & 0xFF);
                     }
@@ -2861,7 +2892,7 @@ public class UTF8DataInputJsonParser
 
     private final int _decodeUtf8_2(int c) throws IOException
     {
-        int d = _inputData.readUnsignedByte();
+        int d = _inputRead();
         if ((d & 0xC0) != 0x080) {
             _reportInvalidOther(d & 0xFF);
         }
@@ -2871,12 +2902,12 @@ public class UTF8DataInputJsonParser
     private final int _decodeUtf8_3(int c1) throws IOException
     {
         c1 &= 0x0F;
-        int d = _inputData.readUnsignedByte();
+        int d = _inputRead();
         if ((d & 0xC0) != 0x080) {
             _reportInvalidOther(d & 0xFF);
         }
         int c = (c1 << 6) | (d & 0x3F);
-        d = _inputData.readUnsignedByte();
+        d = _inputRead();
         if ((d & 0xC0) != 0x080) {
             _reportInvalidOther(d & 0xFF);
         }
@@ -2894,17 +2925,17 @@ public class UTF8DataInputJsonParser
      */
     private final int _decodeUtf8_4(int c) throws IOException
     {
-        int d = _inputData.readUnsignedByte();
+        int d = _inputRead();
         if ((d & 0xC0) != 0x080) {
             _reportInvalidOther(d & 0xFF);
         }
         c = ((c & 0x07) << 6) | (d & 0x3F);
-        d = _inputData.readUnsignedByte();
+        d = _inputRead();
         if ((d & 0xC0) != 0x080) {
             _reportInvalidOther(d & 0xFF);
         }
         c = (c << 6) | (d & 0x3F);
-        d = _inputData.readUnsignedByte();
+        d = _inputRead();
         if ((d & 0xC0) != 0x080) {
             _reportInvalidOther(d & 0xFF);
         }
@@ -2917,7 +2948,7 @@ public class UTF8DataInputJsonParser
 
     private final void _skipUtf8_2() throws IOException
     {
-        int c = _inputData.readUnsignedByte();
+        int c = _inputRead();
         if ((c & 0xC0) != 0x080) {
             _reportInvalidOther(c & 0xFF);
         }
@@ -2929,11 +2960,11 @@ public class UTF8DataInputJsonParser
     private final void _skipUtf8_3() throws IOException
     {
         //c &= 0x0F;
-        int c = _inputData.readUnsignedByte();
+        int c = _inputRead();
         if ((c & 0xC0) != 0x080) {
             _reportInvalidOther(c & 0xFF);
         }
-        c = _inputData.readUnsignedByte();
+        c = _inputRead();
         if ((c & 0xC0) != 0x080) {
             _reportInvalidOther(c & 0xFF);
         }
@@ -2941,15 +2972,15 @@ public class UTF8DataInputJsonParser
 
     private final void _skipUtf8_4() throws IOException
     {
-        int d = _inputData.readUnsignedByte();
+        int d = _inputRead();
         if ((d & 0xC0) != 0x080) {
             _reportInvalidOther(d & 0xFF);
         }
-        d = _inputData.readUnsignedByte();
+        d = _inputRead();
         if ((d & 0xC0) != 0x080) {
             _reportInvalidOther(d & 0xFF);
         }
-        d = _inputData.readUnsignedByte();
+        d = _inputRead();
         if ((d & 0xC0) != 0x080) {
             _reportInvalidOther(d & 0xFF);
         }
@@ -2980,7 +3011,7 @@ public class UTF8DataInputJsonParser
                      break;
                  }
                  sb.append(c);
-                 ch = _inputData.readUnsignedByte();
+                 ch = _inputRead();
              }
          } catch (IOException e) {
              ; // ok since we are just trying to get token for diagnostics
@@ -3036,7 +3067,7 @@ public class UTF8DataInputJsonParser
             // first, we'll skip preceding white space, if any
             int ch;
             do {
-                ch = _inputData.readUnsignedByte();
+                ch = _inputRead();
             } while (ch <= INT_SPACE);
             int bits = b64variant.decodeBase64Char(ch);
             if (bits < 0) { // reached the end, fair and square?
@@ -3051,14 +3082,14 @@ public class UTF8DataInputJsonParser
             int decodedData = bits;
 
             // then second base64 char; can't get padding yet, nor ws
-            ch = _inputData.readUnsignedByte();
+            ch = _inputRead();
             bits = b64variant.decodeBase64Char(ch);
             if (bits < 0) {
                 bits = _decodeBase64Escape(b64variant, ch, 1);
             }
             decodedData = (decodedData << 6) | bits;
             // third base64 char; can be padding, but not ws
-            ch = _inputData.readUnsignedByte();
+            ch = _inputRead();
             bits = b64variant.decodeBase64Char(ch);
 
             // First branch: can get padding (-> 1 byte)
@@ -3076,7 +3107,7 @@ public class UTF8DataInputJsonParser
                     bits = _decodeBase64Escape(b64variant, ch, 2);
                 }
                 if (bits == Base64Variant.BASE64_VALUE_PADDING) {
-                    ch = _inputData.readUnsignedByte();
+                    ch = _inputRead();
                     if (!b64variant.usesPaddingChar(ch)) {
                         if ((ch != INT_BACKSLASH)
                                 || _decodeBase64Escape(b64variant, ch, 3) != Base64Variant.BASE64_VALUE_PADDING) {
@@ -3092,7 +3123,7 @@ public class UTF8DataInputJsonParser
             // Nope, 2 or 3 bytes
             decodedData = (decodedData << 6) | bits;
             // fourth and last base64 char; can be padding, but not ws
-            ch = _inputData.readUnsignedByte();
+            ch = _inputRead();
             bits = b64variant.decodeBase64Char(ch);
             if (bits < 0) {
                 if (bits != Base64Variant.BASE64_VALUE_PADDING) {

--- a/src/main/java/tools/jackson/core/json/UTF8DataInputJsonParser.java
+++ b/src/main/java/tools/jackson/core/json/UTF8DataInputJsonParser.java
@@ -93,18 +93,6 @@ public class UTF8DataInputJsonParser
      */
     protected int _nextByte = -1;
 
-    /**
-     * Whether a maximum document length limit has been configured.
-     * Used to decide whether to track {@link #_inputProcessed}.
-     */
-    private final boolean _hasMaxDocumentLength;
-
-    /**
-     * Number of bytes read from {@link #_inputData}, used to enforce
-     * the maximum document length constraint when configured.
-     */
-    protected long _inputProcessed = 0L;
-
     /*
     /**********************************************************************
     /* Life-cycle
@@ -120,7 +108,6 @@ public class UTF8DataInputJsonParser
         _symbols = sym;
         _inputData = inputData;
         _nextByte = firstByte;
-        _hasMaxDocumentLength = _streamReadConstraints.hasMaxDocumentLength();
     }
 
     /*
@@ -160,18 +147,6 @@ public class UTF8DataInputJsonParser
         super._releaseBuffers();
         // Merge found symbols, if any:
         _symbols.release();
-    }
-
-    /**
-     * Helper method that reads one unsigned byte from {@link #_inputData},
-     * incrementing {@link #_inputProcessed} when max-document-length tracking
-     * is active.
-     */
-    private int _inputRead() throws IOException {
-        if (_hasMaxDocumentLength) {
-            ++_inputProcessed;
-        }
-        return _inputData.readUnsignedByte();
     }
 
     /*
@@ -470,7 +445,7 @@ public class UTF8DataInputJsonParser
             // first, we'll skip preceding white space, if any
             int ch;
             do {
-                ch = _inputRead();
+                ch = _inputData.readUnsignedByte();
             } while (ch <= INT_SPACE);
             int bits = b64variant.decodeBase64Char(ch);
             if (bits < 0) { // reached the end, fair and square?
@@ -493,7 +468,7 @@ public class UTF8DataInputJsonParser
             int decodedData = bits;
 
             // then second base64 char; can't get padding yet, nor ws
-            ch = _inputRead();
+            ch = _inputData.readUnsignedByte();
             bits = b64variant.decodeBase64Char(ch);
             if (bits < 0) {
                 bits = _decodeBase64Escape(b64variant, ch, 1);
@@ -501,7 +476,7 @@ public class UTF8DataInputJsonParser
             decodedData = (decodedData << 6) | bits;
 
             // third base64 char; can be padding, but not ws
-            ch = _inputRead();
+            ch = _inputData.readUnsignedByte();
             bits = b64variant.decodeBase64Char(ch);
 
             // First branch: can get padding (-> 1 byte)
@@ -520,7 +495,7 @@ public class UTF8DataInputJsonParser
                 }
                 if (bits == Base64Variant.BASE64_VALUE_PADDING) {
                     // Ok, must get padding
-                    ch = _inputRead();
+                    ch = _inputData.readUnsignedByte();
                     if (!b64variant.usesPaddingChar(ch)) {
                         if ((ch != INT_BACKSLASH)
                                 || _decodeBase64Escape(b64variant, ch, 3) != Base64Variant.BASE64_VALUE_PADDING) {
@@ -536,7 +511,7 @@ public class UTF8DataInputJsonParser
             // Nope, 2 or 3 bytes
             decodedData = (decodedData << 6) | bits;
             // fourth and last base64 char; can be padding, but not ws
-            ch = _inputRead();
+            ch = _inputData.readUnsignedByte();
             bits = b64variant.decodeBase64Char(ch);
             if (bits < 0) {
                 if (bits != Base64Variant.BASE64_VALUE_PADDING) {
@@ -620,9 +595,6 @@ public class UTF8DataInputJsonParser
             // Close/release things like input source, symbol table and recyclable buffers
             close();
             return _updateTokenToNull();
-        }
-        if (_hasMaxDocumentLength) {
-            _streamReadConstraints.validateDocumentLength(_inputProcessed);
         }
         // clear any data retained so far
         _binaryValue = null;
@@ -824,9 +796,6 @@ public class UTF8DataInputJsonParser
             _skipString();
         }
         int i = _skipWS();
-        if (_hasMaxDocumentLength) {
-            _streamReadConstraints.validateDocumentLength(_inputProcessed);
-        }
         _binaryValue = null;
         _tokenInputRow = _currInputRow;
 
@@ -1087,7 +1056,7 @@ public class UTF8DataInputJsonParser
             }
         } else {
             outBuf[0] = (char) c;
-            c = _inputRead();
+            c = _inputData.readUnsignedByte();
             outPtr = 1;
         }
         int intLen = outPtr;
@@ -1100,7 +1069,7 @@ public class UTF8DataInputJsonParser
                 outPtr = 0;
             }
             outBuf[outPtr++] = (char) c;
-            c = _inputRead();
+            c = _inputData.readUnsignedByte();
         }
         if (c == '.' || (c | 0x20) == INT_e) { // ~ '.eE'
             return _parseFloat(outBuf, outPtr, c, false, intLen);
@@ -1132,7 +1101,7 @@ public class UTF8DataInputJsonParser
 
         // [core#784]: Include sign character ('+' or '-') in textual representation
         outBuf[outPtr++] = negative ? '-' : '+';
-        int c = _inputRead();
+        int c = _inputData.readUnsignedByte();
         outBuf[outPtr++] = (char) c;
         // Note: must be followed by a digit
         if (c <= INT_0) {
@@ -1148,7 +1117,7 @@ public class UTF8DataInputJsonParser
             if (c > INT_9) {
                 return _handleInvalidNumberStart(c, negative, true);
             }
-            c = _inputRead();
+            c = _inputData.readUnsignedByte();
         }
         // Ok: we can first just add digit we saw first:
         int intLen = 1;
@@ -1161,7 +1130,7 @@ public class UTF8DataInputJsonParser
                 outPtr = 0;
             }
             outBuf[outPtr++] = (char) c;
-            c = _inputRead();
+            c = _inputData.readUnsignedByte();
         }
         if (c == '.' || (c | 0x20) == INT_e) { // ~ '.eE'
             return _parseFloat(outBuf, outPtr, c, negative, intLen);
@@ -1188,7 +1157,7 @@ public class UTF8DataInputJsonParser
      */
     private final int _handleLeadingZeroes() throws IOException
     {
-        int ch = _inputRead();
+        int ch = _inputData.readUnsignedByte();
         // if not followed by a number (probably '.'); return zero as is, to be included
         if (ch < INT_0 || ch > INT_9) {
             return ch;
@@ -1199,7 +1168,7 @@ public class UTF8DataInputJsonParser
         }
         // if so, just need to skip either all zeroes (if followed by number); or all but one (if non-number)
         while (ch == INT_0) {
-            ch = _inputRead();
+            ch = _inputData.readUnsignedByte();
         }
         return ch;
     }
@@ -1220,7 +1189,7 @@ public class UTF8DataInputJsonParser
 
             fract_loop:
             while (true) {
-                c = _inputRead();
+                c = _inputData.readUnsignedByte();
                 if (c < INT_0 || c > INT_9) {
                     break fract_loop;
                 }
@@ -1248,7 +1217,7 @@ public class UTF8DataInputJsonParser
                 outPtr = 0;
             }
             outBuf[outPtr++] = (char) c;
-            c = _inputRead();
+            c = _inputData.readUnsignedByte();
             // Sign indicator?
             if (c == '-' || c == '+') {
                 if (outPtr >= outBuf.length) {
@@ -1256,7 +1225,7 @@ public class UTF8DataInputJsonParser
                     outPtr = 0;
                 }
                 outBuf[outPtr++] = (char) c;
-                c = _inputRead();
+                c = _inputData.readUnsignedByte();
             }
             while (c <= INT_9 && c >= INT_0) {
                 ++expLen;
@@ -1265,7 +1234,7 @@ public class UTF8DataInputJsonParser
                     outPtr = 0;
                 }
                 outBuf[outPtr++] = (char) c;
-                c = _inputRead();
+                c = _inputData.readUnsignedByte();
             }
             // must be followed by sequence of ints, one minimum
             if (expLen == 0) {
@@ -1325,19 +1294,19 @@ public class UTF8DataInputJsonParser
          */
         final int[] codes = _icLatin1;
 
-        int q = _inputRead();
+        int q = _inputData.readUnsignedByte();
 
         if (codes[q] == 0) {
-            i = _inputRead();
+            i = _inputData.readUnsignedByte();
             if (codes[i] == 0) {
                 q = (q << 8) | i;
-                i = _inputRead();
+                i = _inputData.readUnsignedByte();
                 if (codes[i] == 0) {
                     q = (q << 8) | i;
-                    i = _inputRead();
+                    i = _inputData.readUnsignedByte();
                     if (codes[i] == 0) {
                         q = (q << 8) | i;
-                        i = _inputRead();
+                        i = _inputData.readUnsignedByte();
                         if (codes[i] == 0) {
                             _quad1 = q;
                             return _parseMediumName(i);
@@ -1373,7 +1342,7 @@ public class UTF8DataInputJsonParser
         final int[] codes = _icLatin1;
 
         // Ok, got 5 name bytes so far
-        int i = _inputRead();
+        int i = _inputData.readUnsignedByte();
         if (codes[i] != 0) {
             if (i == INT_QUOTE) { // 5 bytes
                 return findName(_quad1, q2, 1);
@@ -1381,7 +1350,7 @@ public class UTF8DataInputJsonParser
             return parseName(_quad1, q2, i, 1); // quoting or invalid char
         }
         q2 = (q2 << 8) | i;
-        i = _inputRead();
+        i = _inputData.readUnsignedByte();
         if (codes[i] != 0) {
             if (i == INT_QUOTE) { // 6 bytes
                 return findName(_quad1, q2, 2);
@@ -1389,7 +1358,7 @@ public class UTF8DataInputJsonParser
             return parseName(_quad1, q2, i, 2);
         }
         q2 = (q2 << 8) | i;
-        i = _inputRead();
+        i = _inputData.readUnsignedByte();
         if (codes[i] != 0) {
             if (i == INT_QUOTE) { // 7 bytes
                 return findName(_quad1, q2, 3);
@@ -1397,7 +1366,7 @@ public class UTF8DataInputJsonParser
             return parseName(_quad1, q2, i, 3);
         }
         q2 = (q2 << 8) | i;
-        i = _inputRead();
+        i = _inputData.readUnsignedByte();
         if (codes[i] != 0) {
             if (i == INT_QUOTE) { // 8 bytes
                 return findName(_quad1, q2, 4);
@@ -1412,7 +1381,7 @@ public class UTF8DataInputJsonParser
         final int[] codes = _icLatin1;
 
         // Got 9 name bytes so far
-        int i = _inputRead();
+        int i = _inputData.readUnsignedByte();
         if (codes[i] != 0) {
             if (i == INT_QUOTE) { // 9 bytes
                 return findName(_quad1, q2, q3, 1);
@@ -1420,7 +1389,7 @@ public class UTF8DataInputJsonParser
             return parseName(_quad1, q2, q3, i, 1);
         }
         q3 = (q3 << 8) | i;
-        i = _inputRead();
+        i = _inputData.readUnsignedByte();
         if (codes[i] != 0) {
             if (i == INT_QUOTE) { // 10 bytes
                 return findName(_quad1, q2, q3, 2);
@@ -1428,7 +1397,7 @@ public class UTF8DataInputJsonParser
             return parseName(_quad1, q2, q3, i, 2);
         }
         q3 = (q3 << 8) | i;
-        i = _inputRead();
+        i = _inputData.readUnsignedByte();
         if (codes[i] != 0) {
             if (i == INT_QUOTE) { // 11 bytes
                 return findName(_quad1, q2, q3, 3);
@@ -1436,7 +1405,7 @@ public class UTF8DataInputJsonParser
             return parseName(_quad1, q2, q3, i, 3);
         }
         q3 = (q3 << 8) | i;
-        i = _inputRead();
+        i = _inputData.readUnsignedByte();
         if (codes[i] != 0) {
             if (i == INT_QUOTE) { // 12 bytes
                 return findName(_quad1, q2, q3, 4);
@@ -1458,7 +1427,7 @@ public class UTF8DataInputJsonParser
         int qlen = 3;
 
         while (true) {
-            int i = _inputRead();
+            int i = _inputData.readUnsignedByte();
             if (codes[i] != 0) {
                 if (i == INT_QUOTE) {
                     return findName(_quadBuffer, qlen, q, 1);
@@ -1467,7 +1436,7 @@ public class UTF8DataInputJsonParser
             }
 
             q = (q << 8) | i;
-            i = _inputRead();
+            i = _inputData.readUnsignedByte();
             if (codes[i] != 0) {
                 if (i == INT_QUOTE) {
                     return findName(_quadBuffer, qlen, q, 2);
@@ -1476,7 +1445,7 @@ public class UTF8DataInputJsonParser
             }
 
             q = (q << 8) | i;
-            i = _inputRead();
+            i = _inputData.readUnsignedByte();
             if (codes[i] != 0) {
                 if (i == INT_QUOTE) {
                     return findName(_quadBuffer, qlen, q, 3);
@@ -1485,7 +1454,7 @@ public class UTF8DataInputJsonParser
             }
 
             q = (q << 8) | i;
-            i = _inputRead();
+            i = _inputData.readUnsignedByte();
             if (codes[i] != 0) {
                 if (i == INT_QUOTE) {
                     return findName(_quadBuffer, qlen, q, 4);
@@ -1548,7 +1517,7 @@ public class UTF8DataInputJsonParser
                 // [jackson-core#1541]: Handle JSON-escaped surrogate pairs in field names
                 if (ch >= 0xD800 && ch <= 0xDBFF) { // high surrogate
                     // Must be followed by \\uXXXX low surrogate
-                    int next = _inputRead();
+                    int next = _inputData.readUnsignedByte();
                     if (next != INT_BACKSLASH) {
                         _reportError("Broken surrogate pair in property name: expected '\\' to start low surrogate, got 0x"
                                 + Integer.toHexString(next));
@@ -1628,7 +1597,7 @@ public class UTF8DataInputJsonParser
                 currQuad = ch;
                 currQuadBytes = 1;
             }
-            ch = _inputRead();
+            ch = _inputData.readUnsignedByte();
         }
 
         if (currQuadBytes > 0) {
@@ -1698,7 +1667,7 @@ public class UTF8DataInputJsonParser
                 currQuad = ch;
                 currQuadBytes = 1;
             }
-            ch = _inputRead();
+            ch = _inputData.readUnsignedByte();
             if (codes[ch] != 0) {
                 break;
             }
@@ -1726,7 +1695,7 @@ public class UTF8DataInputJsonParser
      */
     protected String _parseAposName() throws IOException
     {
-        int ch = _inputRead();
+        int ch = _inputData.readUnsignedByte();
         if (ch == '\'') { // special case, ''
             return "";
         }
@@ -1755,7 +1724,7 @@ public class UTF8DataInputJsonParser
                 }
                 // [jackson-core#1541]: Handle JSON-escaped surrogate pairs in field names
                 if (ch >= 0xD800 && ch <= 0xDBFF) { // high surrogate
-                    int next = _inputRead();
+                    int next = _inputData.readUnsignedByte();
                     if (next != INT_BACKSLASH) {
                         _reportError("Broken surrogate pair in property name: expected '\\' to start low surrogate, got 0x"
                                 + Integer.toHexString(next));
@@ -1835,7 +1804,7 @@ public class UTF8DataInputJsonParser
                 currQuad = ch;
                 currQuadBytes = 1;
             }
-            ch = _inputRead();
+            ch = _inputData.readUnsignedByte();
         }
 
         if (currQuadBytes > 0) {
@@ -2049,7 +2018,7 @@ public class UTF8DataInputJsonParser
 
         try {
             do {
-                int c = _inputRead();
+                int c = _inputData.readUnsignedByte();
                 if (codes[c] != 0) {
                     if (c == INT_QUOTE) {
                         _textBuffer.setCurrentLength(outPtr);
@@ -2060,7 +2029,7 @@ public class UTF8DataInputJsonParser
                 }
                 outBuf[outPtr++] = (char) c;
             } while (outPtr < outEnd);
-            _finishString2(outBuf, outPtr, _inputRead());
+            _finishString2(outBuf, outPtr, _inputData.readUnsignedByte());
         } catch (IOException e) {
             throw _wrapIOFailure(e);
         }
@@ -2075,7 +2044,7 @@ public class UTF8DataInputJsonParser
 
         try {
             do {
-                int c = _inputRead();
+                int c = _inputData.readUnsignedByte();
                 if (codes[c] != 0) {
                     if (c == INT_QUOTE) {
                         return _textBuffer.setCurrentAndReturn(outPtr);
@@ -2085,7 +2054,7 @@ public class UTF8DataInputJsonParser
                 }
                 outBuf[outPtr++] = (char) c;
             } while (outPtr < outEnd);
-            _finishString2(outBuf, outPtr, _inputRead());
+            _finishString2(outBuf, outPtr, _inputData.readUnsignedByte());
         } catch (IOException e) {
             throw _wrapIOFailure(e);
         }
@@ -2100,7 +2069,7 @@ public class UTF8DataInputJsonParser
         int outEnd = outBuf.length;
 
         main_loop:
-        for (;; c = _inputRead()) {
+        for (;; c = _inputData.readUnsignedByte()) {
             // Then the tight ASCII non-funny-char loop:
             while (codes[c] == 0) {
                 if (outPtr >= outEnd) {
@@ -2109,7 +2078,7 @@ public class UTF8DataInputJsonParser
                     outEnd = outBuf.length;
                 }
                 outBuf[outPtr++] = (char) c;
-                c = _inputRead();
+                c = _inputData.readUnsignedByte();
             }
             // Ok: end marker, escape or multi-byte?
             if (c == INT_QUOTE) {
@@ -2178,7 +2147,7 @@ public class UTF8DataInputJsonParser
 
             ascii_loop:
             while (true) {
-                c = _inputRead();
+                c = _inputData.readUnsignedByte();
                 if (codes[c] != 0) {
                     break ascii_loop;
                 }
@@ -2231,7 +2200,7 @@ public class UTF8DataInputJsonParser
 
             ascii_loop:
             while (true) {
-                c = _inputRead();
+                c = _inputData.readUnsignedByte();
                 if (codes[c] != 0) {
                     break ascii_loop;
                 }
@@ -2355,7 +2324,7 @@ public class UTF8DataInputJsonParser
             _reportError("Non-standard token 'Infinity': enable `JsonReadFeature.ALLOW_NON_NUMERIC_NUMBERS` to allow");
             break;
         case '+': // note: '-' is taken as number
-            return _handleInvalidNumberStart(_inputRead(), false, true);
+            return _handleInvalidNumberStart(_inputData.readUnsignedByte(), false, true);
         }
         // [core#77] Try to decode most likely token
         if (Character.isJavaIdentifierStart(c)) {
@@ -2388,7 +2357,7 @@ public class UTF8DataInputJsonParser
                     outEnd = outBuf.length;
                 }
                 do {
-                    c = _inputRead();
+                    c = _inputData.readUnsignedByte();
                     if (c == '\'') {
                         break main_loop;
                     }
@@ -2454,7 +2423,7 @@ public class UTF8DataInputJsonParser
     protected JsonToken _handleInvalidNumberStart(int ch, final boolean neg, final boolean hasSign) throws IOException
     {
         while (ch == 'I') {
-            ch = _inputRead();
+            ch = _inputData.readUnsignedByte();
             String match;
             if (ch == 'N') {
                 match = neg ? "-INF" :"+INF";
@@ -2483,13 +2452,13 @@ public class UTF8DataInputJsonParser
     {
         final int len = matchStr.length();
         do {
-            int ch = _inputRead();
+            int ch = _inputData.readUnsignedByte();
             if (ch != matchStr.charAt(i)) {
                 _reportInvalidToken(ch, matchStr.substring(0, i));
             }
         } while (++i < len);
 
-        int ch = _inputRead();
+        int ch = _inputData.readUnsignedByte();
         if (ch >= '0' && ch != ']' && ch != '}') { // expected/allowed chars
             _checkMatchEnd(matchStr, i, ch);
         }
@@ -2514,7 +2483,7 @@ public class UTF8DataInputJsonParser
     {
         int i = _nextByte;
         if (i < 0) {
-            i = _inputRead();
+            i = _inputData.readUnsignedByte();
         } else {
             _nextByte = -1;
         }
@@ -2531,7 +2500,7 @@ public class UTF8DataInputJsonParser
                     ++_currInputRow;
                 }
             }
-            i = _inputRead();
+            i = _inputData.readUnsignedByte();
         }
     }
 
@@ -2544,7 +2513,7 @@ public class UTF8DataInputJsonParser
         int i = _nextByte;
         if (i < 0) {
             try {
-                i = _inputRead();
+                i = _inputData.readUnsignedByte();
             } catch (EOFException e) {
                 return _eofAsNextChar();
             }
@@ -2565,7 +2534,7 @@ public class UTF8DataInputJsonParser
                 }
             }
             try {
-                i = _inputRead();
+                i = _inputData.readUnsignedByte();
             } catch (EOFException e) {
                 return _eofAsNextChar();
             }
@@ -2597,7 +2566,7 @@ public class UTF8DataInputJsonParser
                 }
                 */
             }
-            i = _inputRead();
+            i = _inputData.readUnsignedByte();
         }
     }
 
@@ -2605,13 +2574,13 @@ public class UTF8DataInputJsonParser
     {
         int i = _nextByte;
         if (i < 0) {
-            i = _inputRead();
+            i = _inputData.readUnsignedByte();
         } else {
             _nextByte = -1;
         }
         // Fast path: colon with optional single-space/tab before and/or after:
         if (i == INT_COLON) { // common case, no leading space
-            i = _inputRead();
+            i = _inputData.readUnsignedByte();
             if (i > INT_SPACE) { // nor trailing
                 if (i == INT_SLASH || i == INT_HASH) {
                     return _skipColon2(i, true);
@@ -2619,7 +2588,7 @@ public class UTF8DataInputJsonParser
                 return i;
             }
             if (i == INT_SPACE || i == INT_TAB) {
-                i = _inputRead();
+                i = _inputData.readUnsignedByte();
                 if (i > INT_SPACE) {
                     if (i == INT_SLASH || i == INT_HASH) {
                         return _skipColon2(i, true);
@@ -2630,10 +2599,10 @@ public class UTF8DataInputJsonParser
             return _skipColon2(i, true); // true -> skipped colon
         }
         if (i == INT_SPACE || i == INT_TAB) {
-            i = _inputRead();
+            i = _inputData.readUnsignedByte();
         }
         if (i == INT_COLON) {
-            i = _inputRead();
+            i = _inputData.readUnsignedByte();
             if (i > INT_SPACE) {
                 if (i == INT_SLASH || i == INT_HASH) {
                     return _skipColon2(i, true);
@@ -2641,7 +2610,7 @@ public class UTF8DataInputJsonParser
                 return i;
             }
             if (i == INT_SPACE || i == INT_TAB) {
-                i = _inputRead();
+                i = _inputData.readUnsignedByte();
                 if (i > INT_SPACE) {
                     if (i == INT_SLASH || i == INT_HASH) {
                         return _skipColon2(i, true);
@@ -2656,7 +2625,7 @@ public class UTF8DataInputJsonParser
 
     private final int _skipColon2(int i, boolean gotColon) throws IOException
     {
-        for (;; i = _inputRead()) {
+        for (;; i = _inputData.readUnsignedByte()) {
             if (i > INT_SPACE) {
                 if (i == INT_SLASH) {
                     _skipComment();
@@ -2689,7 +2658,7 @@ public class UTF8DataInputJsonParser
         if (!isEnabled(JsonReadFeature.ALLOW_JAVA_COMMENTS)) {
             _reportUnexpectedChar('/', "maybe a (non-standard) comment? (not recognized as one since Feature 'ALLOW_COMMENTS' not enabled for parser)");
         }
-        int c = _inputRead();
+        int c = _inputData.readUnsignedByte();
         if (c == '/') {
             _skipLine();
         } else if (c == '*') {
@@ -2703,7 +2672,7 @@ public class UTF8DataInputJsonParser
     {
         // Need to be UTF-8 aware here to decode content (for skipping)
         final int[] codes = CharTypes.getInputCodeComment();
-        int i = _inputRead();
+        int i = _inputData.readUnsignedByte();
 
         // Ok: need the matching '*/'
         main_loop:
@@ -2712,7 +2681,7 @@ public class UTF8DataInputJsonParser
             if (code != 0) {
                 switch (code) {
                 case '*':
-                    i = _inputRead();
+                    i = _inputData.readUnsignedByte();
                     if (i == INT_SLASH) {
                         return;
                     }
@@ -2735,7 +2704,7 @@ public class UTF8DataInputJsonParser
                     _reportInvalidChar(i);
                 }
             }
-            i = _inputRead();
+            i = _inputData.readUnsignedByte();
         }
     }
 
@@ -2757,7 +2726,7 @@ public class UTF8DataInputJsonParser
         // Ok: need to find EOF or linefeed
         final int[] codes = CharTypes.getInputCodeComment();
         while (true) {
-            int i = _inputRead();
+            int i = _inputData.readUnsignedByte();
             int code = codes[i];
             if (code != 0) {
                 switch (code) {
@@ -2797,7 +2766,7 @@ public class UTF8DataInputJsonParser
 
     private char _decodeEscaped2() throws IOException
     {
-        int c = _inputRead();
+        int c = _inputData.readUnsignedByte();
 
         switch (c) {
             // First, ones that are mapped
@@ -2828,7 +2797,7 @@ public class UTF8DataInputJsonParser
         // Ok, a hex escape. Need 4 characters
         int value = 0;
         for (int i = 0; i < 4; ++i) {
-            int ch = _inputRead();
+            int ch = _inputData.readUnsignedByte();
             int digit = CharTypes.charToHex(ch);
             if (digit < 0) {
                 _reportUnexpectedChar(ch, "expected a hex-digit for character escape sequence");
@@ -2860,20 +2829,20 @@ public class UTF8DataInputJsonParser
                 needed = 1; // never gets here
             }
 
-            int d = _inputRead();
+            int d = _inputData.readUnsignedByte();
             if ((d & 0xC0) != 0x080) {
                 _reportInvalidOther(d & 0xFF);
             }
             c = (c << 6) | (d & 0x3F);
 
             if (needed > 1) { // needed == 1 means 2 bytes total
-                d = _inputRead(); // 3rd byte
+                d = _inputData.readUnsignedByte(); // 3rd byte
                 if ((d & 0xC0) != 0x080) {
                     _reportInvalidOther(d & 0xFF);
                 }
                 c = (c << 6) | (d & 0x3F);
                 if (needed > 2) { // 4 bytes? (need surrogates)
-                    d = _inputRead();
+                    d = _inputData.readUnsignedByte();
                     if ((d & 0xC0) != 0x080) {
                         _reportInvalidOther(d & 0xFF);
                     }
@@ -2892,7 +2861,7 @@ public class UTF8DataInputJsonParser
 
     private final int _decodeUtf8_2(int c) throws IOException
     {
-        int d = _inputRead();
+        int d = _inputData.readUnsignedByte();
         if ((d & 0xC0) != 0x080) {
             _reportInvalidOther(d & 0xFF);
         }
@@ -2902,12 +2871,12 @@ public class UTF8DataInputJsonParser
     private final int _decodeUtf8_3(int c1) throws IOException
     {
         c1 &= 0x0F;
-        int d = _inputRead();
+        int d = _inputData.readUnsignedByte();
         if ((d & 0xC0) != 0x080) {
             _reportInvalidOther(d & 0xFF);
         }
         int c = (c1 << 6) | (d & 0x3F);
-        d = _inputRead();
+        d = _inputData.readUnsignedByte();
         if ((d & 0xC0) != 0x080) {
             _reportInvalidOther(d & 0xFF);
         }
@@ -2925,17 +2894,17 @@ public class UTF8DataInputJsonParser
      */
     private final int _decodeUtf8_4(int c) throws IOException
     {
-        int d = _inputRead();
+        int d = _inputData.readUnsignedByte();
         if ((d & 0xC0) != 0x080) {
             _reportInvalidOther(d & 0xFF);
         }
         c = ((c & 0x07) << 6) | (d & 0x3F);
-        d = _inputRead();
+        d = _inputData.readUnsignedByte();
         if ((d & 0xC0) != 0x080) {
             _reportInvalidOther(d & 0xFF);
         }
         c = (c << 6) | (d & 0x3F);
-        d = _inputRead();
+        d = _inputData.readUnsignedByte();
         if ((d & 0xC0) != 0x080) {
             _reportInvalidOther(d & 0xFF);
         }
@@ -2948,7 +2917,7 @@ public class UTF8DataInputJsonParser
 
     private final void _skipUtf8_2() throws IOException
     {
-        int c = _inputRead();
+        int c = _inputData.readUnsignedByte();
         if ((c & 0xC0) != 0x080) {
             _reportInvalidOther(c & 0xFF);
         }
@@ -2960,11 +2929,11 @@ public class UTF8DataInputJsonParser
     private final void _skipUtf8_3() throws IOException
     {
         //c &= 0x0F;
-        int c = _inputRead();
+        int c = _inputData.readUnsignedByte();
         if ((c & 0xC0) != 0x080) {
             _reportInvalidOther(c & 0xFF);
         }
-        c = _inputRead();
+        c = _inputData.readUnsignedByte();
         if ((c & 0xC0) != 0x080) {
             _reportInvalidOther(c & 0xFF);
         }
@@ -2972,15 +2941,15 @@ public class UTF8DataInputJsonParser
 
     private final void _skipUtf8_4() throws IOException
     {
-        int d = _inputRead();
+        int d = _inputData.readUnsignedByte();
         if ((d & 0xC0) != 0x080) {
             _reportInvalidOther(d & 0xFF);
         }
-        d = _inputRead();
+        d = _inputData.readUnsignedByte();
         if ((d & 0xC0) != 0x080) {
             _reportInvalidOther(d & 0xFF);
         }
-        d = _inputRead();
+        d = _inputData.readUnsignedByte();
         if ((d & 0xC0) != 0x080) {
             _reportInvalidOther(d & 0xFF);
         }
@@ -3011,7 +2980,7 @@ public class UTF8DataInputJsonParser
                      break;
                  }
                  sb.append(c);
-                 ch = _inputRead();
+                 ch = _inputData.readUnsignedByte();
              }
          } catch (IOException e) {
              ; // ok since we are just trying to get token for diagnostics
@@ -3067,7 +3036,7 @@ public class UTF8DataInputJsonParser
             // first, we'll skip preceding white space, if any
             int ch;
             do {
-                ch = _inputRead();
+                ch = _inputData.readUnsignedByte();
             } while (ch <= INT_SPACE);
             int bits = b64variant.decodeBase64Char(ch);
             if (bits < 0) { // reached the end, fair and square?
@@ -3082,14 +3051,14 @@ public class UTF8DataInputJsonParser
             int decodedData = bits;
 
             // then second base64 char; can't get padding yet, nor ws
-            ch = _inputRead();
+            ch = _inputData.readUnsignedByte();
             bits = b64variant.decodeBase64Char(ch);
             if (bits < 0) {
                 bits = _decodeBase64Escape(b64variant, ch, 1);
             }
             decodedData = (decodedData << 6) | bits;
             // third base64 char; can be padding, but not ws
-            ch = _inputRead();
+            ch = _inputData.readUnsignedByte();
             bits = b64variant.decodeBase64Char(ch);
 
             // First branch: can get padding (-> 1 byte)
@@ -3107,7 +3076,7 @@ public class UTF8DataInputJsonParser
                     bits = _decodeBase64Escape(b64variant, ch, 2);
                 }
                 if (bits == Base64Variant.BASE64_VALUE_PADDING) {
-                    ch = _inputRead();
+                    ch = _inputData.readUnsignedByte();
                     if (!b64variant.usesPaddingChar(ch)) {
                         if ((ch != INT_BACKSLASH)
                                 || _decodeBase64Escape(b64variant, ch, 3) != Base64Variant.BASE64_VALUE_PADDING) {
@@ -3123,7 +3092,7 @@ public class UTF8DataInputJsonParser
             // Nope, 2 or 3 bytes
             decodedData = (decodedData << 6) | bits;
             // fourth and last base64 char; can be padding, but not ws
-            ch = _inputRead();
+            ch = _inputData.readUnsignedByte();
             bits = b64variant.decodeBase64Char(ch);
             if (bits < 0) {
                 if (bits != Base64Variant.BASE64_VALUE_PADDING) {

--- a/src/main/java/tools/jackson/core/json/UTF8DataInputJsonParser.java
+++ b/src/main/java/tools/jackson/core/json/UTF8DataInputJsonParser.java
@@ -138,6 +138,8 @@ public class UTF8DataInputJsonParser
     /**
      * Read the next unsigned byte from the input.
      * Subclasses may override to track byte counts for document length enforcement.
+     *
+     * @since 3.2
      */
     protected int readUnsignedByte() throws IOException {
         return _inputData.readUnsignedByte();

--- a/src/main/java/tools/jackson/core/json/UTF8DataInputWithDocLengthJsonParser.java
+++ b/src/main/java/tools/jackson/core/json/UTF8DataInputWithDocLengthJsonParser.java
@@ -30,9 +30,9 @@ public class UTF8DataInputWithDocLengthJsonParser
             ByteQuadsCanonicalizer sym, int firstByte)
     {
         super(readCtxt, ctxt, stdFeatures, formatFeatures, inputData, sym, firstByte);
-        // firstByte was already read from inputData by ByteSourceJsonBootstrapper.skipUTF8BOM()
-        // before this constructor was called, so count it now.
-        _bytesRead = 1;
+        // NOTE: bytes consumed by ByteSourceJsonBootstrapper.skipUTF8BOM() before this
+        // constructor (1 without BOM, 4 with BOM) are not tracked — the undercount of
+        // a few bytes is negligible for document length constraint enforcement.
     }
 
     @Override

--- a/src/main/java/tools/jackson/core/json/UTF8DataInputWithDocLengthJsonParser.java
+++ b/src/main/java/tools/jackson/core/json/UTF8DataInputWithDocLengthJsonParser.java
@@ -14,6 +14,8 @@ import tools.jackson.core.sym.ByteQuadsCanonicalizer;
  * Byte tracking is achieved by overriding {@link #readUnsignedByte()}: every
  * call increments {@link #_bytesRead} so that validation can be performed at
  * token boundaries in {@link #nextToken()} and {@link #nextName()}.
+ *
+ * @since 3.2
  */
 public class UTF8DataInputWithDocLengthJsonParser
     extends UTF8DataInputJsonParser
@@ -21,7 +23,7 @@ public class UTF8DataInputWithDocLengthJsonParser
     /**
      * Running total of bytes read from {@link #_inputData}.
      */
-    private long _bytesRead;
+    protected long _bytesRead;
 
     public UTF8DataInputWithDocLengthJsonParser(ObjectReadContext readCtxt, IOContext ctxt,
             int stdFeatures, int formatFeatures, DataInput inputData,

--- a/src/main/java/tools/jackson/core/json/UTF8DataInputWithDocLengthJsonParser.java
+++ b/src/main/java/tools/jackson/core/json/UTF8DataInputWithDocLengthJsonParser.java
@@ -1,0 +1,159 @@
+package tools.jackson.core.json;
+
+import java.io.*;
+
+import tools.jackson.core.*;
+import tools.jackson.core.io.IOContext;
+import tools.jackson.core.sym.ByteQuadsCanonicalizer;
+
+/**
+ * Specialization of {@link UTF8DataInputJsonParser} that tracks the number of
+ * bytes read and enforces the
+ * {@link tools.jackson.core.StreamReadConstraints#getMaxDocumentLength()} limit.
+ *<p>
+ * The tracking is achieved by wrapping the source {@link DataInput} in a
+ * {@link CountingDataInput} that increments a counter on every
+ * {@code readUnsignedByte()} call.  Validation is performed at token
+ * boundaries (in {@link #nextToken()} and {@link #nextName()}).
+ */
+public class UTF8DataInputWithDocLengthJsonParser
+    extends UTF8DataInputJsonParser
+{
+    /**
+     * The counting wrapper we passed to the superclass constructor.
+     * Held here so we can query {@link CountingDataInput#getBytesRead()}
+     * when performing document-length validation.
+     */
+    private final CountingDataInput _countingInput;
+
+    public UTF8DataInputWithDocLengthJsonParser(ObjectReadContext readCtxt, IOContext ctxt,
+            int stdFeatures, int formatFeatures, DataInput inputData,
+            ByteQuadsCanonicalizer sym, int firstByte)
+    {
+        // Wrap the real DataInput so all readUnsignedByte() calls are counted
+        super(readCtxt, ctxt, stdFeatures, formatFeatures,
+                new CountingDataInput(inputData), sym, firstByte);
+        // _inputData has been set to our CountingDataInput by the super constructor
+        _countingInput = (CountingDataInput) _inputData;
+    }
+
+    @Override
+    public JsonToken nextToken() throws JacksonException {
+        JsonToken token = super.nextToken();
+        _streamReadConstraints.validateDocumentLength(_countingInput.getBytesRead());
+        return token;
+    }
+
+    @Override
+    public String nextName() throws JacksonException {
+        String name = super.nextName();
+        _streamReadConstraints.validateDocumentLength(_countingInput.getBytesRead());
+        return name;
+    }
+
+    /*
+    /**********************************************************************
+    /* Helper class: counting DataInput wrapper
+    /**********************************************************************
+     */
+
+    /**
+     * {@link DataInput} wrapper that counts the number of bytes consumed via
+     * {@link #readUnsignedByte()} (the only method used by the JSON parser).
+     */
+    static final class CountingDataInput implements DataInput
+    {
+        private final DataInput _wrapped;
+        private long _bytesRead;
+
+        CountingDataInput(DataInput wrapped) {
+            _wrapped = wrapped;
+        }
+
+        long getBytesRead() {
+            return _bytesRead;
+        }
+
+        @Override
+        public int readUnsignedByte() throws IOException {
+            ++_bytesRead;
+            return _wrapped.readUnsignedByte();
+        }
+
+        // ---- Remaining DataInput methods delegate straight through ----
+
+        @Override
+        public void readFully(byte[] b) throws IOException {
+            _wrapped.readFully(b);
+            _bytesRead += b.length;
+        }
+
+        @Override
+        public void readFully(byte[] b, int off, int len) throws IOException {
+            _wrapped.readFully(b, off, len);
+            _bytesRead += len;
+        }
+
+        @Override
+        public int skipBytes(int n) throws IOException {
+            int skipped = _wrapped.skipBytes(n);
+            _bytesRead += skipped;
+            return skipped;
+        }
+
+        @Override
+        public boolean readBoolean() throws IOException {
+            return _wrapped.readBoolean();
+        }
+
+        @Override
+        public byte readByte() throws IOException {
+            return _wrapped.readByte();
+        }
+
+        @Override
+        public short readShort() throws IOException {
+            return _wrapped.readShort();
+        }
+
+        @Override
+        public int readUnsignedShort() throws IOException {
+            return _wrapped.readUnsignedShort();
+        }
+
+        @Override
+        public char readChar() throws IOException {
+            return _wrapped.readChar();
+        }
+
+        @Override
+        public int readInt() throws IOException {
+            return _wrapped.readInt();
+        }
+
+        @Override
+        public long readLong() throws IOException {
+            return _wrapped.readLong();
+        }
+
+        @Override
+        public float readFloat() throws IOException {
+            return _wrapped.readFloat();
+        }
+
+        @Override
+        public double readDouble() throws IOException {
+            return _wrapped.readDouble();
+        }
+
+        @Override
+        public String readLine() throws IOException {
+            return _wrapped.readLine();
+        }
+
+        @Override
+        public String readUTF() throws IOException {
+            return _wrapped.readUTF();
+        }
+    }
+}

--- a/src/main/java/tools/jackson/core/json/UTF8DataInputWithDocLengthJsonParser.java
+++ b/src/main/java/tools/jackson/core/json/UTF8DataInputWithDocLengthJsonParser.java
@@ -13,7 +13,7 @@ import tools.jackson.core.sym.ByteQuadsCanonicalizer;
  *<p>
  * Byte tracking is achieved by overriding {@link #readUnsignedByte()}: every
  * call increments {@link #_bytesRead} so that validation can be performed at
- * token boundaries in {@link #nextToken()} and {@link #nextName()}.
+ * token boundaries in {@link #nextToken()}.
  *
  * @since 3.2
  */
@@ -48,10 +48,4 @@ public class UTF8DataInputWithDocLengthJsonParser
         return token;
     }
 
-    @Override
-    public String nextName() throws JacksonException {
-        String name = super.nextName();
-        _streamReadConstraints.validateDocumentLength(_bytesRead);
-        return name;
-    }
 }

--- a/src/main/java/tools/jackson/core/json/UTF8DataInputWithDocLengthJsonParser.java
+++ b/src/main/java/tools/jackson/core/json/UTF8DataInputWithDocLengthJsonParser.java
@@ -11,149 +11,45 @@ import tools.jackson.core.sym.ByteQuadsCanonicalizer;
  * bytes read and enforces the
  * {@link tools.jackson.core.StreamReadConstraints#getMaxDocumentLength()} limit.
  *<p>
- * The tracking is achieved by wrapping the source {@link DataInput} in a
- * {@link CountingDataInput} that increments a counter on every
- * {@code readUnsignedByte()} call.  Validation is performed at token
- * boundaries (in {@link #nextToken()} and {@link #nextName()}).
+ * Byte tracking is achieved by overriding {@link #readUnsignedByte()}: every
+ * call increments {@link #_bytesRead} so that validation can be performed at
+ * token boundaries in {@link #nextToken()} and {@link #nextName()}.
  */
 public class UTF8DataInputWithDocLengthJsonParser
     extends UTF8DataInputJsonParser
 {
     /**
-     * The counting wrapper we passed to the superclass constructor.
-     * Held here so we can query {@link CountingDataInput#getBytesRead()}
-     * when performing document-length validation.
+     * Running total of bytes read from {@link #_inputData}.
      */
-    private final CountingDataInput _countingInput;
+    private long _bytesRead;
 
     public UTF8DataInputWithDocLengthJsonParser(ObjectReadContext readCtxt, IOContext ctxt,
             int stdFeatures, int formatFeatures, DataInput inputData,
             ByteQuadsCanonicalizer sym, int firstByte)
     {
-        // Wrap the real DataInput so all readUnsignedByte() calls are counted
-        super(readCtxt, ctxt, stdFeatures, formatFeatures,
-                new CountingDataInput(inputData), sym, firstByte);
-        // _inputData has been set to our CountingDataInput by the super constructor
-        _countingInput = (CountingDataInput) _inputData;
+        super(readCtxt, ctxt, stdFeatures, formatFeatures, inputData, sym, firstByte);
+        // firstByte was already read from inputData by ByteSourceJsonBootstrapper.skipUTF8BOM()
+        // before this constructor was called, so count it now.
+        _bytesRead = 1;
+    }
+
+    @Override
+    protected int readUnsignedByte() throws IOException {
+        ++_bytesRead;
+        return _inputData.readUnsignedByte();
     }
 
     @Override
     public JsonToken nextToken() throws JacksonException {
         JsonToken token = super.nextToken();
-        _streamReadConstraints.validateDocumentLength(_countingInput.getBytesRead());
+        _streamReadConstraints.validateDocumentLength(_bytesRead);
         return token;
     }
 
     @Override
     public String nextName() throws JacksonException {
         String name = super.nextName();
-        _streamReadConstraints.validateDocumentLength(_countingInput.getBytesRead());
+        _streamReadConstraints.validateDocumentLength(_bytesRead);
         return name;
-    }
-
-    /*
-    /**********************************************************************
-    /* Helper class: counting DataInput wrapper
-    /**********************************************************************
-     */
-
-    /**
-     * {@link DataInput} wrapper that counts the number of bytes consumed via
-     * {@link #readUnsignedByte()} (the only method used by the JSON parser).
-     */
-    static final class CountingDataInput implements DataInput
-    {
-        private final DataInput _wrapped;
-        private long _bytesRead;
-
-        CountingDataInput(DataInput wrapped) {
-            _wrapped = wrapped;
-        }
-
-        long getBytesRead() {
-            return _bytesRead;
-        }
-
-        @Override
-        public int readUnsignedByte() throws IOException {
-            ++_bytesRead;
-            return _wrapped.readUnsignedByte();
-        }
-
-        // ---- Remaining DataInput methods delegate straight through ----
-
-        @Override
-        public void readFully(byte[] b) throws IOException {
-            _wrapped.readFully(b);
-            _bytesRead += b.length;
-        }
-
-        @Override
-        public void readFully(byte[] b, int off, int len) throws IOException {
-            _wrapped.readFully(b, off, len);
-            _bytesRead += len;
-        }
-
-        @Override
-        public int skipBytes(int n) throws IOException {
-            int skipped = _wrapped.skipBytes(n);
-            _bytesRead += skipped;
-            return skipped;
-        }
-
-        @Override
-        public boolean readBoolean() throws IOException {
-            return _wrapped.readBoolean();
-        }
-
-        @Override
-        public byte readByte() throws IOException {
-            return _wrapped.readByte();
-        }
-
-        @Override
-        public short readShort() throws IOException {
-            return _wrapped.readShort();
-        }
-
-        @Override
-        public int readUnsignedShort() throws IOException {
-            return _wrapped.readUnsignedShort();
-        }
-
-        @Override
-        public char readChar() throws IOException {
-            return _wrapped.readChar();
-        }
-
-        @Override
-        public int readInt() throws IOException {
-            return _wrapped.readInt();
-        }
-
-        @Override
-        public long readLong() throws IOException {
-            return _wrapped.readLong();
-        }
-
-        @Override
-        public float readFloat() throws IOException {
-            return _wrapped.readFloat();
-        }
-
-        @Override
-        public double readDouble() throws IOException {
-            return _wrapped.readDouble();
-        }
-
-        @Override
-        public String readLine() throws IOException {
-            return _wrapped.readLine();
-        }
-
-        @Override
-        public String readUTF() throws IOException {
-            return _wrapped.readUTF();
-        }
     }
 }

--- a/src/test/java/tools/jackson/core/unittest/constraints/LargeDocReadTest.java
+++ b/src/test/java/tools/jackson/core/unittest/constraints/LargeDocReadTest.java
@@ -108,17 +108,17 @@ class LargeDocReadTest extends AsyncTestBase
         }
     }
 
-    // [core#1570] Should fail fast when DataInput used with maxDocumentLength set
+    // [core#1570] DataInput with maxDocumentLength should enforce the limit
     @Test
-    void dataInputWithDocLengthLimitFails() throws Exception
+    void dataInputWithDocLengthLimitEnforced() throws Exception
     {
-        final String doc = generateJSON(100);
+        final String doc = generateJSON(12_000);
         try (JsonParser p = JSON_F_DOC_10K.createParser(ObjectReadContext.empty(),
                 new MockDataInput(doc))) {
+            consumeTokens(p);
             fail("expected StreamConstraintsException");
         } catch (StreamConstraintsException e) {
-            verifyException(e, "DataInput");
-            verifyException(e, "maxDocumentLength");
+            verifyMaxDocLen(JSON_F_DOC_10K, e);
         }
     }
 

--- a/src/test/java/tools/jackson/core/unittest/constraints/LargeDocReadTest.java
+++ b/src/test/java/tools/jackson/core/unittest/constraints/LargeDocReadTest.java
@@ -108,7 +108,7 @@ class LargeDocReadTest extends AsyncTestBase
         }
     }
 
-    // [core#1570] DataInput with maxDocumentLength should enforce the limit
+    // [core#1575] DataInput with maxDocumentLength should enforce the limit
     @Test
     void dataInputWithDocLengthLimitEnforced() throws Exception
     {
@@ -122,7 +122,7 @@ class LargeDocReadTest extends AsyncTestBase
         }
     }
 
-    // [core#1570] DataInput without maxDocumentLength should still work
+    // [core#1575] DataInput without maxDocumentLength should still work
     @Test
     void dataInputWithoutDocLengthLimitWorks() throws Exception
     {


### PR DESCRIPTION
One possible way to support max document len on DataInput use case.
The count and validation overhead only kicks in if you set a non-negative max document len - which is not the default case.