### PR TITLE
performance enhancement in UTF-8 generator

### DIFF
--- a/src/main/java/tools/jackson/core/json/UTF8JsonGenerator.java
+++ b/src/main/java/tools/jackson/core/json/UTF8JsonGenerator.java
@@ -1485,6 +1485,7 @@ public class UTF8JsonGenerator
             if (((ch0 | ch1 | ch2 | ch3) > 0x7F)
                     || escCodes[ch0] != 0 || escCodes[ch1] != 0
                     || escCodes[ch2] != 0 || escCodes[ch3] != 0) {
+                // handle the remaining bytes using the one at a time loop below
                 break;
             }
             outputBuffer[outputPtr++] = (byte) ch0;
@@ -1535,6 +1536,7 @@ public class UTF8JsonGenerator
             if (((ch0 | ch1 | ch2 | ch3) > 0x7F)
                     || escCodes[ch0] != 0 || escCodes[ch1] != 0
                     || escCodes[ch2] != 0 || escCodes[ch3] != 0) {
+                // handle the remaining chars using the one at a time loop below
                 break;
             }
             outputBuffer[outputPtr++] = (byte) ch0;

--- a/src/main/java/tools/jackson/core/json/UTF8JsonGenerator.java
+++ b/src/main/java/tools/jackson/core/json/UTF8JsonGenerator.java
@@ -1471,6 +1471,29 @@ public class UTF8JsonGenerator
         final byte[] outputBuffer = _outputBuffer;
         final int[] escCodes = _outputEscapes;
 
+        // Unrolled 4-char inner loop: reduces loop overhead and lets the JIT
+        // see a wider window for optimisation (auto-vectorisation, etc.).
+        // We use bitwise OR of all four char values: if the OR result is > 0x7F
+        // then at least one char needs multi-byte UTF-8 encoding; then we check
+        // the escape table for each char individually.
+        while ((offset + 4) <= len) {
+            int ch0 = cbuf[offset];
+            int ch1 = cbuf[offset + 1];
+            int ch2 = cbuf[offset + 2];
+            int ch3 = cbuf[offset + 3];
+            // Bit-OR: if any ch is > 0x7F the combined result will be too
+            if (((ch0 | ch1 | ch2 | ch3) > 0x7F)
+                    || escCodes[ch0] != 0 || escCodes[ch1] != 0
+                    || escCodes[ch2] != 0 || escCodes[ch3] != 0) {
+                break;
+            }
+            outputBuffer[outputPtr++] = (byte) ch0;
+            outputBuffer[outputPtr++] = (byte) ch1;
+            outputBuffer[outputPtr++] = (byte) ch2;
+            outputBuffer[outputPtr++] = (byte) ch3;
+            offset += 4;
+        }
+        // Handle any remaining chars (< 4) one at a time
         while (offset < len) {
             int ch = cbuf[offset];
             // note: here we know that (ch > 0x7F) will cover case of escaping non-ASCII too:
@@ -1503,6 +1526,24 @@ public class UTF8JsonGenerator
         final byte[] outputBuffer = _outputBuffer;
         final int[] escCodes = _outputEscapes;
 
+        // Unrolled 4-char inner loop (same logic as the char[] overload above)
+        while ((offset + 4) <= len) {
+            int ch0 = text.charAt(offset);
+            int ch1 = text.charAt(offset + 1);
+            int ch2 = text.charAt(offset + 2);
+            int ch3 = text.charAt(offset + 3);
+            if (((ch0 | ch1 | ch2 | ch3) > 0x7F)
+                    || escCodes[ch0] != 0 || escCodes[ch1] != 0
+                    || escCodes[ch2] != 0 || escCodes[ch3] != 0) {
+                break;
+            }
+            outputBuffer[outputPtr++] = (byte) ch0;
+            outputBuffer[outputPtr++] = (byte) ch1;
+            outputBuffer[outputPtr++] = (byte) ch2;
+            outputBuffer[outputPtr++] = (byte) ch3;
+            offset += 4;
+        }
+        // Handle any remaining chars (< 4) one at a time
         while (offset < len) {
             int ch = text.charAt(offset);
             // note: here we know that (ch > 0x7F) will cover case of escaping non-ASCII too:


### PR DESCRIPTION
This was suggested by Copilot.
If there any existing JMH benchmarks for UTF-8 generator, I can try this out.
These new loops can be optimised by the JIT compiler to process 4 bytes or chars at a time instead of one byte/char at a time. 

## UTF8JsonGenerator — 4-char loop unrolling in ASCII fast path

`_writeStringSegment(char[], …)` and `_writeStringSegment(String, …)` now process 4 characters per iteration. A single bit-OR of all four values serves as the non-ASCII guard, giving the JIT a wider straight-line block to work with:

```java
while ((offset + 4) <= len) {
    int ch0 = cbuf[offset], ch1 = cbuf[offset+1],
        ch2 = cbuf[offset+2], ch3 = cbuf[offset+3];
    if (((ch0 | ch1 | ch2 | ch3) > 0x7F)
            || escCodes[ch0] != 0 || escCodes[ch1] != 0
            || escCodes[ch2] != 0 || escCodes[ch3] != 0) break;
    outputBuffer[outputPtr]   = (byte) ch0;  outputBuffer[outputPtr+1] = (byte) ch1;
    outputBuffer[outputPtr+2] = (byte) ch2;  outputBuffer[outputPtr+3] = (byte) ch3;
    outputPtr += 4; offset += 4;
}
// tail handled by the existing single-char loop
```