### PR TITLE
Fix #1602: enforce StreamReadConstraints.maxNameLen on UTF8DataInputJsonParser too

### DIFF
--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -21,6 +21,9 @@ a pure JSON library.
  (fix by @cowtowncoder, w/ Claude code)
 #1600: Rework 3rd party licenses in jar
  (fix by @pjfanning)
+#1602: `UTF8DataInputJsonParser` needs to enforce
+  `StreamReadConstraints.maxNameLength` limit
+ (fix by @cowtowncoder, w/ Claude code)
 
 2.18.6 (22-Feb-2026)
 

--- a/src/main/java/com/fasterxml/jackson/core/json/UTF8DataInputJsonParser.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/UTF8DataInputJsonParser.java
@@ -1426,7 +1426,7 @@ public class UTF8DataInputJsonParser
 
             // Nope, no end in sight. Need to grow quad array etc
             if (qlen >= _quadBuffer.length) {
-                _quadBuffer = growArrayBy(_quadBuffer, qlen);
+                _quadBuffer = _growNameDecodeBuffer(_quadBuffer, qlen);
             }
             _quadBuffer[qlen++] = q;
             q = i;
@@ -1485,7 +1485,7 @@ public class UTF8DataInputJsonParser
                     // Ok, we'll need room for first byte right away
                     if (currQuadBytes >= 4) {
                         if (qlen >= quads.length) {
-                            _quadBuffer = quads = growArrayBy(quads, quads.length);
+                            _quadBuffer = quads = _growNameDecodeBuffer(quads, quads.length);
                         }
                         quads[qlen++] = currQuad;
                         currQuad = 0;
@@ -1501,7 +1501,7 @@ public class UTF8DataInputJsonParser
                         // need room for middle byte?
                         if (currQuadBytes >= 4) {
                             if (qlen >= quads.length) {
-                                _quadBuffer = quads = growArrayBy(quads, quads.length);
+                                _quadBuffer = quads = _growNameDecodeBuffer(quads, quads.length);
                             }
                             quads[qlen++] = currQuad;
                             currQuad = 0;
@@ -1520,7 +1520,7 @@ public class UTF8DataInputJsonParser
                 currQuad = (currQuad << 8) | ch;
             } else {
                 if (qlen >= quads.length) {
-                    _quadBuffer = quads = growArrayBy(quads, quads.length);
+                    _quadBuffer = quads = _growNameDecodeBuffer(quads, quads.length);
                 }
                 quads[qlen++] = currQuad;
                 currQuad = ch;
@@ -1531,7 +1531,7 @@ public class UTF8DataInputJsonParser
 
         if (currQuadBytes > 0) {
             if (qlen >= quads.length) {
-                _quadBuffer = quads = growArrayBy(quads, quads.length);
+                _quadBuffer = quads = _growNameDecodeBuffer(quads, quads.length);
             }
             quads[qlen++] = pad(currQuad, currQuadBytes);
         }
@@ -1590,7 +1590,7 @@ public class UTF8DataInputJsonParser
                 currQuad = (currQuad << 8) | ch;
             } else {
                 if (qlen >= quads.length) {
-                    _quadBuffer = quads = growArrayBy(quads, quads.length);
+                    _quadBuffer = quads = _growNameDecodeBuffer(quads, quads.length);
                 }
                 quads[qlen++] = currQuad;
                 currQuad = ch;
@@ -1605,7 +1605,7 @@ public class UTF8DataInputJsonParser
         _nextByte = ch;
         if (currQuadBytes > 0) {
             if (qlen >= quads.length) {
-                _quadBuffer = quads = growArrayBy(quads, quads.length);
+                _quadBuffer = quads = _growNameDecodeBuffer(quads, quads.length);
             }
             quads[qlen++] = currQuad;
         }
@@ -1659,7 +1659,7 @@ public class UTF8DataInputJsonParser
                     // Ok, we'll need room for first byte right away
                     if (currQuadBytes >= 4) {
                         if (qlen >= quads.length) {
-                            _quadBuffer = quads = growArrayBy(quads, quads.length);
+                            _quadBuffer = quads = _growNameDecodeBuffer(quads, quads.length);
                         }
                         quads[qlen++] = currQuad;
                         currQuad = 0;
@@ -1675,7 +1675,7 @@ public class UTF8DataInputJsonParser
                         // need room for middle byte?
                         if (currQuadBytes >= 4) {
                             if (qlen >= quads.length) {
-                                _quadBuffer = quads = growArrayBy(quads, quads.length);
+                                _quadBuffer = quads = _growNameDecodeBuffer(quads, quads.length);
                             }
                             quads[qlen++] = currQuad;
                             currQuad = 0;
@@ -1694,7 +1694,7 @@ public class UTF8DataInputJsonParser
                 currQuad = (currQuad << 8) | ch;
             } else {
                 if (qlen >= quads.length) {
-                    _quadBuffer = quads = growArrayBy(quads, quads.length);
+                    _quadBuffer = quads = _growNameDecodeBuffer(quads, quads.length);
                 }
                 quads[qlen++] = currQuad;
                 currQuad = ch;
@@ -1705,7 +1705,7 @@ public class UTF8DataInputJsonParser
 
         if (currQuadBytes > 0) {
             if (qlen >= quads.length) {
-                _quadBuffer = quads = growArrayBy(quads, quads.length);
+                _quadBuffer = quads = _growNameDecodeBuffer(quads, quads.length);
             }
             quads[qlen++] = pad(currQuad, currQuadBytes);
         }
@@ -1770,7 +1770,7 @@ public class UTF8DataInputJsonParser
             throws JsonParseException, StreamConstraintsException
     {
         if (qlen >= quads.length) {
-            _quadBuffer = quads = growArrayBy(quads, quads.length);
+            _quadBuffer = quads = _growNameDecodeBuffer(quads, quads.length);
         }
         quads[qlen++] = pad(lastQuad, lastQuadBytes);
         String name = _symbols.findName(quads, qlen);
@@ -1795,6 +1795,7 @@ public class UTF8DataInputJsonParser
          */
         // 4 bytes per quad, except last one maybe less
         int byteLen = (qlen << 2) - 4 + lastQuadBytes;
+        _streamReadConstraints.validateNameLength(byteLen);
 
         /* And last one is not correctly aligned (leading zero bytes instead
          * need to shift a bit, instead of trailing). Only need to shift it

--- a/src/test/java/com/fasterxml/jackson/core/constraints/LargeNameReadTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/constraints/LargeNameReadTest.java
@@ -91,6 +91,24 @@ class LargeNameReadTest extends JUnit5TestBase
         }
     }
 
+    // [core#1602]: DataInput-backed parser must also enforce maxNameLength
+    @Test
+    void largeNameWithSmallLimitDataInput() throws Exception {
+        _testLargeNameWithSmallLimitDataInput(JSON_F_NAME_100);
+        _testLargeNameWithSmallLimitDataInput(JSON_F_NAME_100_B);
+    }
+
+    private void _testLargeNameWithSmallLimitDataInput(JsonFactory jf) throws Exception
+    {
+        final String doc = generateJSON(1000);
+        try (JsonParser p = createParser(jf, MODE_DATA_INPUT, doc)) {
+            consumeTokens(p);
+            fail("expected StreamConstraintsException");
+        } catch (StreamConstraintsException e) {
+            verifyException(e, "Name length");
+        }
+    }
+
     private void consumeTokens(JsonParser p) throws IOException {
         while (p.nextToken() != null) {
             ;


### PR DESCRIPTION
Fixes #1602 (low risk due to very few user parsing from `DataInput`)