### PR TITLE
Use intrinsified Math.multiplyHigh()

### DIFF
--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -40,3 +40,7 @@ Rohan Nagendra (@rohan-repos)
  * Reported #1553: Max Depth validation not working for `DataInput`-backed `JsonParser`s
    in 3.0
   (3.1.0)
+
+Antonin Janec (@xtonik)
+ * Contributed #1576: Use Java 17 intrinstics for long multiplication
+  (3.2.0)

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -26,6 +26,8 @@ JSON library.
 #1570: Fail parsing from `DataInput` if
  `StreamReadConstraints.getMaxDocumentLength()` set
  (fix by @cowtowncoder, w/ Claude code)
+#1576: Use Java 17 intrinstics for long multiplication
+ (contributed by @xtonik)
 
 3.1.1 (not yet released)
 

--- a/src/main/java/tools/jackson/core/io/schubfach/DoubleToDecimal.java
+++ b/src/main/java/tools/jackson/core/io/schubfach/DoubleToDecimal.java
@@ -27,7 +27,6 @@ import static tools.jackson.core.io.schubfach.MathUtils.flog10threeQuartersPow2;
 import static tools.jackson.core.io.schubfach.MathUtils.flog2pow10;
 import static tools.jackson.core.io.schubfach.MathUtils.g0;
 import static tools.jackson.core.io.schubfach.MathUtils.g1;
-import static tools.jackson.core.io.schubfach.MathUtils.multiplyHigh;
 import static tools.jackson.core.io.schubfach.MathUtils.pow10;
 
 import static java.lang.Double.doubleToRawLongBits;
@@ -365,7 +364,7 @@ final public class DoubleToDecimal {
             wpin    iff    w' = tp10 10^k in Rv
             See section 9.4 of [1].
              */
-            long sp10 = 10 * multiplyHigh(s, 115_292_150_460_684_698L << 4);
+            long sp10 = 10 * Math.multiplyHigh(s, 115_292_150_460_684_698L << 4);
             long tp10 = sp10 + 10;
             boolean upin = vbl + out <= sp10 << 2;
             boolean wpin = (tp10 << 2) + out <= vbr;
@@ -400,9 +399,9 @@ final public class DoubleToDecimal {
     See section 9.10 and figure 5 of [1].
      */
     private static long rop(long g1, long g0, long cp) {
-        long x1 = multiplyHigh(g0, cp);
+        long x1 = Math.multiplyHigh(g0, cp);
         long y0 = g1 * cp;
-        long y1 = multiplyHigh(g1, cp);
+        long y1 = Math.multiplyHigh(g1, cp);
         long z = (y0 >>> 1) + x1;
         long vbp = y1 + (z >>> 63);
         return vbp | (z & MASK_63) + MASK_63 >>> 63;
@@ -446,7 +445,7 @@ final public class DoubleToDecimal {
         and for n = 9, m = 8
             floor(hm / 10^8) = floor(1_441_151_881 hm / 2^57)
          */
-        long hm = multiplyHigh(f, 193_428_131_138_340_668L) >>> 20;
+        long hm = Math.multiplyHigh(f, 193_428_131_138_340_668L) >>> 20;
         int l = (int) (f - 100_000_000L * hm);
         int h = (int) (hm * 1_441_151_881L >>> 57);
         int m = (int) (hm - 100_000_000 * h);
@@ -547,7 +546,7 @@ final public class DoubleToDecimal {
             (a + 1) 2^n <= 10^8 2^28 < 10^17
         For n = 17, m = 8 the table in section 10 of [1] leads to:
          */
-        return (int) (multiplyHigh(
+        return (int) (Math.multiplyHigh(
                 (long) (a + 1) << 28,
                 193_428_131_138_340_668L) >>> 20) - 1;
     }

--- a/src/main/java/tools/jackson/core/io/schubfach/FloatToDecimal.java
+++ b/src/main/java/tools/jackson/core/io/schubfach/FloatToDecimal.java
@@ -26,7 +26,6 @@ import static tools.jackson.core.io.schubfach.MathUtils.flog10pow2;
 import static tools.jackson.core.io.schubfach.MathUtils.flog10threeQuartersPow2;
 import static tools.jackson.core.io.schubfach.MathUtils.flog2pow10;
 import static tools.jackson.core.io.schubfach.MathUtils.g1;
-import static tools.jackson.core.io.schubfach.MathUtils.multiplyHigh;
 import static tools.jackson.core.io.schubfach.MathUtils.pow10;
 
 import static java.lang.Float.floatToRawIntBits;
@@ -398,7 +397,7 @@ final public class FloatToDecimal {
     See appendix and figure 8 of [1].
      */
     private static int rop(long g, long cp) {
-        long x1 = multiplyHigh(g, cp);
+        long x1 = Math.multiplyHigh(g, cp);
         long vbp = x1 >>> 31;
         return (int) (vbp | (x1 & MASK_32) + MASK_32 >>> 32);
     }
@@ -529,7 +528,7 @@ final public class FloatToDecimal {
             (a + 1) 2^n <= 10^8 2^28 < 10^17
         For n = 17, m = 8 the table in section 10 of [1] leads to:
          */
-        return (int) (multiplyHigh(
+        return (int) (Math.multiplyHigh(
                 (long) (a + 1) << 28,
                 193_428_131_138_340_668L) >>> 20) - 1;
     }

--- a/src/main/java/tools/jackson/core/io/schubfach/MathUtils.java
+++ b/src/main/java/tools/jackson/core/io/schubfach/MathUtils.java
@@ -185,18 +185,6 @@ public final class MathUtils { // public only for testing (but not exposed by Mo
         return g[k - K_MIN << 1 | 1];
     }
 
-    //a Java port of https://github.com/plokhotnyuk/jsoniter-scala/blob/c70a293ac802dc2eb44165471d76d7df2d4657b6/jsoniter-scala-core/native/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/core/JsonWriter.scala#L2027
-    static long multiplyHigh(long x, long y) {
-        // Karatsuba technique for two positive ints
-        long x2 = x & 0xFFFFFFFFL;
-        long y2 = y & 0xFFFFFFFFL;
-        long b = x2 * y2;
-        long x1 = x >>> 32;
-        long y1 = y >>> 32;
-        long a = x1 * y1;
-        return (((b >>> 32) + (x1 + x2) * (y1 + y2) - b - a) >>> 32) + a;
-    }
-
     /*
     The precomputed values for g1(int) and g0(int).
     The first entry must be for an exponent of K_MIN or less.


### PR DESCRIPTION
Prefer use of intrinsified method `Math.multiplyHigh()` over custom implementation as reported in #1576. Even built-in JDK method is for signed values and thus signed result, it works well for positive value also. Possible fallback to not intrinsified JDK version does not affect negatively performance as demonstrated in this benchmark (not provided) results:

  | (multiplier) | Mode | Cnt | Score | Error | Units
-- | -- | -- | -- | -- | -- | --
MultiplyHighBenchmark.multiplyHigh | SIGNED_INTRINSIFIED | thrpt | 10 | 0.991 | ± 0.443 | ops/us
MultiplyHighBenchmark.multiplyHigh | SIGNED | thrpt | 10 | 0.386 | ± 0.014 | ops/us
MultiplyHighBenchmark.multiplyHigh | UNSIGNED_JACKSON | thrpt | 10 | 0.388 | ± 0.012  | ops/us
MultiplyHighBenchmark.multiplyHigh | UNSIGNED_INTRINSIFIED  |  thrpt   |  10    |  0.999 | ±  0.048  |  ops/us

