### PR TITLE
Add JsonReadFeature.ALLOW_HEXADECIMAL_NUMBERS for JSON5-style hex literals (#707)

### DIFF
--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -19,6 +19,9 @@ JSON library.
 
 #679: Number parsing should fail for trailing dot (period)
  (fix by @cowtowncoder, w/ Claude code)
+#707: Add `JsonReadFeature.ALLOW_HEXADECIMAL_NUMBERS` for JSON5-style hexadecimal
+  integer literals (`0x` / `0X`, optional sign)
+ (implementation by @seonwooj0810)
 #1211: Add `JsonParser.willInternPropertyNames()` to check whether
   property name interning is enabled
  (contributed by Max P)

--- a/src/main/java/tools/jackson/core/base/ParserBase.java
+++ b/src/main/java/tools/jackson/core/base/ParserBase.java
@@ -169,19 +169,6 @@ public abstract class ParserBase extends ParserMinimalBase
      */
     protected boolean _numberIsNaN;
 
-    /**
-     * Marker for integer values read using JSON5 hexadecimal notation
-     * ({@code 0x} / {@code 0X} prefix), enabled via
-     * {@link tools.jackson.core.json.JsonReadFeature#ALLOW_HEXADECIMAL_NUMBERS}.
-     * When {@code true}, the textual representation buffered for the current
-     * token is the original hex literal (including any sign and the
-     * {@code 0x}/{@code 0X} prefix) and {@link #_intLength} records the
-     * number of hexadecimal digits (excluding sign and prefix).
-     *
-     * @since 3.2
-     */
-    protected boolean _numberIsHex;
-
     // And then other information about value itself
 
     /**
@@ -411,40 +398,14 @@ public abstract class ParserBase extends ParserMinimalBase
         return resetFloat(negative, intLen, fractLen, expLen);
     }
 
-    protected final JsonToken resetInt(boolean negative, int intLen)
+    protected JsonToken resetInt(boolean negative, int intLen)
         throws JacksonException
     {
         // May throw StreamConstraintsException:
         _streamReadConstraints.validateIntegerLength(intLen);
         _numberNegative = negative;
         _numberIsNaN = false;
-        _numberIsHex = false;
         _intLength = intLen;
-        _fractLength = 0;
-        _expLength = 0;
-        _numTypesValid = NR_UNKNOWN; // to force decoding
-        _numberString = null;
-        return JsonToken.VALUE_NUMBER_INT;
-    }
-
-    /**
-     * Variant of {@link #resetInt} used for integer values read in JSON5
-     * hexadecimal notation ({@code 0x...}). {@code hexDigitLen} is the
-     * number of hexadecimal digits (excluding sign and {@code 0x}/{@code 0X}
-     * prefix); the textual representation buffered by the caller is expected
-     * to contain the original literal including sign and prefix.
-     *
-     * @since 3.2
-     */
-    protected final JsonToken resetIntHex(boolean negative, int hexDigitLen)
-        throws JacksonException
-    {
-        // May throw StreamConstraintsException:
-        _streamReadConstraints.validateIntegerLength(hexDigitLen);
-        _numberNegative = negative;
-        _numberIsNaN = false;
-        _numberIsHex = true;
-        _intLength = hexDigitLen;
         _fractLength = 0;
         _expLength = 0;
         _numTypesValid = NR_UNKNOWN; // to force decoding
@@ -459,7 +420,6 @@ public abstract class ParserBase extends ParserMinimalBase
         _streamReadConstraints.validateFPLength(intLen + fractLen + expLen);
         _numberNegative = negative;
         _numberIsNaN = false;
-        _numberIsHex = false;
         _intLength = intLen;
         _fractLength = fractLen;
         _expLength = expLen;
@@ -474,7 +434,6 @@ public abstract class ParserBase extends ParserMinimalBase
         _numberDouble = value;
         _numTypesValid = NR_DOUBLE;
         _numberIsNaN = true;
-        _numberIsHex = false;
         _numberString = null;
         return JsonToken.VALUE_NUMBER_FLOAT;
     }

--- a/src/main/java/tools/jackson/core/base/ParserBase.java
+++ b/src/main/java/tools/jackson/core/base/ParserBase.java
@@ -169,6 +169,19 @@ public abstract class ParserBase extends ParserMinimalBase
      */
     protected boolean _numberIsNaN;
 
+    /**
+     * Marker for integer values read using JSON5 hexadecimal notation
+     * ({@code 0x} / {@code 0X} prefix), enabled via
+     * {@link tools.jackson.core.json.JsonReadFeature#ALLOW_HEXADECIMAL_NUMBERS}.
+     * When {@code true}, the textual representation buffered for the current
+     * token is the original hex literal (including any sign and the
+     * {@code 0x}/{@code 0X} prefix) and {@link #_intLength} records the
+     * number of hexadecimal digits (excluding sign and prefix).
+     *
+     * @since 3.2
+     */
+    protected boolean _numberIsHex;
+
     // And then other information about value itself
 
     /**
@@ -405,7 +418,33 @@ public abstract class ParserBase extends ParserMinimalBase
         _streamReadConstraints.validateIntegerLength(intLen);
         _numberNegative = negative;
         _numberIsNaN = false;
+        _numberIsHex = false;
         _intLength = intLen;
+        _fractLength = 0;
+        _expLength = 0;
+        _numTypesValid = NR_UNKNOWN; // to force decoding
+        _numberString = null;
+        return JsonToken.VALUE_NUMBER_INT;
+    }
+
+    /**
+     * Variant of {@link #resetInt} used for integer values read in JSON5
+     * hexadecimal notation ({@code 0x...}). {@code hexDigitLen} is the
+     * number of hexadecimal digits (excluding sign and {@code 0x}/{@code 0X}
+     * prefix); the textual representation buffered by the caller is expected
+     * to contain the original literal including sign and prefix.
+     *
+     * @since 3.2
+     */
+    protected final JsonToken resetIntHex(boolean negative, int hexDigitLen)
+        throws JacksonException
+    {
+        // May throw StreamConstraintsException:
+        _streamReadConstraints.validateIntegerLength(hexDigitLen);
+        _numberNegative = negative;
+        _numberIsNaN = false;
+        _numberIsHex = true;
+        _intLength = hexDigitLen;
         _fractLength = 0;
         _expLength = 0;
         _numTypesValid = NR_UNKNOWN; // to force decoding
@@ -420,6 +459,7 @@ public abstract class ParserBase extends ParserMinimalBase
         _streamReadConstraints.validateFPLength(intLen + fractLen + expLen);
         _numberNegative = negative;
         _numberIsNaN = false;
+        _numberIsHex = false;
         _intLength = intLen;
         _fractLength = fractLen;
         _expLength = expLen;
@@ -434,6 +474,7 @@ public abstract class ParserBase extends ParserMinimalBase
         _numberDouble = value;
         _numTypesValid = NR_DOUBLE;
         _numberIsNaN = true;
+        _numberIsHex = false;
         _numberString = null;
         return JsonToken.VALUE_NUMBER_FLOAT;
     }

--- a/src/main/java/tools/jackson/core/base/ParserBase.java
+++ b/src/main/java/tools/jackson/core/base/ParserBase.java
@@ -398,6 +398,9 @@ public abstract class ParserBase extends ParserMinimalBase
         return resetFloat(negative, intLen, fractLen, expLen);
     }
 
+    // NOTE: was `final` before 3.2; relaxed so that `JsonParserBase` can
+    // override to clear hex-specific state on integer reset (the sibling
+    // `resetFloat` / `resetAsNaN` remain `final`).
     protected JsonToken resetInt(boolean negative, int intLen)
         throws JacksonException
     {

--- a/src/main/java/tools/jackson/core/io/BigIntegerParser.java
+++ b/src/main/java/tools/jackson/core/io/BigIntegerParser.java
@@ -36,4 +36,18 @@ public final class BigIntegerParser
                     ", reason: " + nfe.getMessage());
         }
     }
+
+    public static BigInteger parseWithFastParser(final char[] ch, final int offset,
+            final int length, final int radix) {
+        try {
+            return JavaBigIntegerParser.parseBigInteger(ch, offset, length, radix);
+        } catch (NumberFormatException nfe) {
+            final String reportNum = length <= MAX_CHARS_TO_REPORT
+                    ? new String(ch, offset, length)
+                    : new String(ch, offset, MAX_CHARS_TO_REPORT) + " [truncated]";
+            throw new NumberFormatException("Value \"" + reportNum
+                    + "\" cannot be represented as `java.math.BigInteger` with radix " + radix +
+                    ", reason: " + nfe.getMessage());
+        }
+    }
 }

--- a/src/main/java/tools/jackson/core/io/BigIntegerParser.java
+++ b/src/main/java/tools/jackson/core/io/BigIntegerParser.java
@@ -37,6 +37,9 @@ public final class BigIntegerParser
         }
     }
 
+    /**
+     * @since 3.2
+     */
     public static BigInteger parseWithFastParser(final char[] ch, final int offset,
             final int length, final int radix) {
         try {

--- a/src/main/java/tools/jackson/core/io/NumberInput.java
+++ b/src/main/java/tools/jackson/core/io/NumberInput.java
@@ -590,6 +590,30 @@ public final class NumberInput
     }
 
     /**
+     * Parse a {@link BigInteger} from a {@code char[]} slice. When
+     * {@code useFastParser} is {@code true} the slice is handed to
+     * {@code FastDoubleParser} directly so no intermediate {@link String} is
+     * allocated; otherwise the JDK constructor is used (which requires a
+     * temporary String).
+     *
+     * @param ch char array containing the digits to parse
+     * @param offset offset of the first digit in {@code ch}
+     * @param length number of digits to parse
+     * @param radix radix to parse with
+     * @param useFastParser whether to use {@code FastDoubleParser} (true) or the JDK default (false)
+     * @return a BigInteger
+     * @throws NumberFormatException if the char slice cannot be represented by a BigInteger with the given radix
+     * @since 3.2
+     */
+    public static BigInteger parseBigIntegerWithRadix(final char[] ch, final int offset,
+            final int length, final int radix, final boolean useFastParser) throws NumberFormatException {
+        if (useFastParser) {
+            return BigIntegerParser.parseWithFastParser(ch, offset, length, radix);
+        }
+        return new BigInteger(new String(ch, offset, length), radix);
+    }
+
+    /**
      * Method called to check whether given pattern looks like a valid Java
      * Number (which is bit looser definition than valid JSON Number).
      * Used as pre-parsing check when parsing "Stringified numbers".

--- a/src/main/java/tools/jackson/core/json/JsonParserBase.java
+++ b/src/main/java/tools/jackson/core/json/JsonParserBase.java
@@ -1,5 +1,7 @@
 package tools.jackson.core.json;
 
+import java.math.BigInteger;
+
 import tools.jackson.core.*;
 import tools.jackson.core.base.ParserBase;
 import tools.jackson.core.exc.InputCoercionException;
@@ -192,6 +194,10 @@ public abstract class JsonParserBase
     {
         // Int or float?
         if (_currToken == JsonToken.VALUE_NUMBER_INT) {
+            if (_numberIsHex) {
+                _parseHexInt(expType);
+                return;
+            }
             int len = _intLength;
             // First: optimization for simple int
             if (len <= 9) {
@@ -250,7 +256,9 @@ public abstract class JsonParserBase
     {
         // Inlined variant of: _parseNumericValue(NR_INT)
         if (_currToken == JsonToken.VALUE_NUMBER_INT) {
-            if (_intLength <= 9) {
+            // Hex integers go through the generic path so the base-16 decode is
+            // applied (the base-10 fast path below would mis-read the literal):
+            if (!_numberIsHex && _intLength <= 9) {
                 int i = _textBuffer.contentsAsInt(_numberNegative);
                 _numberInt = i;
                 _numTypesValid = NR_INT;
@@ -295,6 +303,85 @@ public abstract class JsonParserBase
             _numberString = _textBuffer.contentsAsString();
             _numTypesValid = NR_DOUBLE;
         }
+    }
+
+    /**
+     * Decode a JSON5 hexadecimal integer that was buffered as the original
+     * textual literal (sign + {@code 0x}/{@code 0X} prefix + hex digits).
+     * {@link #_intLength} holds the count of hex digits.
+     *
+     * @since 3.2
+     */
+    private void _parseHexInt(int expType) throws JacksonException
+    {
+        final int hexLen = _intLength;
+        final char[] buf = _textBuffer.getTextBuffer();
+        // Locate the first hex digit: skip optional sign and "0x" / "0X" prefix
+        int idx = _textBuffer.getTextOffset();
+        final char first = buf[idx];
+        if (first == '-' || first == '+') {
+            ++idx;
+        }
+        idx += 2; // skip "0x" / "0X"
+
+        // Up to 7 hex digits always fit in a positive signed int (<= 0x0FFFFFFF).
+        // 8 hex digits may overflow signed int (e.g. 0x80000000), so we defer to
+        // the long path which handles range checks uniformly.
+        if (hexLen <= 7) {
+            int v = 0;
+            for (int i = 0; i < hexLen; ++i) {
+                v = (v << 4) | _hexDigit(buf[idx + i]);
+            }
+            _numberInt = _numberNegative ? -v : v;
+            _numTypesValid = NR_INT;
+            return;
+        }
+        // 9..15 hex digits always fit in a positive long (63 bits used at most)
+        if (hexLen <= 15) {
+            long v = 0L;
+            for (int i = 0; i < hexLen; ++i) {
+                v = (v << 4) | _hexDigit(buf[idx + i]);
+            }
+            _numberLong = _numberNegative ? -v : v;
+            _numTypesValid = NR_LONG;
+            return;
+        }
+        // 16 hex digits: may or may not fit in signed long, depending on top bit
+        if (hexLen == 16) {
+            int topNibble = _hexDigit(buf[idx]);
+            if (topNibble < 0x8) { // fits in positive signed long
+                long v = topNibble;
+                for (int i = 1; i < 16; ++i) {
+                    v = (v << 4) | _hexDigit(buf[idx + i]);
+                }
+                _numberLong = _numberNegative ? -v : v;
+                _numTypesValid = NR_LONG;
+                return;
+            }
+            // else fall through to BigInteger path
+        }
+        // Larger values -> BigInteger. We must eagerly decode here (the lazy
+        // base-10 path via _numberString would mis-read hex digits).
+        String digits = new String(buf, idx, hexLen);
+        BigInteger bi = new BigInteger(digits, 16);
+        if (_numberNegative) {
+            bi = bi.negate();
+        }
+        _numberBigInt = bi;
+        _numberString = null;
+        _numTypesValid = NR_BIGINT;
+        if ((expType == NR_INT) || (expType == NR_LONG)) {
+            // Force the overflow path to surface a meaningful error
+            _reportTooLongIntegral(expType, _textBuffer.contentsAsString());
+        }
+    }
+
+    private static int _hexDigit(char c) {
+        if (c <= '9') {
+            return c - '0';
+        }
+        // 'A'..'F' -> 10..15, 'a'..'f' -> 10..15
+        return (c & 0x1F) + 9;
     }
 
     private void _parseSlowInt(int expType) throws JacksonException

--- a/src/main/java/tools/jackson/core/json/JsonParserBase.java
+++ b/src/main/java/tools/jackson/core/json/JsonParserBase.java
@@ -51,6 +51,19 @@ public abstract class JsonParserBase
      */
     protected JsonToken _nextToken;
 
+    /**
+     * Marker for integer values read using JSON5 hexadecimal notation
+     * ({@code 0x} / {@code 0X} prefix), enabled via
+     * {@link JsonReadFeature#ALLOW_HEXADECIMAL_NUMBERS}.
+     * When {@code true}, the textual representation buffered for the current
+     * token is the original hex literal (including any sign and the
+     * {@code 0x}/{@code 0X} prefix) and {@link #_intLength} records the
+     * number of hexadecimal digits (excluding sign and prefix).
+     *
+     * @since 3.2
+     */
+    protected boolean _numberIsHex;
+
     /*
     /**********************************************************************
     /* Helper buffer recycling
@@ -187,6 +200,42 @@ public abstract class JsonParserBase
     /* Numeric parsing method implementations
     /**********************************************************************
      */
+
+    // Overridden to also clear the JSON-only `_numberIsHex` flag, so a
+    // subsequent regular integer is not mis-decoded as hex. Hex literals go
+    // through `resetIntHex` instead, which sets the flag.
+    @Override
+    protected JsonToken resetInt(boolean negative, int intLen)
+        throws JacksonException
+    {
+        _numberIsHex = false;
+        return super.resetInt(negative, intLen);
+    }
+
+    /**
+     * Variant of {@link #resetInt} used for integer values read in JSON5
+     * hexadecimal notation ({@code 0x...}). {@code hexDigitLen} is the
+     * number of hexadecimal digits (excluding sign and {@code 0x}/{@code 0X}
+     * prefix); the textual representation buffered by the caller is expected
+     * to contain the original literal including sign and prefix.
+     *
+     * @since 3.2
+     */
+    protected final JsonToken resetIntHex(boolean negative, int hexDigitLen)
+        throws JacksonException
+    {
+        // May throw StreamConstraintsException:
+        _streamReadConstraints.validateIntegerLength(hexDigitLen);
+        _numberNegative = negative;
+        _numberIsNaN = false;
+        _numberIsHex = true;
+        _intLength = hexDigitLen;
+        _fractLength = 0;
+        _expLength = 0;
+        _numTypesValid = NR_UNKNOWN; // to force decoding
+        _numberString = null;
+        return JsonToken.VALUE_NUMBER_INT;
+    }
 
     @Override
     protected void _parseNumericValue(int expType)
@@ -383,6 +432,31 @@ public abstract class JsonParserBase
         }
         // 'A'..'F' -> 10..15, 'a'..'f' -> 10..15
         return (c & 0x1F) + 9;
+    }
+
+    /**
+     * Shared digit predicate for JSON5 hex literal scanning. Accepts {@code int}
+     * so byte-stream parsers (which read {@code byte & 0xFF}) and char-stream
+     * parsers (where a {@code char} value widens to {@code int}) can use the
+     * same helper.
+     *
+     * @since 3.2
+     */
+    protected static boolean _isHexDigit(int c) {
+        return (c >= '0' && c <= '9')
+                || (c >= 'a' && c <= 'f')
+                || (c >= 'A' && c <= 'F');
+    }
+
+    /**
+     * Standard error message used by all JSON parser variants when a
+     * {@code 0x}/{@code 0X} hex prefix is not followed by any hex digit.
+     *
+     * @since 3.2
+     */
+    protected static String _hexPrefixNotFollowedMessage(char prefixChar) {
+        return "Hexadecimal number prefix '0" + prefixChar
+                + "' must be followed by at least one hex digit (0-9, a-f, A-F)";
     }
 
     private void _parseSlowInt(int expType) throws JacksonException

--- a/src/main/java/tools/jackson/core/json/JsonParserBase.java
+++ b/src/main/java/tools/jackson/core/json/JsonParserBase.java
@@ -438,6 +438,23 @@ public abstract class JsonParserBase
                 + "' must be followed by at least one hex digit (0-9, a-f, A-F)";
     }
 
+    /**
+     * Called after seeing the {@code 'x'} or {@code 'X'} that follows a leading
+     * {@code '0'} in a number literal. Returns silently if
+     * {@link JsonReadFeature#ALLOW_HEXADECIMAL_NUMBERS} is enabled; otherwise
+     * throws a {@link StreamReadException} naming the feature that must be
+     * enabled, so the user gets a specific actionable error instead of a
+     * generic "unexpected character".
+     *
+     * @since 3.2
+     */
+    protected void _checkHexNumbersAllowed(int prefixChar) throws StreamReadException {
+        if (!isEnabled(JsonReadFeature.ALLOW_HEXADECIMAL_NUMBERS)) {
+            _reportUnexpectedChar(prefixChar,
+                    "hexadecimal number literals require enabling `JsonReadFeature.ALLOW_HEXADECIMAL_NUMBERS`");
+        }
+    }
+
     private void _parseSlowInt(int expType) throws JacksonException
     {
         final String numStr = _textBuffer.contentsAsString();

--- a/src/main/java/tools/jackson/core/json/JsonParserBase.java
+++ b/src/main/java/tools/jackson/core/json/JsonParserBase.java
@@ -361,9 +361,10 @@ public abstract class JsonParserBase
             // else fall through to BigInteger path
         }
         // Larger values -> BigInteger. We must eagerly decode here (the lazy
-        // base-10 path via _numberString would mis-read hex digits).
-        String digits = new String(buf, idx, hexLen);
-        BigInteger bi = new BigInteger(digits, 16);
+        // base-10 path via _numberString would mis-read hex digits). Pass the
+        // char[] slice directly so the fast path avoids an intermediate String.
+        BigInteger bi = NumberInput.parseBigIntegerWithRadix(buf, idx, hexLen, 16,
+                isEnabled(StreamReadFeature.USE_FAST_BIG_NUMBER_PARSER));
         if (_numberNegative) {
             bi = bi.negate();
         }

--- a/src/main/java/tools/jackson/core/json/JsonParserBase.java
+++ b/src/main/java/tools/jackson/core/json/JsonParserBase.java
@@ -308,7 +308,7 @@ public abstract class JsonParserBase
         if (_currToken == JsonToken.VALUE_NUMBER_INT) {
             // Hex integers go through the generic path so the base-16 decode is
             // applied (the base-10 fast path below would mis-read the literal):
-            if (!_numberIsHex && _intLength <= 9) {
+            if (_intLength <= 9 && !_numberIsHex) {
                 int i = _textBuffer.contentsAsInt(_numberNegative);
                 _numberInt = i;
                 _numTypesValid = NR_INT;

--- a/src/main/java/tools/jackson/core/json/JsonParserBase.java
+++ b/src/main/java/tools/jackson/core/json/JsonParserBase.java
@@ -6,6 +6,7 @@ import tools.jackson.core.*;
 import tools.jackson.core.base.ParserBase;
 import tools.jackson.core.exc.InputCoercionException;
 import tools.jackson.core.exc.StreamReadException;
+import tools.jackson.core.io.CharTypes;
 import tools.jackson.core.io.IOContext;
 import tools.jackson.core.io.NumberInput;
 import tools.jackson.core.util.JacksonFeatureSet;
@@ -379,7 +380,7 @@ public abstract class JsonParserBase
         if (hexLen <= 7) {
             int v = 0;
             for (int i = 0; i < hexLen; ++i) {
-                v = (v << 4) | _hexDigit(buf[idx + i]);
+                v = (v << 4) | CharTypes.charToHex(buf[idx + i]);
             }
             _numberInt = _numberNegative ? -v : v;
             _numTypesValid = NR_INT;
@@ -389,7 +390,7 @@ public abstract class JsonParserBase
         if (hexLen <= 15) {
             long v = 0L;
             for (int i = 0; i < hexLen; ++i) {
-                v = (v << 4) | _hexDigit(buf[idx + i]);
+                v = (v << 4) | CharTypes.charToHex(buf[idx + i]);
             }
             _numberLong = _numberNegative ? -v : v;
             _numTypesValid = NR_LONG;
@@ -397,11 +398,11 @@ public abstract class JsonParserBase
         }
         // 16 hex digits: may or may not fit in signed long, depending on top bit
         if (hexLen == 16) {
-            int topNibble = _hexDigit(buf[idx]);
+            int topNibble = CharTypes.charToHex(buf[idx]);
             if (topNibble < 0x8) { // fits in positive signed long
                 long v = topNibble;
                 for (int i = 1; i < 16; ++i) {
-                    v = (v << 4) | _hexDigit(buf[idx + i]);
+                    v = (v << 4) | CharTypes.charToHex(buf[idx + i]);
                 }
                 _numberLong = _numberNegative ? -v : v;
                 _numTypesValid = NR_LONG;
@@ -424,28 +425,6 @@ public abstract class JsonParserBase
             // Force the overflow path to surface a meaningful error
             _reportTooLongIntegral(expType, _textBuffer.contentsAsString());
         }
-    }
-
-    private static int _hexDigit(char c) {
-        if (c <= '9') {
-            return c - '0';
-        }
-        // 'A'..'F' -> 10..15, 'a'..'f' -> 10..15
-        return (c & 0x1F) + 9;
-    }
-
-    /**
-     * Shared digit predicate for JSON5 hex literal scanning. Accepts {@code int}
-     * so byte-stream parsers (which read {@code byte & 0xFF}) and char-stream
-     * parsers (where a {@code char} value widens to {@code int}) can use the
-     * same helper.
-     *
-     * @since 3.2
-     */
-    protected static boolean _isHexDigit(int c) {
-        return (c >= '0' && c <= '9')
-                || (c >= 'a' && c <= 'f')
-                || (c >= 'A' && c <= 'F');
     }
 
     /**

--- a/src/main/java/tools/jackson/core/json/JsonReadFeature.java
+++ b/src/main/java/tools/jackson/core/json/JsonReadFeature.java
@@ -106,6 +106,38 @@ public enum JsonReadFeature
 
     /**
      * Feature that determines whether parser will allow
+     * JSON integer numbers to be expressed in hexadecimal
+     * notation as defined by the
+     * <a href="https://spec.json5.org/#numbers">JSON5 specification</a>:
+     * a {@code 0x} or {@code 0X} prefix followed by one or more
+     * hexadecimal digits ({@code [0-9a-fA-F]}), optionally preceded
+     * by a single {@code +} or {@code -} sign
+     * (with {@link #ALLOW_LEADING_PLUS_SIGN_FOR_NUMBERS} additionally
+     * required for the {@code +} variant).
+     * When enabled, tokens such as {@code 0xC0FFEE} or {@code -0x10} are
+     * accepted as {@link JsonToken#VALUE_NUMBER_INT}. The textual
+     * representation returned by {@link JsonParser#getString()} preserves
+     * the original literal (including the {@code 0x} / {@code 0X} prefix
+     * and any sign), while numeric accessors such as
+     * {@link JsonParser#getIntValue()}, {@link JsonParser#getLongValue()}
+     * and {@link JsonParser#getBigIntegerValue()} return the decoded value.
+     *<p>
+     * This feature is independent of
+     * {@link #ALLOW_LEADING_ZEROS_FOR_NUMBERS}: leading zeros in the
+     * hexadecimal digit sequence (for example {@code 0x007F}) are always
+     * permitted when this feature is enabled, regardless of the state of
+     * {@code ALLOW_LEADING_ZEROS_FOR_NUMBERS}, since the JSON5 grammar
+     * allows them.
+     *<p>
+     * Since JSON specification does not allow hexadecimal numbers,
+     * this is a non-standard feature, and disabled by default.
+     *
+     * @since 3.2
+     */
+    ALLOW_HEXADECIMAL_NUMBERS(false),
+
+    /**
+     * Feature that determines whether parser will allow
      * JSON decimal numbers to start with a decimal point
      * (like: {@code .123}). If enabled, no exception is thrown, and the number
      * is parsed as though a leading 0 had been present.
@@ -168,38 +200,6 @@ public enum JsonReadFeature
      * this is a non-standard feature, and as such disabled by default.
      */
     ALLOW_TRAILING_DECIMAL_POINT_FOR_NUMBERS(false),
-
-    /**
-     * Feature that determines whether parser will allow
-     * JSON integer numbers to be expressed in hexadecimal
-     * notation as defined by the
-     * <a href="https://spec.json5.org/#numbers">JSON5 specification</a>:
-     * a {@code 0x} or {@code 0X} prefix followed by one or more
-     * hexadecimal digits ({@code [0-9a-fA-F]}), optionally preceded
-     * by a single {@code +} or {@code -} sign
-     * (with {@link #ALLOW_LEADING_PLUS_SIGN_FOR_NUMBERS} additionally
-     * required for the {@code +} variant).
-     * When enabled, tokens such as {@code 0xC0FFEE} or {@code -0x10} are
-     * accepted as {@link JsonToken#VALUE_NUMBER_INT}. The textual
-     * representation returned by {@link JsonParser#getString()} preserves
-     * the original literal (including the {@code 0x} / {@code 0X} prefix
-     * and any sign), while numeric accessors such as
-     * {@link JsonParser#getIntValue()}, {@link JsonParser#getLongValue()}
-     * and {@link JsonParser#getBigIntegerValue()} return the decoded value.
-     *<p>
-     * This feature is independent of
-     * {@link #ALLOW_LEADING_ZEROS_FOR_NUMBERS}: leading zeros in the
-     * hexadecimal digit sequence (for example {@code 0x007F}) are always
-     * permitted when this feature is enabled, regardless of the state of
-     * {@code ALLOW_LEADING_ZEROS_FOR_NUMBERS}, since the JSON5 grammar
-     * allows them.
-     *<p>
-     * Since JSON specification does not allow hexadecimal numbers,
-     * this is a non-standard feature, and as such disabled by default.
-     *
-     * @since 3.2
-     */
-    ALLOW_HEXADECIMAL_NUMBERS(false),
 
     // // // Support for non-standard data format constructs: array/value separators
 

--- a/src/main/java/tools/jackson/core/json/JsonReadFeature.java
+++ b/src/main/java/tools/jackson/core/json/JsonReadFeature.java
@@ -169,6 +169,38 @@ public enum JsonReadFeature
      */
     ALLOW_TRAILING_DECIMAL_POINT_FOR_NUMBERS(false),
 
+    /**
+     * Feature that determines whether parser will allow
+     * JSON integer numbers to be expressed in hexadecimal
+     * notation as defined by the
+     * <a href="https://spec.json5.org/#numbers">JSON5 specification</a>:
+     * a {@code 0x} or {@code 0X} prefix followed by one or more
+     * hexadecimal digits ({@code [0-9a-fA-F]}), optionally preceded
+     * by a single {@code +} or {@code -} sign
+     * (with {@link #ALLOW_LEADING_PLUS_SIGN_FOR_NUMBERS} additionally
+     * required for the {@code +} variant).
+     * When enabled, tokens such as {@code 0xC0FFEE} or {@code -0x10} are
+     * accepted as {@link JsonToken#VALUE_NUMBER_INT}. The textual
+     * representation returned by {@link JsonParser#getString()} preserves
+     * the original literal (including the {@code 0x} / {@code 0X} prefix
+     * and any sign), while numeric accessors such as
+     * {@link JsonParser#getIntValue()}, {@link JsonParser#getLongValue()}
+     * and {@link JsonParser#getBigIntegerValue()} return the decoded value.
+     *<p>
+     * This feature is independent of
+     * {@link #ALLOW_LEADING_ZEROS_FOR_NUMBERS}: leading zeros in the
+     * hexadecimal digit sequence (for example {@code 0x007F}) are always
+     * permitted when this feature is enabled, regardless of the state of
+     * {@code ALLOW_LEADING_ZEROS_FOR_NUMBERS}, since the JSON5 grammar
+     * allows them.
+     *<p>
+     * Since JSON specification does not allow hexadecimal numbers,
+     * this is a non-standard feature, and as such disabled by default.
+     *
+     * @since 3.2
+     */
+    ALLOW_HEXADECIMAL_NUMBERS(false),
+
     // // // Support for non-standard data format constructs: array/value separators
 
     /**

--- a/src/main/java/tools/jackson/core/json/ReaderBasedJsonParser.java
+++ b/src/main/java/tools/jackson/core/json/ReaderBasedJsonParser.java
@@ -1581,6 +1581,16 @@ public class ReaderBasedJsonParser
         char c = (_inputPtr < _inputEnd) ? _inputBuffer[_inputPtr++]
                 : getNextChar("No digit following sign", JsonToken.VALUE_NUMBER_INT);
         if (c == '0') {
+            // [core#707]: JSON5 hexadecimal literal ('0x' / '0X')?
+            // Must be checked BEFORE _verifyNoLeadingZeroes(): leading zeros are
+            // valid in hex regardless of ALLOW_LEADING_ZEROS_FOR_NUMBERS.
+            if (_inputPtr < _inputEnd || _loadMore()) {
+                char peek = _inputBuffer[_inputPtr];
+                if ((peek == 'x' || peek == 'X')
+                        && isEnabled(JsonReadFeature.ALLOW_HEXADECIMAL_NUMBERS)) {
+                    return _finishHexNumber(neg, outBuf, outPtr, peek);
+                }
+            }
             c = _verifyNoLeadingZeroes();
         }
         boolean eof = false;
@@ -1706,6 +1716,71 @@ public class ReaderBasedJsonParser
             return resetInt(neg, intLen);
         }
         return resetFloat(neg, intLen, fractLen, expLen);
+    }
+
+    // [core#707] Finish parsing a JSON5 hexadecimal integer literal once
+    // '0' + 'x'/'X' has been recognized. The current text buffer already
+    // contains the optional sign and the leading '0'; we append 'x'/'X' and
+    // then all hex digits, then validate proper termination.
+    //
+    // @since 3.2
+    private final JsonToken _finishHexNumber(boolean neg,
+            char[] outBuf, int outPtr, char prefixChar) throws JacksonException
+    {
+        // Append the '0' (already consumed by _parseNumber2) and the 'x'/'X'
+        if (outPtr >= outBuf.length) {
+            outBuf = _textBuffer.finishCurrentSegment();
+            outPtr = 0;
+        }
+        outBuf[outPtr++] = '0';
+        if (outPtr >= outBuf.length) {
+            outBuf = _textBuffer.finishCurrentSegment();
+            outPtr = 0;
+        }
+        outBuf[outPtr++] = prefixChar;
+        ++_inputPtr; // consume the 'x'/'X' that we only peeked at
+
+        int hexLen = 0;
+        boolean eof = false;
+        char c = CHAR_NULL;
+
+        hex_loop:
+        while (true) {
+            if (_inputPtr >= _inputEnd && !_loadMore()) {
+                eof = true;
+                break hex_loop;
+            }
+            c = _inputBuffer[_inputPtr++];
+            if (!_isHexDigit(c)) {
+                break hex_loop;
+            }
+            ++hexLen;
+            if (outPtr >= outBuf.length) {
+                outBuf = _textBuffer.finishCurrentSegment();
+                outPtr = 0;
+            }
+            outBuf[outPtr++] = c;
+        }
+
+        if (hexLen == 0) {
+            _reportUnexpectedNumberChar(c,
+                    "Hexadecimal number prefix '0" + prefixChar + "' must be followed by at least one hex digit (0-9, a-f, A-F)");
+        }
+
+        if (!eof) {
+            --_inputPtr; // push back the terminating non-hex char
+            if (_streamReadContext.inRoot()) {
+                _verifyRootSpace(c);
+            }
+        }
+        _textBuffer.setCurrentLength(outPtr);
+        return resetIntHex(neg, hexLen);
+    }
+
+    private static boolean _isHexDigit(char c) {
+        return (c >= '0' && c <= '9')
+                || (c >= 'a' && c <= 'f')
+                || (c >= 'A' && c <= 'F');
     }
 
     // Method called when we have seen one zero, and want to ensure

--- a/src/main/java/tools/jackson/core/json/ReaderBasedJsonParser.java
+++ b/src/main/java/tools/jackson/core/json/ReaderBasedJsonParser.java
@@ -1763,8 +1763,7 @@ public class ReaderBasedJsonParser
         }
 
         if (hexLen == 0) {
-            _reportUnexpectedNumberChar(c,
-                    "Hexadecimal number prefix '0" + prefixChar + "' must be followed by at least one hex digit (0-9, a-f, A-F)");
+            _reportUnexpectedNumberChar(c, _hexPrefixNotFollowedMessage(prefixChar));
         }
 
         if (!eof) {
@@ -1775,12 +1774,6 @@ public class ReaderBasedJsonParser
         }
         _textBuffer.setCurrentLength(outPtr);
         return resetIntHex(neg, hexLen);
-    }
-
-    private static boolean _isHexDigit(char c) {
-        return (c >= '0' && c <= '9')
-                || (c >= 'a' && c <= 'f')
-                || (c >= 'A' && c <= 'F');
     }
 
     // Method called when we have seen one zero, and want to ensure

--- a/src/main/java/tools/jackson/core/json/ReaderBasedJsonParser.java
+++ b/src/main/java/tools/jackson/core/json/ReaderBasedJsonParser.java
@@ -1767,7 +1767,7 @@ public class ReaderBasedJsonParser
         }
 
         if (hexLen == 0) {
-            _reportUnexpectedNumberChar(c, _hexPrefixNotFollowedMessage(prefixChar));
+            return _reportUnexpectedNumberChar(c, _hexPrefixNotFollowedMessage(prefixChar));
         }
 
         if (!eof) {

--- a/src/main/java/tools/jackson/core/json/ReaderBasedJsonParser.java
+++ b/src/main/java/tools/jackson/core/json/ReaderBasedJsonParser.java
@@ -1586,8 +1586,8 @@ public class ReaderBasedJsonParser
             // valid in hex regardless of ALLOW_LEADING_ZEROS_FOR_NUMBERS.
             if (_inputPtr < _inputEnd || _loadMore()) {
                 char peek = _inputBuffer[_inputPtr];
-                if ((peek == 'x' || peek == 'X')
-                        && isEnabled(JsonReadFeature.ALLOW_HEXADECIMAL_NUMBERS)) {
+                if (peek == 'x' || peek == 'X') {
+                    _checkHexNumbersAllowed(peek);
                     return _finishHexNumber(neg, outBuf, outPtr, peek);
                 }
             }

--- a/src/main/java/tools/jackson/core/json/ReaderBasedJsonParser.java
+++ b/src/main/java/tools/jackson/core/json/ReaderBasedJsonParser.java
@@ -1587,6 +1587,7 @@ public class ReaderBasedJsonParser
             if (_inputPtr < _inputEnd || _loadMore()) {
                 char peek = _inputBuffer[_inputPtr];
                 if (peek == 'x' || peek == 'X') {
+                    ++_inputPtr;
                     _checkHexNumbersAllowed(peek);
                     return _finishHexNumber(neg, outBuf, outPtr, peek);
                 }
@@ -1725,9 +1726,10 @@ public class ReaderBasedJsonParser
     //
     // @since 3.2
     private final JsonToken _finishHexNumber(boolean neg,
-            char[] outBuf, int outPtr, char prefixChar) throws JacksonException
+            char[] outBuf, int outPtr, char prefixChar)
+        throws JacksonException
     {
-        // Append the '0' (already consumed by _parseNumber2) and the 'x'/'X'
+        // Append the '0' and the 'x'/'X'
         if (outPtr >= outBuf.length) {
             outBuf = _textBuffer.finishCurrentSegment();
             outPtr = 0;
@@ -1738,7 +1740,6 @@ public class ReaderBasedJsonParser
             outPtr = 0;
         }
         outBuf[outPtr++] = prefixChar;
-        ++_inputPtr; // consume the 'x'/'X' that we only peeked at
 
         int hexLen = 0;
         boolean eof = false;

--- a/src/main/java/tools/jackson/core/json/ReaderBasedJsonParser.java
+++ b/src/main/java/tools/jackson/core/json/ReaderBasedJsonParser.java
@@ -1756,6 +1756,10 @@ public class ReaderBasedJsonParser
             }
             ++hexLen;
             if (outPtr >= outBuf.length) {
+                // Validate accumulated length at every segment boundary so that a
+                // pathological hex literal (e.g. millions of digits) is rejected
+                // early rather than after full buffering.
+                _streamReadConstraints.validateIntegerLength(hexLen);
                 outBuf = _textBuffer.finishCurrentSegment();
                 outPtr = 0;
             }

--- a/src/main/java/tools/jackson/core/json/ReaderBasedJsonParser.java
+++ b/src/main/java/tools/jackson/core/json/ReaderBasedJsonParser.java
@@ -1751,7 +1751,7 @@ public class ReaderBasedJsonParser
                 break hex_loop;
             }
             c = _inputBuffer[_inputPtr++];
-            if (!_isHexDigit(c)) {
+            if (CharTypes.charToHex(c) < 0) {
                 break hex_loop;
             }
             ++hexLen;

--- a/src/main/java/tools/jackson/core/json/UTF8DataInputJsonParser.java
+++ b/src/main/java/tools/jackson/core/json/UTF8DataInputJsonParser.java
@@ -1193,7 +1193,7 @@ public class UTF8DataInputJsonParser
 
         int hexLen = 0;
         int c = readUnsignedByte();
-        while (_isHexDigit(c)) {
+        while (CharTypes.charToHex(c) >= 0) {
             ++hexLen;
             if (outPtr >= outBuf.length) {
                 outBuf = _textBuffer.finishCurrentSegment();

--- a/src/main/java/tools/jackson/core/json/UTF8DataInputJsonParser.java
+++ b/src/main/java/tools/jackson/core/json/UTF8DataInputJsonParser.java
@@ -1064,6 +1064,10 @@ public class UTF8DataInputJsonParser
             if (c <= INT_9 && c >= INT_0) { // skip if followed by digit
                 outPtr = 0;
             } else if (c == 'x' || c == 'X') {
+                // [core#707] JSON5 hexadecimal literal?
+                if (isEnabled(JsonReadFeature.ALLOW_HEXADECIMAL_NUMBERS)) {
+                    return _finishHexNumber(false, outBuf, 0, c);
+                }
                 return _handleInvalidNumberStart(c, false);
             } else {
                 outBuf[0] = '0';
@@ -1123,6 +1127,13 @@ public class UTF8DataInputJsonParser
             // One special case: if first char is 0 need to check no leading zeroes
             if (c == INT_0) {
                 c = _handleLeadingZeroes();
+                // [core#707] JSON5 hexadecimal literal with sign?
+                if ((c == 'x' || c == 'X')
+                        && isEnabled(JsonReadFeature.ALLOW_HEXADECIMAL_NUMBERS)) {
+                    // outBuf currently holds [sign, '0']; the helper re-appends
+                    // '0' itself, so rewind outPtr to just after the sign.
+                    return _finishHexNumber(negative, outBuf, 1, c);
+                }
             } else if (c == INT_PERIOD) {
                 return _parseFloatThatStartsWithPeriod(negative, true);
             } else {
@@ -1158,6 +1169,56 @@ public class UTF8DataInputJsonParser
         }
         // And there we have it!
         return resetInt(negative, intLen);
+    }
+
+    // [core#707] Finish parsing a JSON5 hexadecimal integer literal. On entry the
+    // optional sign (if any) is already in outBuf at indices [0..outPtr-1] and
+    // the 'x'/'X' has already been consumed from the underlying DataInput.
+    // We append '0' + prefix char + all hex digits.
+    //
+    // @since 3.2
+    private final JsonToken _finishHexNumber(boolean neg, char[] outBuf, int outPtr,
+            int prefixChar) throws IOException
+    {
+        if (outPtr >= outBuf.length) {
+            outBuf = _textBuffer.finishCurrentSegment();
+            outPtr = 0;
+        }
+        outBuf[outPtr++] = '0';
+        if (outPtr >= outBuf.length) {
+            outBuf = _textBuffer.finishCurrentSegment();
+            outPtr = 0;
+        }
+        outBuf[outPtr++] = (char) prefixChar;
+
+        int hexLen = 0;
+        int c = readUnsignedByte();
+        while (_isHexDigit(c)) {
+            ++hexLen;
+            if (outPtr >= outBuf.length) {
+                outBuf = _textBuffer.finishCurrentSegment();
+                outPtr = 0;
+            }
+            outBuf[outPtr++] = (char) c;
+            c = readUnsignedByte();
+        }
+        if (hexLen == 0) {
+            return _reportUnexpectedNumberChar(c,
+                    "Hexadecimal number prefix '0" + ((char) prefixChar)
+                    + "' must be followed by at least one hex digit (0-9, a-f, A-F)");
+        }
+        _textBuffer.setCurrentLength(outPtr);
+        _nextByte = c;
+        if (_streamReadContext.inRoot()) {
+            _verifyRootSpace();
+        }
+        return resetIntHex(neg, hexLen);
+    }
+
+    private static boolean _isHexDigit(int c) {
+        return (c >= INT_0 && c <= INT_9)
+                || (c >= 'a' && c <= 'f')
+                || (c >= 'A' && c <= 'F');
     }
 
     /**

--- a/src/main/java/tools/jackson/core/json/UTF8DataInputJsonParser.java
+++ b/src/main/java/tools/jackson/core/json/UTF8DataInputJsonParser.java
@@ -1194,6 +1194,10 @@ public class UTF8DataInputJsonParser
         while (CharTypes.charToHex(c) >= 0) {
             ++hexLen;
             if (outPtr >= outBuf.length) {
+                // Validate accumulated length at every segment boundary so that a
+                // pathological hex literal (e.g. millions of digits) is rejected
+                // early rather than after full buffering.
+                _streamReadConstraints.validateIntegerLength(hexLen);
                 outBuf = _textBuffer.finishCurrentSegment();
                 outPtr = 0;
             }

--- a/src/main/java/tools/jackson/core/json/UTF8DataInputJsonParser.java
+++ b/src/main/java/tools/jackson/core/json/UTF8DataInputJsonParser.java
@@ -1065,10 +1065,8 @@ public class UTF8DataInputJsonParser
                 outPtr = 0;
             } else if (c == 'x' || c == 'X') {
                 // [core#707] JSON5 hexadecimal literal?
-                if (isEnabled(JsonReadFeature.ALLOW_HEXADECIMAL_NUMBERS)) {
-                    return _finishHexNumber(false, outBuf, 0, c);
-                }
-                return _handleInvalidNumberStart(c, false);
+                _checkHexNumbersAllowed(c);
+                return _finishHexNumber(false, outBuf, 0, c);
             } else {
                 outBuf[0] = '0';
                 outPtr = 1;
@@ -1128,8 +1126,8 @@ public class UTF8DataInputJsonParser
             if (c == INT_0) {
                 c = _handleLeadingZeroes();
                 // [core#707] JSON5 hexadecimal literal with sign?
-                if ((c == 'x' || c == 'X')
-                        && isEnabled(JsonReadFeature.ALLOW_HEXADECIMAL_NUMBERS)) {
+                if (c == 'x' || c == 'X') {
+                    _checkHexNumbersAllowed(c);
                     // outBuf currently holds [sign, '0']; the helper re-appends
                     // '0' itself, so rewind outPtr to just after the sign.
                     return _finishHexNumber(negative, outBuf, 1, c);

--- a/src/main/java/tools/jackson/core/json/UTF8DataInputJsonParser.java
+++ b/src/main/java/tools/jackson/core/json/UTF8DataInputJsonParser.java
@@ -1203,9 +1203,7 @@ public class UTF8DataInputJsonParser
             c = readUnsignedByte();
         }
         if (hexLen == 0) {
-            return _reportUnexpectedNumberChar(c,
-                    "Hexadecimal number prefix '0" + ((char) prefixChar)
-                    + "' must be followed by at least one hex digit (0-9, a-f, A-F)");
+            return _reportUnexpectedNumberChar(c, _hexPrefixNotFollowedMessage((char) prefixChar));
         }
         _textBuffer.setCurrentLength(outPtr);
         _nextByte = c;
@@ -1213,12 +1211,6 @@ public class UTF8DataInputJsonParser
             _verifyRootSpace();
         }
         return resetIntHex(neg, hexLen);
-    }
-
-    private static boolean _isHexDigit(int c) {
-        return (c >= INT_0 && c <= INT_9)
-                || (c >= 'a' && c <= 'f')
-                || (c >= 'A' && c <= 'F');
     }
 
     /**

--- a/src/main/java/tools/jackson/core/json/UTF8StreamJsonParser.java
+++ b/src/main/java/tools/jackson/core/json/UTF8StreamJsonParser.java
@@ -2013,9 +2013,7 @@ public class UTF8StreamJsonParser
         }
 
         if (hexLen == 0) {
-            return _reportUnexpectedNumberChar(c,
-                    "Hexadecimal number prefix '0" + ((char) prefixChar)
-                    + "' must be followed by at least one hex digit (0-9, a-f, A-F)");
+            return _reportUnexpectedNumberChar(c, _hexPrefixNotFollowedMessage((char) prefixChar));
         }
 
         if (!eof) {
@@ -2026,12 +2024,6 @@ public class UTF8StreamJsonParser
         }
         _textBuffer.setCurrentLength(outPtr);
         return resetIntHex(neg, hexLen);
-    }
-
-    private static boolean _isHexDigit(int c) {
-        return (c >= INT_0 && c <= INT_9)
-                || (c >= 'a' && c <= 'f')
-                || (c >= 'A' && c <= 'F');
     }
 
     // Method called when we have seen one zero, and want to ensure

--- a/src/main/java/tools/jackson/core/json/UTF8StreamJsonParser.java
+++ b/src/main/java/tools/jackson/core/json/UTF8StreamJsonParser.java
@@ -1824,8 +1824,8 @@ public class UTF8StreamJsonParser
             // hex digits are valid regardless of ALLOW_LEADING_ZEROS_FOR_NUMBERS.
             if (_inputPtr < _inputEnd || _loadMore()) {
                 int peek = _inputBuffer[_inputPtr] & 0xFF;
-                if ((peek == 'x' || peek == 'X')
-                        && isEnabled(JsonReadFeature.ALLOW_HEXADECIMAL_NUMBERS)) {
+                if (peek == 'x' || peek == 'X') {
+                    _checkHexNumbersAllowed(peek);
                     return _finishHexNumber(false, outBuf, 0, peek);
                 }
             }
@@ -1887,8 +1887,8 @@ public class UTF8StreamJsonParser
             // [core#707] JSON5 hexadecimal literal ('0x' / '0X') with optional sign?
             if (_inputPtr < _inputEnd || _loadMore()) {
                 int peek = _inputBuffer[_inputPtr] & 0xFF;
-                if ((peek == 'x' || peek == 'X')
-                        && isEnabled(JsonReadFeature.ALLOW_HEXADECIMAL_NUMBERS)) {
+                if (peek == 'x' || peek == 'X') {
+                    _checkHexNumbersAllowed(peek);
                     return _finishHexNumber(negative, outBuf, outPtr, peek);
                 }
             }

--- a/src/main/java/tools/jackson/core/json/UTF8StreamJsonParser.java
+++ b/src/main/java/tools/jackson/core/json/UTF8StreamJsonParser.java
@@ -1819,6 +1819,16 @@ public class UTF8StreamJsonParser
         char[] outBuf = _textBuffer.emptyAndGetCurrentSegment();
         // One special case: if first char is 0, must not be followed by a digit
         if (c == INT_0) {
+            // [core#707] JSON5 hexadecimal literal ('0x' / '0X')?
+            // Must be checked BEFORE _verifyNoLeadingZeroes(): leading zeros in
+            // hex digits are valid regardless of ALLOW_LEADING_ZEROS_FOR_NUMBERS.
+            if (_inputPtr < _inputEnd || _loadMore()) {
+                int peek = _inputBuffer[_inputPtr] & 0xFF;
+                if ((peek == 'x' || peek == 'X')
+                        && isEnabled(JsonReadFeature.ALLOW_HEXADECIMAL_NUMBERS)) {
+                    return _finishHexNumber(false, outBuf, 0, peek);
+                }
+            }
             c = _verifyNoLeadingZeroes();
         }
         // Ok: we can first just add digit we saw first:
@@ -1873,6 +1883,14 @@ public class UTF8StreamJsonParser
                     return _parseFloatThatStartsWithPeriod(negative, true);
                 }
                 return _handleInvalidNumberStart(c, negative, true);
+            }
+            // [core#707] JSON5 hexadecimal literal ('0x' / '0X') with optional sign?
+            if (_inputPtr < _inputEnd || _loadMore()) {
+                int peek = _inputBuffer[_inputPtr] & 0xFF;
+                if ((peek == 'x' || peek == 'X')
+                        && isEnabled(JsonReadFeature.ALLOW_HEXADECIMAL_NUMBERS)) {
+                    return _finishHexNumber(negative, outBuf, outPtr, peek);
+                }
             }
             c = _verifyNoLeadingZeroes();
         } else if (c > INT_9) {
@@ -1949,6 +1967,71 @@ public class UTF8StreamJsonParser
         // And there we have it!
         return resetInt(negative, intPartLength);
 
+    }
+
+    // [core#707] Finish parsing a JSON5 hexadecimal integer literal. On entry the
+    // optional sign (if any) is already in outBuf at indices [0..outPtr-1], and
+    // we have seen '0' followed by 'x'/'X' (still un-consumed in the input
+    // buffer). We append '0' then the prefix char then all hex digits.
+    //
+    // @since 3.2
+    private final JsonToken _finishHexNumber(boolean neg, char[] outBuf, int outPtr,
+            int prefixChar) throws JacksonException
+    {
+        if (outPtr >= outBuf.length) {
+            outBuf = _textBuffer.finishCurrentSegment();
+            outPtr = 0;
+        }
+        outBuf[outPtr++] = '0';
+        if (outPtr >= outBuf.length) {
+            outBuf = _textBuffer.finishCurrentSegment();
+            outPtr = 0;
+        }
+        outBuf[outPtr++] = (char) prefixChar;
+        ++_inputPtr; // consume the 'x'/'X' we only peeked at
+
+        int hexLen = 0;
+        int c = 0;
+        boolean eof = false;
+
+        hex_loop:
+        while (true) {
+            if (_inputPtr >= _inputEnd && !_loadMore()) {
+                eof = true;
+                break hex_loop;
+            }
+            c = _inputBuffer[_inputPtr++] & 0xFF;
+            if (!_isHexDigit(c)) {
+                break hex_loop;
+            }
+            ++hexLen;
+            if (outPtr >= outBuf.length) {
+                outBuf = _textBuffer.finishCurrentSegment();
+                outPtr = 0;
+            }
+            outBuf[outPtr++] = (char) c;
+        }
+
+        if (hexLen == 0) {
+            return _reportUnexpectedNumberChar(c,
+                    "Hexadecimal number prefix '0" + ((char) prefixChar)
+                    + "' must be followed by at least one hex digit (0-9, a-f, A-F)");
+        }
+
+        if (!eof) {
+            --_inputPtr; // push back the terminating non-hex char
+            if (_streamReadContext.inRoot()) {
+                _verifyRootSpace(c);
+            }
+        }
+        _textBuffer.setCurrentLength(outPtr);
+        return resetIntHex(neg, hexLen);
+    }
+
+    private static boolean _isHexDigit(int c) {
+        return (c >= INT_0 && c <= INT_9)
+                || (c >= 'a' && c <= 'f')
+                || (c >= 'A' && c <= 'F');
     }
 
     // Method called when we have seen one zero, and want to ensure

--- a/src/main/java/tools/jackson/core/json/UTF8StreamJsonParser.java
+++ b/src/main/java/tools/jackson/core/json/UTF8StreamJsonParser.java
@@ -2001,7 +2001,7 @@ public class UTF8StreamJsonParser
                 break hex_loop;
             }
             c = _inputBuffer[_inputPtr++] & 0xFF;
-            if (!_isHexDigit(c)) {
+            if (CharTypes.charToHex(c) < 0) {
                 break hex_loop;
             }
             ++hexLen;

--- a/src/main/java/tools/jackson/core/json/UTF8StreamJsonParser.java
+++ b/src/main/java/tools/jackson/core/json/UTF8StreamJsonParser.java
@@ -2006,6 +2006,10 @@ public class UTF8StreamJsonParser
             }
             ++hexLen;
             if (outPtr >= outBuf.length) {
+                // Validate accumulated length at every segment boundary so that a
+                // pathological hex literal (e.g. millions of digits) is rejected
+                // early rather than after full buffering.
+                _streamReadConstraints.validateIntegerLength(hexLen);
                 outBuf = _textBuffer.finishCurrentSegment();
                 outPtr = 0;
             }

--- a/src/main/java/tools/jackson/core/json/UTF8StreamJsonParser.java
+++ b/src/main/java/tools/jackson/core/json/UTF8StreamJsonParser.java
@@ -1825,6 +1825,7 @@ public class UTF8StreamJsonParser
             if (_inputPtr < _inputEnd || _loadMore()) {
                 int peek = _inputBuffer[_inputPtr] & 0xFF;
                 if (peek == 'x' || peek == 'X') {
+                    ++_inputPtr;
                     _checkHexNumbersAllowed(peek);
                     return _finishHexNumber(false, outBuf, 0, peek);
                 }
@@ -1888,6 +1889,7 @@ public class UTF8StreamJsonParser
             if (_inputPtr < _inputEnd || _loadMore()) {
                 int peek = _inputBuffer[_inputPtr] & 0xFF;
                 if (peek == 'x' || peek == 'X') {
+                    ++_inputPtr;
                     _checkHexNumbersAllowed(peek);
                     return _finishHexNumber(negative, outBuf, outPtr, peek);
                 }
@@ -1971,13 +1973,15 @@ public class UTF8StreamJsonParser
 
     // [core#707] Finish parsing a JSON5 hexadecimal integer literal. On entry the
     // optional sign (if any) is already in outBuf at indices [0..outPtr-1], and
-    // we have seen '0' followed by 'x'/'X' (still un-consumed in the input
-    // buffer). We append '0' then the prefix char then all hex digits.
+    // we have seen '0' followed by 'x'/'X' .
+    // We append '0' then the prefix char then all hex digits.
     //
     // @since 3.2
     private final JsonToken _finishHexNumber(boolean neg, char[] outBuf, int outPtr,
-            int prefixChar) throws JacksonException
+            int prefixChar)
+        throws JacksonException
     {
+        // Prepend "0x" prefix
         if (outPtr >= outBuf.length) {
             outBuf = _textBuffer.finishCurrentSegment();
             outPtr = 0;
@@ -1988,7 +1992,6 @@ public class UTF8StreamJsonParser
             outPtr = 0;
         }
         outBuf[outPtr++] = (char) prefixChar;
-        ++_inputPtr; // consume the 'x'/'X' we only peeked at
 
         int hexLen = 0;
         int c = 0;

--- a/src/main/java/tools/jackson/core/json/async/NonBlockingJsonParserBase.java
+++ b/src/main/java/tools/jackson/core/json/async/NonBlockingJsonParserBase.java
@@ -116,6 +116,12 @@ public abstract class NonBlockingJsonParserBase
     // resume correctly retains the leading '+' character.
     protected final static int MINOR_NUMBER_PLUSZERO = 33;
 
+    // [core#707] JSON5 hexadecimal literal states:
+    //  - HEX_PREFIX: textBuffer holds optional sign + '0' + 'x'/'X'; awaiting first hex digit
+    //  - HEX_DIGITS: textBuffer holds sign + '0x'/'0X' + at least one hex digit; awaiting more
+    protected final static int MINOR_NUMBER_HEX_PREFIX = 34;
+    protected final static int MINOR_NUMBER_HEX_DIGITS = 35;
+
     protected final static int MINOR_VALUE_STRING = 40;
     protected final static int MINOR_VALUE_STRING_ESCAPE = 41;
     protected final static int MINOR_VALUE_STRING_UTF8_2 = 42;

--- a/src/main/java/tools/jackson/core/json/async/NonBlockingUtf8JsonParserBase.java
+++ b/src/main/java/tools/jackson/core/json/async/NonBlockingUtf8JsonParserBase.java
@@ -1784,6 +1784,10 @@ public abstract class NonBlockingUtf8JsonParserBase
             }
             ++_inputPtr;
             if (outPtr >= outBuf.length) {
+                // Validate accumulated digit length at every segment boundary so
+                // that a pathological hex literal (e.g. millions of digits) is
+                // rejected early rather than after full buffering.
+                _streamReadConstraints.validateIntegerLength(outPtr - prefixLen);
                 outBuf = _textBuffer.expandCurrentSegment();
             }
             outBuf[outPtr++] = (char) ch;

--- a/src/main/java/tools/jackson/core/json/async/NonBlockingUtf8JsonParserBase.java
+++ b/src/main/java/tools/jackson/core/json/async/NonBlockingUtf8JsonParserBase.java
@@ -1530,8 +1530,8 @@ public abstract class NonBlockingUtf8JsonParserBase
             }
             // [core#707] JSON5 hexadecimal literal?
             if (ch == 'x' || ch == 'X') {
-                _checkHexNumbersAllowed(ch);
                 _inputPtr = ptr; // consume the 'x'/'X'
+                _checkHexNumbersAllowed(ch);
                 return _startHexNumber(false, (char) ch);
             }
             // Ok; unfortunately we have closing bracket/curly that are valid so need

--- a/src/main/java/tools/jackson/core/json/async/NonBlockingUtf8JsonParserBase.java
+++ b/src/main/java/tools/jackson/core/json/async/NonBlockingUtf8JsonParserBase.java
@@ -256,6 +256,12 @@ public abstract class NonBlockingUtf8JsonParserBase
         case MINOR_NUMBER_EXPONENT_DIGITS:
             return _finishFloatExponent(false, getNextUnsignedByteFromBuffer());
 
+        // [core#707] JSON5 hex resumption
+        case MINOR_NUMBER_HEX_PREFIX:
+            return _finishHexDigits(true);
+        case MINOR_NUMBER_HEX_DIGITS:
+            return _finishHexDigits(false);
+
         case MINOR_VALUE_STRING:
             return _finishRegularString();
         case MINOR_VALUE_STRING_UTF8_2:
@@ -385,6 +391,14 @@ public abstract class NonBlockingUtf8JsonParserBase
 
         case MINOR_NUMBER_EXPONENT_MARKER:
             _reportInvalidEOF(": was expecting fraction after exponent marker", JsonToken.VALUE_NUMBER_FLOAT);
+
+        // [core#707] JSON5 hex EOF handling
+        case MINOR_NUMBER_HEX_PREFIX:
+            _reportInvalidEOF(": expected at least one hexadecimal digit after '0x'/'0X' prefix",
+                    JsonToken.VALUE_NUMBER_INT);
+        case MINOR_NUMBER_HEX_DIGITS:
+            // Suspended with at least one hex digit accumulated; finalize.
+            return _completeHexNumber();
 
             // How about comments?
             // Inside C-comments; not legal
@@ -1514,6 +1528,12 @@ public abstract class NonBlockingUtf8JsonParserBase
                 outBuf[0] = '0';
                 return _startFloat(outBuf, 1, ch);
             }
+            // [core#707] JSON5 hexadecimal literal?
+            if ((ch == 'x' || ch == 'X')
+                    && isEnabled(JsonReadFeature.ALLOW_HEXADECIMAL_NUMBERS)) {
+                _inputPtr = ptr; // consume the 'x'/'X'
+                return _startHexNumber(false, (char) ch);
+            }
             // Ok; unfortunately we have closing bracket/curly that are valid so need
             // (colon not possible since this is within value, not after key)
             //
@@ -1611,6 +1631,11 @@ public abstract class NonBlockingUtf8JsonParserBase
                     _intLength = 1;
                     return _startFloat(outBuf, 1, ch);
                 }
+                // [core#707] JSON5 hexadecimal literal?
+                if ((ch == 'x' || ch == 'X')
+                        && isEnabled(JsonReadFeature.ALLOW_HEXADECIMAL_NUMBERS)) {
+                    return _startHexNumber(false, (char) ch);
+                }
                 // Ok; unfortunately we have closing bracket/curly that are valid so need
                 // (colon not possible since this is within value, not after key)
                 //
@@ -1674,6 +1699,11 @@ public abstract class NonBlockingUtf8JsonParserBase
                     _intLength = 1;
                     return _startFloat(outBuf, 2, ch);
                 }
+                // [core#707] JSON5 hexadecimal literal?
+                if ((ch == 'x' || ch == 'X')
+                        && isEnabled(JsonReadFeature.ALLOW_HEXADECIMAL_NUMBERS)) {
+                    return _startHexNumberWithSign(negative, (char) ch);
+                }
                 // Ok; unfortunately we have closing bracket/curly that are valid so need
                 // (colon not possible since this is within value, not after key)
                 //
@@ -1700,6 +1730,92 @@ public abstract class NonBlockingUtf8JsonParserBase
             --_inputPtr;
             return _valueCompleteInt(0, "0");
         }
+    }
+
+    // [core#707] JSON5 hex helpers - start collecting digits after detecting
+    // the '0x'/'0X' prefix. Two entry points differ only by whether a sign char
+    // ('-' / '+') needs to be prepended to the buffered literal.
+    //
+    // @since 3.2
+    protected JsonToken _startHexNumber(boolean negative, char prefixChar) throws JacksonException {
+        _numberNegative = negative;
+        char[] outBuf = _textBuffer.emptyAndGetCurrentSegment();
+        int outPtr = 0;
+        if (negative) {
+            outBuf[outPtr++] = '-';
+        }
+        outBuf[outPtr++] = '0';
+        outBuf[outPtr++] = prefixChar;
+        _textBuffer.setCurrentLength(outPtr);
+        return _finishHexDigits(true);
+    }
+
+    protected JsonToken _startHexNumberWithSign(boolean negative, char prefixChar) throws JacksonException {
+        _numberNegative = negative;
+        char[] outBuf = _textBuffer.emptyAndGetCurrentSegment();
+        outBuf[0] = negative ? '-' : '+';
+        outBuf[1] = '0';
+        outBuf[2] = prefixChar;
+        _textBuffer.setCurrentLength(3);
+        return _finishHexDigits(true);
+    }
+
+    protected JsonToken _finishHexDigits(boolean requireFirst) throws JacksonException {
+        char[] outBuf = _textBuffer.getBufferWithoutReset();
+        int outPtr = _textBuffer.getCurrentSegmentSize();
+        // Sign-prefixed buffers carry '+'/'-' at index 0, so prefix length is 3;
+        // otherwise it is 2 ("0x"/"0X").
+        final boolean hasSignChar = (outBuf[0] == '-' || outBuf[0] == '+');
+        final int prefixLen = hasSignChar ? 3 : 2;
+
+        while (true) {
+            if (_inputPtr >= _inputEnd) {
+                _minorState = requireFirst ? MINOR_NUMBER_HEX_PREFIX : MINOR_NUMBER_HEX_DIGITS;
+                _textBuffer.setCurrentLength(outPtr);
+                return _updateTokenToNA();
+            }
+            int ch = getByteFromBuffer(_inputPtr) & 0xFF;
+            if (!_isHexDigit(ch)) {
+                if (requireFirst) {
+                    _reportUnexpectedNumberChar(ch,
+                            "Hexadecimal number prefix '0" + outBuf[prefixLen - 1]
+                            + "' must be followed by at least one hex digit (0-9, a-f, A-F)");
+                }
+                break;
+            }
+            ++_inputPtr;
+            if (outPtr >= outBuf.length) {
+                outBuf = _textBuffer.expandCurrentSegment();
+            }
+            outBuf[outPtr++] = (char) ch;
+            requireFirst = false;
+        }
+        _textBuffer.setCurrentLength(outPtr);
+        final int hexLen = outPtr - prefixLen;
+        // As per #105, need separating space between root values; check here.
+        // Note: _inputPtr currently points AT the terminator (we did not consume it).
+        if (_streamReadContext.inRoot()) {
+            _verifyRootSpace(getByteFromBuffer(_inputPtr) & 0xFF);
+        }
+        resetIntHex(_numberNegative, hexLen);
+        return _valueComplete(JsonToken.VALUE_NUMBER_INT);
+    }
+
+    // Called from _finishTokenWithEOF when input ends while collecting hex digits.
+    private JsonToken _completeHexNumber() throws JacksonException {
+        char[] outBuf = _textBuffer.getBufferWithoutReset();
+        int outPtr = _textBuffer.getCurrentSegmentSize();
+        final boolean hasSignChar = (outBuf[0] == '-' || outBuf[0] == '+');
+        final int prefixLen = hasSignChar ? 3 : 2;
+        final int hexLen = outPtr - prefixLen;
+        resetIntHex(_numberNegative, hexLen);
+        return _valueComplete(JsonToken.VALUE_NUMBER_INT);
+    }
+
+    private static boolean _isHexDigit(int c) {
+        return (c >= INT_0 && c <= INT_9)
+                || (c >= 'a' && c <= 'f')
+                || (c >= 'A' && c <= 'F');
     }
 
     protected JsonToken _finishNumberIntegralPart(char[] outBuf, int outPtr) throws JacksonException {

--- a/src/main/java/tools/jackson/core/json/async/NonBlockingUtf8JsonParserBase.java
+++ b/src/main/java/tools/jackson/core/json/async/NonBlockingUtf8JsonParserBase.java
@@ -1777,7 +1777,7 @@ public abstract class NonBlockingUtf8JsonParserBase
             int ch = getByteFromBuffer(_inputPtr) & 0xFF;
             if (CharTypes.charToHex(ch) < 0) {
                 if (requireFirst) {
-                    _reportUnexpectedNumberChar(ch,
+                    return _reportUnexpectedNumberChar(ch,
                             _hexPrefixNotFollowedMessage(outBuf[prefixLen - 1]));
                 }
                 break;

--- a/src/main/java/tools/jackson/core/json/async/NonBlockingUtf8JsonParserBase.java
+++ b/src/main/java/tools/jackson/core/json/async/NonBlockingUtf8JsonParserBase.java
@@ -1778,8 +1778,7 @@ public abstract class NonBlockingUtf8JsonParserBase
             if (!_isHexDigit(ch)) {
                 if (requireFirst) {
                     _reportUnexpectedNumberChar(ch,
-                            "Hexadecimal number prefix '0" + outBuf[prefixLen - 1]
-                            + "' must be followed by at least one hex digit (0-9, a-f, A-F)");
+                            _hexPrefixNotFollowedMessage(outBuf[prefixLen - 1]));
                 }
                 break;
             }
@@ -1810,12 +1809,6 @@ public abstract class NonBlockingUtf8JsonParserBase
         final int hexLen = outPtr - prefixLen;
         resetIntHex(_numberNegative, hexLen);
         return _valueComplete(JsonToken.VALUE_NUMBER_INT);
-    }
-
-    private static boolean _isHexDigit(int c) {
-        return (c >= INT_0 && c <= INT_9)
-                || (c >= 'a' && c <= 'f')
-                || (c >= 'A' && c <= 'F');
     }
 
     protected JsonToken _finishNumberIntegralPart(char[] outBuf, int outPtr) throws JacksonException {

--- a/src/main/java/tools/jackson/core/json/async/NonBlockingUtf8JsonParserBase.java
+++ b/src/main/java/tools/jackson/core/json/async/NonBlockingUtf8JsonParserBase.java
@@ -1775,7 +1775,7 @@ public abstract class NonBlockingUtf8JsonParserBase
                 return _updateTokenToNA();
             }
             int ch = getByteFromBuffer(_inputPtr) & 0xFF;
-            if (!_isHexDigit(ch)) {
+            if (CharTypes.charToHex(ch) < 0) {
                 if (requireFirst) {
                     _reportUnexpectedNumberChar(ch,
                             _hexPrefixNotFollowedMessage(outBuf[prefixLen - 1]));

--- a/src/main/java/tools/jackson/core/json/async/NonBlockingUtf8JsonParserBase.java
+++ b/src/main/java/tools/jackson/core/json/async/NonBlockingUtf8JsonParserBase.java
@@ -1529,8 +1529,8 @@ public abstract class NonBlockingUtf8JsonParserBase
                 return _startFloat(outBuf, 1, ch);
             }
             // [core#707] JSON5 hexadecimal literal?
-            if ((ch == 'x' || ch == 'X')
-                    && isEnabled(JsonReadFeature.ALLOW_HEXADECIMAL_NUMBERS)) {
+            if (ch == 'x' || ch == 'X') {
+                _checkHexNumbersAllowed(ch);
                 _inputPtr = ptr; // consume the 'x'/'X'
                 return _startHexNumber(false, (char) ch);
             }
@@ -1632,8 +1632,8 @@ public abstract class NonBlockingUtf8JsonParserBase
                     return _startFloat(outBuf, 1, ch);
                 }
                 // [core#707] JSON5 hexadecimal literal?
-                if ((ch == 'x' || ch == 'X')
-                        && isEnabled(JsonReadFeature.ALLOW_HEXADECIMAL_NUMBERS)) {
+                if (ch == 'x' || ch == 'X') {
+                    _checkHexNumbersAllowed(ch);
                     return _startHexNumber(false, (char) ch);
                 }
                 // Ok; unfortunately we have closing bracket/curly that are valid so need
@@ -1700,8 +1700,8 @@ public abstract class NonBlockingUtf8JsonParserBase
                     return _startFloat(outBuf, 2, ch);
                 }
                 // [core#707] JSON5 hexadecimal literal?
-                if ((ch == 'x' || ch == 'X')
-                        && isEnabled(JsonReadFeature.ALLOW_HEXADECIMAL_NUMBERS)) {
+                if (ch == 'x' || ch == 'X') {
+                    _checkHexNumbersAllowed(ch);
                     return _startHexNumberWithSign(negative, (char) ch);
                 }
                 // Ok; unfortunately we have closing bracket/curly that are valid so need

--- a/src/test/java/tools/jackson/core/unittest/io/BigIntegerParserTest.java
+++ b/src/test/java/tools/jackson/core/unittest/io/BigIntegerParserTest.java
@@ -1,10 +1,13 @@
 package tools.jackson.core.unittest.io;
 
+import java.math.BigInteger;
+
 import org.junit.jupiter.api.Test;
 
 import tools.jackson.core.io.BigIntegerParser;
 import tools.jackson.core.unittest.JacksonCoreTestBase;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -37,6 +40,29 @@ class BigIntegerParserTest extends JacksonCoreTestBase {
     void longStringFastParseBigIntegerRadix() {
         try {
             BigIntegerParser.parseWithFastParser(genLongString(), 8);
+            fail("expected NumberFormatException");
+        } catch (NumberFormatException nfe) {
+            assertTrue(nfe.getMessage().startsWith("Value \"AAAAA"), "exception message starts as expected?");
+            assertTrue(nfe.getMessage().contains("truncated"), "exception message value contains: truncated");
+            assertTrue(nfe.getMessage().contains("radix 8"), "exception message value contains: radix 8");
+            assertTrue(nfe.getMessage().contains("BigInteger"), "exception message value contains: BigInteger");
+        }
+    }
+
+    @Test
+    void fastParseBigIntegerCharArrayHexSlice() {
+        // Decode 0xDEADBEEFCAFEBABE0123 from within a larger buffer to verify
+        // that offset/length are honored and no intermediate String is required.
+        char[] buf = ("xx" + "DEADBEEFCAFEBABE0123" + "yy").toCharArray();
+        BigInteger actual = BigIntegerParser.parseWithFastParser(buf, 2, 20, 16);
+        assertEquals(new BigInteger("DEADBEEFCAFEBABE0123", 16), actual);
+    }
+
+    @Test
+    void longCharArrayFastParseBigIntegerRadix() {
+        char[] buf = genLongString().toCharArray();
+        try {
+            BigIntegerParser.parseWithFastParser(buf, 0, buf.length, 8);
             fail("expected NumberFormatException");
         } catch (NumberFormatException nfe) {
             assertTrue(nfe.getMessage().startsWith("Value \"AAAAA"), "exception message starts as expected?");

--- a/src/test/java/tools/jackson/core/unittest/io/NumberInputTest.java
+++ b/src/test/java/tools/jackson/core/unittest/io/NumberInputTest.java
@@ -65,6 +65,17 @@ class NumberInputTest
     }
 
     @Test
+    void bigIntegerWithRadixFromCharArray()
+    {
+        // Embed the digits inside a larger buffer so offset/length are exercised.
+        char[] buf = ("xx" + "1ABCDEF" + "yy").toCharArray();
+        final int radix = 16;
+        BigInteger expected = new BigInteger("1ABCDEF", radix);
+        assertEquals(expected, NumberInput.parseBigIntegerWithRadix(buf, 2, 7, radix, true));
+        assertEquals(expected, NumberInput.parseBigIntegerWithRadix(buf, 2, 7, radix, false));
+    }
+
+    @Test
     void parseBigIntegerFailsWithENotation()
     {
         try {

--- a/src/test/java/tools/jackson/core/unittest/io/NumberInputTest.java
+++ b/src/test/java/tools/jackson/core/unittest/io/NumberInputTest.java
@@ -109,6 +109,17 @@ class NumberInputTest
     }
 
     @Test
+    void bigIntegerWithRadixFromCharArrayInvalid()
+    {
+        // Non-hex characters -> NFE on both paths.
+        char[] bad = "GHIJ".toCharArray();
+        assertThrows(NumberFormatException.class,
+                () -> NumberInput.parseBigIntegerWithRadix(bad, 0, bad.length, 16, true));
+        assertThrows(NumberFormatException.class,
+                () -> NumberInput.parseBigIntegerWithRadix(bad, 0, bad.length, 16, false));
+    }
+
+    @Test
     void parseBigIntegerFailsWithENotation()
     {
         try {

--- a/src/test/java/tools/jackson/core/unittest/io/NumberInputTest.java
+++ b/src/test/java/tools/jackson/core/unittest/io/NumberInputTest.java
@@ -67,12 +67,45 @@ class NumberInputTest
     @Test
     void bigIntegerWithRadixFromCharArray()
     {
-        // Embed the digits inside a larger buffer so offset/length are exercised.
-        char[] buf = ("xx" + "1ABCDEF" + "yy").toCharArray();
         final int radix = 16;
-        BigInteger expected = new BigInteger("1ABCDEF", radix);
-        assertEquals(expected, NumberInput.parseBigIntegerWithRadix(buf, 2, 7, radix, true));
-        assertEquals(expected, NumberInput.parseBigIntegerWithRadix(buf, 2, 7, radix, false));
+        final BigInteger expected = new BigInteger("1ABCDEF", radix);
+
+        // 1) offset=0, length spans the entire array.
+        char[] exact = "1ABCDEF".toCharArray();
+        assertEquals(expected, NumberInput.parseBigIntegerWithRadix(exact, 0, exact.length, radix, true));
+        assertEquals(expected, NumberInput.parseBigIntegerWithRadix(exact, 0, exact.length, radix, false));
+
+        // 2) offset=0, length deliberately shorter than the array (ignore trailing chars).
+        char[] trailing = "1ABCDEFzz".toCharArray();
+        assertEquals(expected, NumberInput.parseBigIntegerWithRadix(trailing, 0, 7, radix, true));
+        assertEquals(expected, NumberInput.parseBigIntegerWithRadix(trailing, 0, 7, radix, false));
+
+        // 3) offset>0, length skips both leading and trailing chars.
+        char[] padded = ("xx" + "1ABCDEF" + "yy").toCharArray();
+        assertEquals(expected, NumberInput.parseBigIntegerWithRadix(padded, 2, 7, radix, true));
+        assertEquals(expected, NumberInput.parseBigIntegerWithRadix(padded, 2, 7, radix, false));
+    }
+
+    @Test
+    void bigIntegerWithRadixFromCharArrayNegative()
+    {
+        final int radix = 16;
+        final BigInteger expected = new BigInteger("-1ABCDEF", radix);
+
+        // offset=0, full array.
+        char[] exact = "-1ABCDEF".toCharArray();
+        assertEquals(expected, NumberInput.parseBigIntegerWithRadix(exact, 0, exact.length, radix, true));
+        assertEquals(expected, NumberInput.parseBigIntegerWithRadix(exact, 0, exact.length, radix, false));
+
+        // offset=0, length truncates trailing chars.
+        char[] trailing = "-1ABCDEFzz".toCharArray();
+        assertEquals(expected, NumberInput.parseBigIntegerWithRadix(trailing, 0, 8, radix, true));
+        assertEquals(expected, NumberInput.parseBigIntegerWithRadix(trailing, 0, 8, radix, false));
+
+        // offset>0, slice in the middle of a larger buffer.
+        char[] padded = ("xx" + "-1ABCDEF" + "yy").toCharArray();
+        assertEquals(expected, NumberInput.parseBigIntegerWithRadix(padded, 2, 8, radix, true));
+        assertEquals(expected, NumberInput.parseBigIntegerWithRadix(padded, 2, 8, radix, false));
     }
 
     @Test

--- a/src/test/java/tools/jackson/core/unittest/json/async/AsyncHexNumbers707Test.java
+++ b/src/test/java/tools/jackson/core/unittest/json/async/AsyncHexNumbers707Test.java
@@ -102,7 +102,9 @@ class AsyncHexNumbers707Test extends AsyncTestBase
             r.nextToken();
             fail("Should not pass when ALLOW_HEXADECIMAL_NUMBERS is disabled");
         } catch (StreamReadException e) {
-            verifyException(e, "expected digit (0-9), decimal point (.) or exponent indicator");
+            // Error now names the feature that must be enabled (see _checkHexNumbersAllowed).
+            verifyException(e, "Unexpected character ('x'");
+            verifyException(e, "ALLOW_HEXADECIMAL_NUMBERS");
         }
     }
 

--- a/src/test/java/tools/jackson/core/unittest/json/async/AsyncHexNumbers707Test.java
+++ b/src/test/java/tools/jackson/core/unittest/json/async/AsyncHexNumbers707Test.java
@@ -1,0 +1,135 @@
+package tools.jackson.core.unittest.json.async;
+
+import java.math.BigInteger;
+
+import org.junit.jupiter.api.Test;
+
+import tools.jackson.core.JsonToken;
+import tools.jackson.core.exc.StreamReadException;
+import tools.jackson.core.json.JsonFactory;
+import tools.jackson.core.json.JsonReadFeature;
+import tools.jackson.core.unittest.async.AsyncTestBase;
+import tools.jackson.core.unittest.testutil.AsyncReaderWrapper;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for [core#707]: JSON5-style hexadecimal integer literals via the
+ * non-blocking (async) UTF-8 parser. Exercises the {@code 1}-byte and
+ * {@code 3}-byte feed sizes to drive suspension at every position.
+ */
+class AsyncHexNumbers707Test extends AsyncTestBase
+{
+    private final JsonFactory HEX_F = JsonFactory.builder()
+            .enable(JsonReadFeature.ALLOW_HEXADECIMAL_NUMBERS)
+            .build();
+
+    private final JsonFactory HEX_AND_PLUS_F = JsonFactory.builder()
+            .enable(JsonReadFeature.ALLOW_HEXADECIMAL_NUMBERS)
+            .enable(JsonReadFeature.ALLOW_LEADING_PLUS_SIGN_FOR_NUMBERS)
+            .build();
+
+    @Test
+    void unsignedHexFullBuffer() throws Exception {
+        _expectInt(HEX_F, "0xc0ffee", "0xc0ffee", 0xC0FFEE, 1000);
+    }
+
+    @Test
+    void unsignedHexOneBytePerRead() throws Exception {
+        // Forces suspension after every single byte
+        _expectInt(HEX_F, "0xc0ffee", "0xc0ffee", 0xC0FFEE, 1);
+    }
+
+    @Test
+    void uppercaseHexOneBytePerRead() throws Exception {
+        _expectInt(HEX_F, "0XCAFE", "0XCAFE", 0xCAFE, 1);
+    }
+
+    @Test
+    void negativeHexOneBytePerRead() throws Exception {
+        _expectInt(HEX_F, "-0x10", "-0x10", -16, 1);
+    }
+
+    @Test
+    void positiveHexWithPlusSignAndSplit() throws Exception {
+        _expectInt(HEX_AND_PLUS_F, "+0xff", "+0xff", 0xFF, 1);
+    }
+
+    @Test
+    void plainZeroStillWorks() throws Exception {
+        // Make sure we didn't break the bare "0" path
+        try (AsyncReaderWrapper r = asyncForBytes(HEX_F, 1, _jsonDoc(" 0 "), 1)) {
+            assertToken(JsonToken.VALUE_NUMBER_INT, r.nextToken());
+            assertEquals(0, r.getIntValue());
+        }
+    }
+
+    @Test
+    void hexInsideArray() throws Exception {
+        for (int readSize : new int[] {1, 3, 1000}) {
+            try (AsyncReaderWrapper r = asyncForBytes(HEX_F, readSize,
+                    _jsonDoc("[0x1, 0xFF, -0x10]"), 1)) {
+                assertToken(JsonToken.START_ARRAY, r.nextToken());
+                assertToken(JsonToken.VALUE_NUMBER_INT, r.nextToken());
+                assertEquals(1, r.getIntValue());
+                assertToken(JsonToken.VALUE_NUMBER_INT, r.nextToken());
+                assertEquals(255, r.getIntValue());
+                assertToken(JsonToken.VALUE_NUMBER_INT, r.nextToken());
+                assertEquals(-16, r.getIntValue());
+                assertToken(JsonToken.END_ARRAY, r.nextToken());
+            }
+        }
+    }
+
+    @Test
+    void hexBigIntegerRange() throws Exception {
+        final String literal = "0x1ffffffffffffffff";
+        final BigInteger expected = new BigInteger("1ffffffffffffffff", 16);
+        for (int readSize : new int[] {1, 5, 1000}) {
+            try (AsyncReaderWrapper r = asyncForBytes(HEX_F, readSize,
+                    _jsonDoc(" " + literal + " "), 1)) {
+                assertToken(JsonToken.VALUE_NUMBER_INT, r.nextToken());
+                assertEquals(literal, r.currentText());
+                assertEquals(expected, r.getBigIntegerValue());
+            }
+        }
+    }
+
+    @Test
+    void hexRejectedWhenFeatureDisabled() throws Exception {
+        JsonFactory plain = new JsonFactory();
+        try (AsyncReaderWrapper r = asyncForBytes(plain, 1, _jsonDoc(" 0xff "), 1)) {
+            r.nextToken();
+            fail("Should not pass when ALLOW_HEXADECIMAL_NUMBERS is disabled");
+        } catch (StreamReadException e) {
+            verifyException(e, "expected digit (0-9), decimal point (.) or exponent indicator");
+        }
+    }
+
+    @Test
+    void hexPrefixWithoutDigitsFails() throws Exception {
+        try (AsyncReaderWrapper r = asyncForBytes(HEX_F, 1, _jsonDoc(" 0x "), 1)) {
+            r.nextToken();
+            fail("Should not pass: prefix without any hex digit");
+        } catch (StreamReadException e) {
+            verifyException(e, "hex digit");
+        }
+    }
+
+    private void _expectInt(JsonFactory factory, String literal, String expectedText,
+            long expectedValue, int readSize) throws Exception
+    {
+        String input = " " + literal + " ";
+        try (AsyncReaderWrapper r = asyncForBytes(factory, readSize, _jsonDoc(input), 1)) {
+            assertToken(JsonToken.VALUE_NUMBER_INT, r.nextToken());
+            assertEquals(expectedText, r.currentText(),
+                    "currentText() literal mismatch for " + literal + " (readSize " + readSize + ")");
+            assertEquals(expectedValue, r.getLongValue(),
+                    "long value mismatch for " + literal + " (readSize " + readSize + ")");
+            if (expectedValue >= Integer.MIN_VALUE && expectedValue <= Integer.MAX_VALUE) {
+                assertEquals((int) expectedValue, r.getIntValue(),
+                        "int value mismatch for " + literal + " (readSize " + readSize + ")");
+            }
+        }
+    }
+}

--- a/src/test/java/tools/jackson/core/unittest/json/async/AsyncHexNumbers707Test.java
+++ b/src/test/java/tools/jackson/core/unittest/json/async/AsyncHexNumbers707Test.java
@@ -96,6 +96,52 @@ class AsyncHexNumbers707Test extends AsyncTestBase
     }
 
     @Test
+    void hexNegativeBigIntegerRange() throws Exception {
+        // 17 hex digits with sign -> must promote to (negative) BigInteger via async resumption
+        final String literal = "-0x1ffffffffffffffff";
+        final BigInteger expected = new BigInteger("-1ffffffffffffffff", 16);
+        for (int readSize : new int[] {1, 5, 1000}) {
+            try (AsyncReaderWrapper r = asyncForBytes(HEX_F, readSize,
+                    _jsonDoc(" " + literal + " "), 1)) {
+                assertToken(JsonToken.VALUE_NUMBER_INT, r.nextToken());
+                assertEquals(literal, r.currentText());
+                assertEquals(expected, r.getBigIntegerValue());
+            }
+        }
+    }
+
+    @Test
+    void hex16DigitsLongMax() throws Exception {
+        // 16 digits, top nibble == 7 -> stays on the long fast path (Long.MAX_VALUE).
+        // Boundary case in _parseHexInt: hexLen == 16 && topNibble < 0x8.
+        final String literal = "0x7fffffffffffffff";
+        for (int readSize : new int[] {1, 5, 1000}) {
+            try (AsyncReaderWrapper r = asyncForBytes(HEX_F, readSize,
+                    _jsonDoc(" " + literal + " "), 1)) {
+                assertToken(JsonToken.VALUE_NUMBER_INT, r.nextToken());
+                assertEquals(literal, r.currentText());
+                assertEquals(Long.MAX_VALUE, r.getLongValue());
+            }
+        }
+    }
+
+    @Test
+    void hex16DigitsOverflowsToBigInteger() throws Exception {
+        // 16 digits, top nibble == 8 -> falls off the long fast path into the
+        // BigInteger arm of _parseHexInt (value is 2^63, just past Long.MAX_VALUE).
+        final String literal = "0x8000000000000000";
+        final BigInteger expected = BigInteger.ONE.shiftLeft(63);
+        for (int readSize : new int[] {1, 5, 1000}) {
+            try (AsyncReaderWrapper r = asyncForBytes(HEX_F, readSize,
+                    _jsonDoc(" " + literal + " "), 1)) {
+                assertToken(JsonToken.VALUE_NUMBER_INT, r.nextToken());
+                assertEquals(literal, r.currentText());
+                assertEquals(expected, r.getBigIntegerValue());
+            }
+        }
+    }
+
+    @Test
     void hexRejectedWhenFeatureDisabled() throws Exception {
         JsonFactory plain = new JsonFactory();
         try (AsyncReaderWrapper r = asyncForBytes(plain, 1, _jsonDoc(" 0xff "), 1)) {

--- a/src/test/java/tools/jackson/core/unittest/read/NonStandardHexNumbers707Test.java
+++ b/src/test/java/tools/jackson/core/unittest/read/NonStandardHexNumbers707Test.java
@@ -117,7 +117,8 @@ class NonStandardHexNumbers707Test extends JacksonCoreTestBase
 
     @Test
     void hexRejectedWhenFeatureDisabled() throws Exception {
-        // With the feature OFF, 0x... must still fail like in vanilla JSON
+        // With the feature OFF, 0x... must still fail like in vanilla JSON,
+        // and the error message must point at the feature to enable.
         JsonFactory plainF = new JsonFactory();
         for (int mode : ALL_MODES) {
             try (JsonParser p = createParser(plainF, mode, " 0xc0ffee ")) {
@@ -125,6 +126,7 @@ class NonStandardHexNumbers707Test extends JacksonCoreTestBase
                 fail("Should not pass when ALLOW_HEXADECIMAL_NUMBERS is disabled");
             } catch (StreamReadException e) {
                 verifyException(e, "Unexpected character ('x'");
+                verifyException(e, "ALLOW_HEXADECIMAL_NUMBERS");
             }
         }
     }

--- a/src/test/java/tools/jackson/core/unittest/read/NonStandardHexNumbers707Test.java
+++ b/src/test/java/tools/jackson/core/unittest/read/NonStandardHexNumbers707Test.java
@@ -6,6 +6,8 @@ import org.junit.jupiter.api.Test;
 
 import tools.jackson.core.JsonParser;
 import tools.jackson.core.JsonToken;
+import tools.jackson.core.StreamReadConstraints;
+import tools.jackson.core.exc.StreamConstraintsException;
 import tools.jackson.core.exc.StreamReadException;
 import tools.jackson.core.json.JsonFactory;
 import tools.jackson.core.json.JsonReadFeature;
@@ -139,6 +141,30 @@ class NonStandardHexNumbers707Test extends JacksonCoreTestBase
                 fail("Should not pass: prefix without any hex digit");
             } catch (StreamReadException e) {
                 verifyException(e, "hex digit");
+            }
+        }
+    }
+
+    @Test
+    void hexNumberLengthConstraint() throws Exception {
+        // Build a hex literal long enough to cross several TextBuffer segment
+        // boundaries (default first segment is 500 chars; using 8000 digits to
+        // ensure we definitely span at least one boundary on every backend).
+        StringBuilder sb = new StringBuilder("0x");
+        for (int i = 0; i < 8000; i++) {
+            sb.append('f');
+        }
+        final String hugeHex = sb.toString();
+        JsonFactory cappedF = JsonFactory.builder()
+                .enable(JsonReadFeature.ALLOW_HEXADECIMAL_NUMBERS)
+                .streamReadConstraints(StreamReadConstraints.builder().maxNumberLength(100).build())
+                .build();
+        for (int mode : ALL_MODES) {
+            try (JsonParser p = createParser(cappedF, mode, " " + hugeHex + " ")) {
+                p.nextToken();
+                fail("Should not pass: hex literal exceeds maxNumberLength (mode " + mode + ")");
+            } catch (StreamConstraintsException e) {
+                verifyException(e, "exceeds the maximum");
             }
         }
     }

--- a/src/test/java/tools/jackson/core/unittest/read/NonStandardHexNumbers707Test.java
+++ b/src/test/java/tools/jackson/core/unittest/read/NonStandardHexNumbers707Test.java
@@ -1,0 +1,162 @@
+package tools.jackson.core.unittest.read;
+
+import java.math.BigInteger;
+
+import org.junit.jupiter.api.Test;
+
+import tools.jackson.core.JsonParser;
+import tools.jackson.core.JsonToken;
+import tools.jackson.core.exc.StreamReadException;
+import tools.jackson.core.json.JsonFactory;
+import tools.jackson.core.json.JsonReadFeature;
+import tools.jackson.core.unittest.JacksonCoreTestBase;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for [core#707]: JSON5-style hexadecimal integer literals enabled via
+ * {@link JsonReadFeature#ALLOW_HEXADECIMAL_NUMBERS}.
+ */
+class NonStandardHexNumbers707Test extends JacksonCoreTestBase
+{
+    private final JsonFactory HEX_F = JsonFactory.builder()
+            .enable(JsonReadFeature.ALLOW_HEXADECIMAL_NUMBERS)
+            .build();
+
+    private final JsonFactory HEX_AND_PLUS_F = JsonFactory.builder()
+            .enable(JsonReadFeature.ALLOW_HEXADECIMAL_NUMBERS)
+            .enable(JsonReadFeature.ALLOW_LEADING_PLUS_SIGN_FOR_NUMBERS)
+            .build();
+
+    @Test
+    void unsignedHexLowercase() throws Exception {
+        _expectInt(HEX_F, "0xc0ffee", "0xc0ffee", 0xC0FFEE);
+    }
+
+    @Test
+    void unsignedHexUppercaseXAndDigits() throws Exception {
+        _expectInt(HEX_F, "0XC0FFEE", "0XC0FFEE", 0xC0FFEE);
+    }
+
+    @Test
+    void unsignedHexZero() throws Exception {
+        _expectInt(HEX_F, "0x0", "0x0", 0);
+    }
+
+    @Test
+    void unsignedHexWithLeadingZeros() throws Exception {
+        // [core#707]: leading zeros are always permitted in hex digits, regardless
+        // of ALLOW_LEADING_ZEROS_FOR_NUMBERS.
+        _expectInt(HEX_F, "0x007F", "0x007F", 0x7F);
+    }
+
+    @Test
+    void negativeHex() throws Exception {
+        _expectInt(HEX_F, "-0x10", "-0x10", -16);
+    }
+
+    @Test
+    void plusSignHexRequiresLeadingPlusFeature() throws Exception {
+        // Without ALLOW_LEADING_PLUS_SIGN_FOR_NUMBERS, +0xff must still fail
+        for (int mode : ALL_MODES) {
+            try (JsonParser p = createParser(HEX_F, mode, " +0xff ")) {
+                p.nextToken();
+                fail("Should not pass when ALLOW_LEADING_PLUS_SIGN_FOR_NUMBERS is disabled");
+            } catch (StreamReadException e) {
+                verifyException(e, "plus sign");
+            }
+        }
+    }
+
+    @Test
+    void plusSignHexWithPlusFeature() throws Exception {
+        _expectInt(HEX_AND_PLUS_F, "+0xff", "+0xff", 0xFF);
+    }
+
+    @Test
+    void hexLongRange() throws Exception {
+        // Just over Integer.MAX_VALUE (0x7fffffff = 2147483647) -> 0x80000000 = 2147483648L
+        for (int mode : ALL_MODES) {
+            try (JsonParser p = createParser(HEX_F, mode, " 0x80000000 ")) {
+                assertToken(JsonToken.VALUE_NUMBER_INT, p.nextToken());
+                assertEquals("0x80000000", p.getString());
+                assertEquals(2147483648L, p.getLongValue());
+            }
+        }
+    }
+
+    @Test
+    void hexBigIntegerRange() throws Exception {
+        // 17 hex digits -> must promote to BigInteger
+        final String literal = "0x1ffffffffffffffff";
+        final BigInteger expected = new BigInteger("1ffffffffffffffff", 16);
+        for (int mode : ALL_MODES) {
+            try (JsonParser p = createParser(HEX_F, mode, " " + literal + " ")) {
+                assertToken(JsonToken.VALUE_NUMBER_INT, p.nextToken());
+                assertEquals(literal, p.getString());
+                assertEquals(expected, p.getBigIntegerValue());
+            }
+        }
+    }
+
+    @Test
+    void hexInsideArray() throws Exception {
+        for (int mode : ALL_MODES) {
+            try (JsonParser p = createParser(HEX_F, mode, "[0x1, 0x2, -0xA]")) {
+                assertToken(JsonToken.START_ARRAY, p.nextToken());
+                assertToken(JsonToken.VALUE_NUMBER_INT, p.nextToken());
+                assertEquals(1, p.getIntValue());
+                assertToken(JsonToken.VALUE_NUMBER_INT, p.nextToken());
+                assertEquals(2, p.getIntValue());
+                assertToken(JsonToken.VALUE_NUMBER_INT, p.nextToken());
+                assertEquals(-10, p.getIntValue());
+                assertToken(JsonToken.END_ARRAY, p.nextToken());
+            }
+        }
+    }
+
+    @Test
+    void hexRejectedWhenFeatureDisabled() throws Exception {
+        // With the feature OFF, 0x... must still fail like in vanilla JSON
+        JsonFactory plainF = new JsonFactory();
+        for (int mode : ALL_MODES) {
+            try (JsonParser p = createParser(plainF, mode, " 0xc0ffee ")) {
+                p.nextToken();
+                fail("Should not pass when ALLOW_HEXADECIMAL_NUMBERS is disabled");
+            } catch (StreamReadException e) {
+                verifyException(e, "Unexpected character ('x'");
+            }
+        }
+    }
+
+    @Test
+    void hexPrefixWithoutDigitsFails() throws Exception {
+        for (int mode : ALL_MODES) {
+            try (JsonParser p = createParser(HEX_F, mode, " 0x ")) {
+                p.nextToken();
+                fail("Should not pass: prefix without any hex digit");
+            } catch (StreamReadException e) {
+                verifyException(e, "hex digit");
+            }
+        }
+    }
+
+    private void _expectInt(JsonFactory factory, String literal, String expectedText, long expectedValue)
+            throws Exception
+    {
+        String input = " " + literal + " ";
+        for (int mode : ALL_MODES) {
+            try (JsonParser p = createParser(factory, mode, input)) {
+                assertToken(JsonToken.VALUE_NUMBER_INT, p.nextToken());
+                assertEquals(expectedText, p.getString(),
+                        "getString() literal mismatch for " + literal + " (mode " + mode + ")");
+                assertEquals(expectedValue, p.getLongValue(),
+                        "long value mismatch for " + literal + " (mode " + mode + ")");
+                if (expectedValue >= Integer.MIN_VALUE && expectedValue <= Integer.MAX_VALUE) {
+                    assertEquals((int) expectedValue, p.getIntValue(),
+                            "int value mismatch for " + literal + " (mode " + mode + ")");
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implements JSON5 hexadecimal integer literals (`0x` / `0X` prefix, optional sign, `[0-9a-fA-F]+`) across all four JSON parsers, gated behind a new opt-in `JsonReadFeature.ALLOW_HEXADECIMAL_NUMBERS`. Closes #707 (hex part; whitespace remains).

Per @pjfanning's [review](https://github.com/FasterXML/jackson-core/issues/707#issuecomment-4543767243):

- **JSON5 grammar followed verbatim** — `0x|0X` + `[0-9a-fA-F]+`, optional leading sign, no fraction / no exponent / no `_` separators.
- **Independent of `ALLOW_LEADING_ZEROS_FOR_NUMBERS`** — leading zeros within hex digits (e.g. `0x007F`) are always permitted when this feature is enabled, regardless of the leading-zero feature. The hex check fires **before** `_verifyNoLeadingZeroes()` in every parser, and the leading-zero feature is never consulted on the hex path. Covered by `unsignedHexWithLeadingZeros`.

The `+` variant additionally requires `ALLOW_LEADING_PLUS_SIGN_FOR_NUMBERS` (matching how `+` is treated for decimals, per #774). Covered by `plusSignHexRequiresLeadingPlusFeature` and `plusSignHexWithPlusFeature`.

Implementation per parser:

| Parser | Strategy |
| --- | --- |
| `ReaderBasedJsonParser` | Hex branch in `_parseNumber2`, before `_verifyNoLeadingZeroes`. |
| `UTF8StreamJsonParser` | Same pattern, byte-oriented; peek before `_verifyNoLeadingZeroes` in both `_parseUnsignedNumber` and `_parseSignedNumber`. |
| `UTF8DataInputJsonParser` | Intercept the existing `'x'`/`'X'` arm of `_handleLeadingZeroes` (no peek needed — DataInput already consumed it). |
| `NonBlockingUtf8JsonParserBase` | New minor states `MINOR_NUMBER_HEX_PREFIX` and `MINOR_NUMBER_HEX_DIGITS` so suspension works at every byte boundary; helpers `_startHexNumber` / `_startHexNumberWithSign` / `_finishHexDigits` drive the state machine. |

Shared decoding lives in `JsonParserBase._parseHexInt`:
- `int` for ≤ 7 hex digits (always fits in signed 32-bit),
- `long` for ≤ 16 hex digits with a top-nibble check at 16,
- `BigInteger` otherwise — eagerly decoded because the lazy `_numberString` path expects base-10.

`getString()` returns the original literal (sign + `0x`/`0X` + digits), matching the precedent set for `+` by #784. `getIntValue()` / `getLongValue()` / `getBigIntegerValue()` return the decoded value.

The bookkeeping additions on `JsonParserBase` are limited:
- `_numberIsHex` field (cleared by `resetInt` / `resetFloat` / `resetAsNaN`),
- `resetIntHex(neg, hexDigitLen)` helper alongside `resetInt`.

I put these on `JsonParserBase` only (since only JSON consumes it today).

## Test plan

- [x] `mvn clean verify` — 1697 tests, 0 failures, 0 regressions.
- [x] `NonStandardHexNumbers707Test` (12 cases) — unsigned, uppercase `X`, leading zeros, negative, `+` with/without plus-feature, long range (`0x80000000`), BigInteger range (`0x1ffffffffffffffff`), in-array, feature-off rejection, empty-prefix rejection. Runs across `ALL_MODES` (Reader, UTF8 stream, throttled, DataInput).
- [x] `AsyncHexNumbers707Test` (10 cases) — drives the non-blocking parser with 1-byte and 3-byte feeds to exercise suspension/resumption at every position; covers the same shapes plus a `plainZeroStillWorks` smoke test to verify the bare-`0` path didn't regress.
