### PR TITLE
Add `JsonParser.willInternPropertyNames()` for property name intern introspection (#1211)

### DIFF
--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -41,6 +41,11 @@ Rohan Nagendra (@rohan-repos)
    in 3.0
   (3.1.0)
 
+Max Paulus (@maxpaulus43)
+ * Contributed #1211: Add `JsonParser.willInternPropertyNames()` to check whether
+   property name interning is enabled
+  (3.2.0)
+
 Antonin Janec (@xtonik)
  * Contributed #1576: Use Java 17 intrinstics for long multiplication
   (3.2.0)

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -28,6 +28,8 @@ JSON library.
  (implemented by @pjfanning)
 #1576: Use Java 17 intrinstics for long multiplication
  (contributed by @xtonik)
+#1211: Add `JsonParser.willInternPropertyNames()` to check whether
+  property name interning is enabled
 
 3.1.1 (not yet released)
 

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -19,6 +19,9 @@ JSON library.
 
 #679: Number parsing should fail for trailing dot (period)
  (fix by @cowtowncoder, w/ Claude code)
+#1211: Add `JsonParser.willInternPropertyNames()` to check whether
+  property name interning is enabled
+ (contributed by Max P)
 #1544: Validate `read()` parameters in `MergedStream` and `UTF32Reader`
  (implemented by @pjfanning)
 #1545: Increase Android baseline from 26 to 34 in Jackson 3.2
@@ -28,8 +31,6 @@ JSON library.
  (implemented by @pjfanning)
 #1576: Use Java 17 intrinstics for long multiplication
  (contributed by @xtonik)
-#1211: Add `JsonParser.willInternPropertyNames()` to check whether
-  property name interning is enabled
 
 3.1.1 (not yet released)
 

--- a/src/main/java/tools/jackson/core/JsonParser.java
+++ b/src/main/java/tools/jackson/core/JsonParser.java
@@ -260,6 +260,20 @@ public abstract class JsonParser
     public boolean canParseAsync() { return false; }
 
     /**
+     * Introspection method that can be called to check whether this parser
+     * is configured to intern parsed field names (property names) using
+     * {@link String#intern()} or not.
+     *<p>
+     * Default implementation returns {@code false}; JSON-backed parsers
+     * override to check the state of the underlying symbol table.
+     *
+     * @return {@code True} if this parser interns field names; {@code false} if not
+     *
+     * @since 3.2
+     */
+    public boolean willInternPropertyNames() { return false; }
+
+    /**
      * Method that will either return a feeder instance (if parser uses
      * non-blocking, aka asynchronous access); or <code>null</code> for
      * parsers that use blocking I/O.

--- a/src/main/java/tools/jackson/core/json/ReaderBasedJsonParser.java
+++ b/src/main/java/tools/jackson/core/json/ReaderBasedJsonParser.java
@@ -182,7 +182,7 @@ public class ReaderBasedJsonParser
 
     @Override
     public boolean willInternPropertyNames() {
-        return _symbols.isInternStrings();
+        return _symbols.willInternStrings();
     }
 
     protected char getNextChar(String eofMsg, JsonToken forToken) throws JacksonException {

--- a/src/main/java/tools/jackson/core/json/ReaderBasedJsonParser.java
+++ b/src/main/java/tools/jackson/core/json/ReaderBasedJsonParser.java
@@ -180,6 +180,11 @@ public class ReaderBasedJsonParser
 
     @Override public Object streamReadInputSource() { return _reader; }
 
+    @Override
+    public boolean willInternPropertyNames() {
+        return _symbols.isInternStrings();
+    }
+
     protected char getNextChar(String eofMsg, JsonToken forToken) throws JacksonException {
         if (_inputPtr >= _inputEnd) {
             if (!_loadMore()) {

--- a/src/main/java/tools/jackson/core/json/UTF8DataInputJsonParser.java
+++ b/src/main/java/tools/jackson/core/json/UTF8DataInputJsonParser.java
@@ -128,7 +128,7 @@ public class UTF8DataInputJsonParser
 
     @Override
     public boolean willInternPropertyNames() {
-        return _symbols.isInternStrings();
+        return _symbols.willInternStrings();
     }
 
     /*

--- a/src/main/java/tools/jackson/core/json/UTF8DataInputJsonParser.java
+++ b/src/main/java/tools/jackson/core/json/UTF8DataInputJsonParser.java
@@ -126,6 +126,11 @@ public class UTF8DataInputJsonParser
         return _inputData;
     }
 
+    @Override
+    public boolean willInternPropertyNames() {
+        return _symbols.isInternStrings();
+    }
+
     /*
     /**********************************************************************
     /* Overrides, low-level reading

--- a/src/main/java/tools/jackson/core/json/UTF8StreamJsonParser.java
+++ b/src/main/java/tools/jackson/core/json/UTF8StreamJsonParser.java
@@ -185,6 +185,11 @@ public class UTF8StreamJsonParser
         return _inputStream;
     }
 
+    @Override
+    public boolean willInternPropertyNames() {
+        return _symbols.isInternStrings();
+    }
+
     /*
     /**********************************************************************
     /* Overrides, low-level reading

--- a/src/main/java/tools/jackson/core/json/UTF8StreamJsonParser.java
+++ b/src/main/java/tools/jackson/core/json/UTF8StreamJsonParser.java
@@ -187,7 +187,7 @@ public class UTF8StreamJsonParser
 
     @Override
     public boolean willInternPropertyNames() {
-        return _symbols.isInternStrings();
+        return _symbols.willInternStrings();
     }
 
     /*

--- a/src/main/java/tools/jackson/core/json/async/NonBlockingJsonParserBase.java
+++ b/src/main/java/tools/jackson/core/json/async/NonBlockingJsonParserBase.java
@@ -270,6 +270,11 @@ public abstract class NonBlockingJsonParserBase
     @Override
     public boolean canParseAsync() { return true; }
 
+    @Override
+    public boolean willInternPropertyNames() {
+        return _symbols.isInternStrings();
+    }
+
     /*
     /**********************************************************
     /* Test support

--- a/src/main/java/tools/jackson/core/json/async/NonBlockingJsonParserBase.java
+++ b/src/main/java/tools/jackson/core/json/async/NonBlockingJsonParserBase.java
@@ -272,7 +272,7 @@ public abstract class NonBlockingJsonParserBase
 
     @Override
     public boolean willInternPropertyNames() {
-        return _symbols.isInternStrings();
+        return _symbols.willInternStrings();
     }
 
     /*

--- a/src/main/java/tools/jackson/core/sym/ByteQuadsCanonicalizer.java
+++ b/src/main/java/tools/jackson/core/sym/ByteQuadsCanonicalizer.java
@@ -468,6 +468,18 @@ public class ByteQuadsCanonicalizer
     }
 
     /**
+     * Accessor for checking whether this symbol table is configured to
+     * intern field names (using {@link String#intern()}) or not.
+     *
+     * @return {@code True} if field names will be interned; {@code false} if not
+     *
+     * @since 3.2
+     */
+    public boolean isInternStrings() {
+        return _interner != null;
+    }
+
+    /**
      * Method mostly needed by unit tests; calculates number of
      * entries that are in the primary slot set. These are
      * "perfect" entries, accessible with a single lookup

--- a/src/main/java/tools/jackson/core/sym/ByteQuadsCanonicalizer.java
+++ b/src/main/java/tools/jackson/core/sym/ByteQuadsCanonicalizer.java
@@ -475,7 +475,7 @@ public class ByteQuadsCanonicalizer
      *
      * @since 3.2
      */
-    public boolean isInternStrings() {
+    public boolean willInternStrings() {
         return _interner != null;
     }
 

--- a/src/main/java/tools/jackson/core/sym/CharsToNameCanonicalizer.java
+++ b/src/main/java/tools/jackson/core/sym/CharsToNameCanonicalizer.java
@@ -417,6 +417,18 @@ public final class CharsToNameCanonicalizer
     public int hashSeed() { return _seed; }
 
     /**
+     * Accessor for checking whether this symbol table is configured to
+     * intern field names (using {@link String#intern()}) or not.
+     *
+     * @return {@code True} if field names will be interned; {@code false} if not
+     *
+     * @since 3.2
+     */
+    public boolean isInternStrings() {
+        return JsonFactory.Feature.INTERN_PROPERTY_NAMES.enabledIn(_factoryFeatures);
+    }
+
+    /**
      * Method mostly needed by unit tests; calculates number of
      * entries that are in collision list. Value can be at most
      * ({@link #size} - 1), but should usually be much lower, ideally 0.

--- a/src/main/java/tools/jackson/core/sym/CharsToNameCanonicalizer.java
+++ b/src/main/java/tools/jackson/core/sym/CharsToNameCanonicalizer.java
@@ -424,7 +424,7 @@ public final class CharsToNameCanonicalizer
      *
      * @since 3.2
      */
-    public boolean isInternStrings() {
+    public boolean willInternStrings() {
         return JsonFactory.Feature.INTERN_PROPERTY_NAMES.enabledIn(_factoryFeatures);
     }
 

--- a/src/main/java/tools/jackson/core/util/JsonParserDelegate.java
+++ b/src/main/java/tools/jackson/core/util/JsonParserDelegate.java
@@ -91,6 +91,8 @@ public class JsonParserDelegate extends JsonParser
 
     @Override public boolean canParseAsync() { return delegate.canParseAsync(); }
 
+    @Override public boolean willInternPropertyNames() { return delegate.willInternPropertyNames(); }
+
     @Override public NonBlockingInputFeeder nonBlockingInputFeeder() { return delegate.nonBlockingInputFeeder(); }
 
     @Override public JacksonFeatureSet<StreamReadCapability> streamReadCapabilities() { return delegate.streamReadCapabilities(); }

--- a/src/test/java/tools/jackson/core/unittest/read/InternPropertyNamesTest.java
+++ b/src/test/java/tools/jackson/core/unittest/read/InternPropertyNamesTest.java
@@ -1,0 +1,145 @@
+package tools.jackson.core.unittest.read;
+
+import java.io.*;
+
+import org.junit.jupiter.api.Test;
+
+import tools.jackson.core.JsonParser;
+import tools.jackson.core.ObjectReadContext;
+import tools.jackson.core.TokenStreamFactory;
+import tools.jackson.core.json.JsonFactory;
+import tools.jackson.core.unittest.JacksonCoreTestBase;
+import tools.jackson.core.unittest.testutil.MockDataInput;
+import tools.jackson.core.util.JsonParserDelegate;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests to verify {@link JsonParser#willInternPropertyNames()} works correctly
+ * for various parser implementations and configuration settings.
+ *
+ * @since 3.2
+ */
+class InternPropertyNamesTest extends JacksonCoreTestBase
+{
+    private final String DOC = "{\"a\":1}";
+
+    @Test
+    void interningEnabledWithStreamParser() throws Exception {
+        JsonFactory f = _factoryWith(true, true);
+        try (JsonParser p = createParserUsingStream(f, DOC, "UTF-8")) {
+            assertTrue(p.willInternPropertyNames());
+        }
+    }
+
+    @Test
+    void interningEnabledWithReaderParser() throws Exception {
+        JsonFactory f = _factoryWith(true, true);
+        try (JsonParser p = createParserUsingReader(f, DOC)) {
+            assertTrue(p.willInternPropertyNames());
+        }
+    }
+
+    @Test
+    void interningEnabledWithDataInputParser() throws Exception {
+        JsonFactory f = _factoryWith(true, true);
+        try (JsonParser p = createParserForDataInput(f, new MockDataInput(DOC))) {
+            assertTrue(p.willInternPropertyNames());
+        }
+    }
+
+    @Test
+    void interningEnabledWithAsyncParser() throws Exception {
+        JsonFactory f = _factoryWith(true, true);
+        try (JsonParser p = f.createNonBlockingByteArrayParser(ObjectReadContext.empty())) {
+            assertTrue(p.willInternPropertyNames());
+        }
+    }
+
+    // Tests with INTERN_PROPERTY_NAMES disabled (3.x default)
+    @Test
+    void interningDisabledWithStreamParser() throws Exception {
+        JsonFactory f = _factoryWith(false, true);
+        try (JsonParser p = createParserUsingStream(f, DOC, "UTF-8")) {
+            assertFalse(p.willInternPropertyNames());
+        }
+    }
+
+    @Test
+    void interningDisabledWithReaderParser() throws Exception {
+        JsonFactory f = _factoryWith(false, true);
+        try (JsonParser p = createParserUsingReader(f, DOC)) {
+            assertFalse(p.willInternPropertyNames());
+        }
+    }
+
+    @Test
+    void interningDisabledWithDataInputParser() throws Exception {
+        JsonFactory f = _factoryWith(false, true);
+        try (JsonParser p = createParserForDataInput(f, new MockDataInput(DOC))) {
+            assertFalse(p.willInternPropertyNames());
+        }
+    }
+
+    @Test
+    void interningDisabledWithAsyncParser() throws Exception {
+        JsonFactory f = _factoryWith(false, true);
+        try (JsonParser p = f.createNonBlockingByteArrayParser(ObjectReadContext.empty())) {
+            assertFalse(p.willInternPropertyNames());
+        }
+    }
+
+    // When CANONICALIZE is disabled for byte-based input, the bootstrapper falls back
+    // to a ReaderBasedJsonParser. Its CharsToNameCanonicalizer still honours the
+    // INTERN_PROPERTY_NAMES flag, so interning is reported as enabled when that flag is set.
+    @Test
+    void interningWhenCanonicalizationDisabled() throws Exception {
+        JsonFactory f = _factoryWith(true, false);
+        try (JsonParser p = createParserUsingStream(f, DOC, "UTF-8")) {
+            assertTrue(p.willInternPropertyNames());
+        }
+        // But when INTERN is also disabled, should be false
+        JsonFactory f2 = _factoryWith(false, false);
+        try (JsonParser p = createParserUsingStream(f2, DOC, "UTF-8")) {
+            assertFalse(p.willInternPropertyNames());
+        }
+    }
+
+    // Test with default factory settings
+    @Test
+    void interningWithDefaultFactory() throws Exception {
+        JsonFactory f = new JsonFactory();
+        assertFalse(f.isEnabled(TokenStreamFactory.Feature.INTERN_PROPERTY_NAMES));
+        try (JsonParser p = createParserUsingStream(f, DOC, "UTF-8")) {
+            assertFalse(p.willInternPropertyNames());
+        }
+        try (JsonParser p = createParserUsingReader(f, DOC)) {
+            assertFalse(p.willInternPropertyNames());
+        }
+    }
+
+    // Test delegation via JsonParserDelegate
+    @Test
+    void interningDelegation() throws Exception {
+        JsonFactory internF = _factoryWith(true, true);
+        JsonFactory noInternF = _factoryWith(false, true);
+        try (JsonParser p = createParserUsingStream(internF, DOC, "UTF-8")) {
+            JsonParserDelegate del = new JsonParserDelegate(p);
+            assertTrue(del.willInternPropertyNames());
+        }
+        try (JsonParser p = createParserUsingReader(noInternF, DOC)) {
+            JsonParserDelegate del = new JsonParserDelegate(p);
+            assertFalse(del.willInternPropertyNames());
+        }
+    }
+
+    private JsonFactory _factoryWith(boolean intern, boolean canonicalize) {
+        return JsonFactory.builder()
+                .configure(TokenStreamFactory.Feature.INTERN_PROPERTY_NAMES, intern)
+                .configure(TokenStreamFactory.Feature.CANONICALIZE_PROPERTY_NAMES, canonicalize)
+                .build();
+    }
+
+}
+
+

--- a/src/test/java/tools/jackson/core/unittest/util/DelegatesTest.java
+++ b/src/test/java/tools/jackson/core/unittest/util/DelegatesTest.java
@@ -148,13 +148,14 @@ class DelegatesTest extends JacksonCoreTestBase
 
         // Basic capabilities for parser:
         assertFalse(del.canParseAsync());
-        assertFalse(del.willInternPropertyNames());
         assertFalse(del.canReadObjectId());
         assertFalse(del.canReadTypeId());
         assertEquals(parser.version(), del.version());
         assertSame(parser.streamReadConstraints(), del.streamReadConstraints());
         assertEquals(MAX_NUMBER_LEN, parser.streamReadConstraints().getMaxNumberLength());
         assertSame(parser.streamReadCapabilities(), del.streamReadCapabilities());
+
+        assertEquals(parser.willInternPropertyNames(), del.willInternPropertyNames());
 
         // configuration
         assertFalse(del.isEnabled(StreamReadFeature.IGNORE_UNDEFINED));

--- a/src/test/java/tools/jackson/core/unittest/util/DelegatesTest.java
+++ b/src/test/java/tools/jackson/core/unittest/util/DelegatesTest.java
@@ -148,6 +148,7 @@ class DelegatesTest extends JacksonCoreTestBase
 
         // Basic capabilities for parser:
         assertFalse(del.canParseAsync());
+        assertFalse(del.willInternPropertyNames());
         assertFalse(del.canReadObjectId());
         assertFalse(del.canReadTypeId());
         assertEquals(parser.version(), del.version());


### PR DESCRIPTION
Add ability to determine whether field name interning is enabled for a `JsonParser` instance, as suggested in [GitHub issue #1211](https://github.com/FasterXML/jackson-core/issues/1211).

## Changes

- Add `JsonParser.willInternPropertyNames()` with default returning `false`
- Add `isInternStrings()` accessor to `ByteQuadsCanonicalizer` and `CharsToNameCanonicalizer` symbol tables
- Override in `UTF8StreamJsonParser`, `ReaderBasedJsonParser`, `UTF8DataInputJsonParser`, and `NonBlockingJsonParserBase` to delegate to their respective symbol tables
- Override in `JsonParserDelegate` to delegate to wrapped parser
- Add comprehensive unit tests (`InternFieldNamesTest`) covering all parser types with various feature configurations
- Update `DelegatesTest` to verify delegation of new method
- Add release notes entry under 3.2.0

Closes #1211