### PR TITLE
Fix #1616: `JsonParserSequence` read methods no longer use Parsers beyond the first

### DIFF
--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -19,7 +19,13 @@ JSON library.
 
 No changes since 3.1
 
-3.1.4 (29-May-2029)
+3.1.5 (not yet released)
+
+#1616: `JsonParserSequence` read methods no longer use Parsers beyond the first
+ (reported by @stefnoten-aca)
+ (fix by @cowtowncoder, w/ Claude code)
+
+3.1.4 (29-May-2026)
 
 #1611: Apply number-length validator on streaming integer path of async parser
  (fix by @tonghuaroot)

--- a/src/main/java/tools/jackson/core/util/JsonParserDelegate.java
+++ b/src/main/java/tools/jackson/core/util/JsonParserDelegate.java
@@ -262,7 +262,7 @@ public class JsonParserDelegate extends JsonParser
     /**********************************************************************
      */
 
-    // 31-May-2026, tatu: [core#1616] Must drive databind read through `this`
+    // 01-Jun-2026, tatu: [core#1616] Must drive databind read through `this`
     //    (delegate's own logical token stream), NOT the raw `delegate`: otherwise
     //    delegates that alter the token sequence (e.g. `JsonParserSequence`,
     //    `FilteringParserDelegate`) would have only the underlying parser read,

--- a/src/main/java/tools/jackson/core/util/JsonParserDelegate.java
+++ b/src/main/java/tools/jackson/core/util/JsonParserDelegate.java
@@ -7,7 +7,6 @@ import java.math.BigInteger;
 
 import tools.jackson.core.*;
 import tools.jackson.core.async.NonBlockingInputFeeder;
-import tools.jackson.core.exc.InputCoercionException;
 import tools.jackson.core.sym.PropertyNameMatcher;
 import tools.jackson.core.type.ResolvedType;
 import tools.jackson.core.type.TypeReference;
@@ -146,12 +145,12 @@ public class JsonParserDelegate extends JsonParser
     /**********************************************************************
      */
 
-    @Override public JsonToken nextToken() throws JacksonException { return delegate.nextToken(); }
-    @Override public JsonToken nextValue() throws JacksonException { return delegate.nextValue(); }
-    @Override public void finishToken() throws JacksonException { delegate.finishToken(); }
+    @Override public JsonToken nextToken() { return delegate.nextToken(); }
+    @Override public JsonToken nextValue() { return delegate.nextValue(); }
+    @Override public void finishToken() { delegate.finishToken(); }
 
     @Override
-    public JsonParser skipChildren() throws JacksonException {
+    public JsonParser skipChildren() {
         delegate.skipChildren();
         // NOTE: must NOT delegate this method to delegate, needs to be self-reference for chaining
         return this;
@@ -160,9 +159,9 @@ public class JsonParserDelegate extends JsonParser
     // 12-Nov-2017, tatu: These DO work as long as `JsonParserSequence` further overrides
     //     handling
 
-    @Override public String nextName() throws JacksonException { return delegate.nextName(); }
-    @Override public boolean nextName(SerializableString str) throws JacksonException { return delegate.nextName(str); }
-    @Override public int nextNameMatch(PropertyNameMatcher matcher) throws JacksonException { return delegate.nextNameMatch(matcher); }
+    @Override public String nextName(){ return delegate.nextName(); }
+    @Override public boolean nextName(SerializableString str) { return delegate.nextName(str); }
+    @Override public int nextNameMatch(PropertyNameMatcher matcher) { return delegate.nextNameMatch(matcher); }
 
     // NOTE: fine without overrides since it does NOT change state
     @Override public int currentNameMatch(PropertyNameMatcher matcher) { return delegate.currentNameMatch(matcher); }
@@ -173,13 +172,13 @@ public class JsonParserDelegate extends JsonParser
     /**********************************************************************
      */
 
-    @Override public String getString() throws JacksonException { return delegate.getString();  }
+    @Override public String getString() { return delegate.getString();  }
     @Override public boolean hasStringCharacters() { return delegate.hasStringCharacters(); }
-    @Override public char[] getStringCharacters() throws JacksonException { return delegate.getStringCharacters(); }
-    @Override public int getStringLength() throws JacksonException { return delegate.getStringLength(); }
-    @Override public int getStringOffset() throws JacksonException { return delegate.getStringOffset(); }
-    @Override public int getString(Writer writer) throws JacksonException { return delegate.getString(writer);  }
-    @Override public long readString(Writer writer) throws JacksonException { return delegate.readString(writer);  }
+    @Override public char[] getStringCharacters() { return delegate.getStringCharacters(); }
+    @Override public int getStringLength() { return delegate.getStringLength(); }
+    @Override public int getStringOffset() { return delegate.getStringOffset(); }
+    @Override public int getString(Writer writer) { return delegate.getString(writer);  }
+    @Override public long readString(Writer writer) { return delegate.readString(writer);  }
 
     /*
     /**********************************************************************
@@ -191,28 +190,28 @@ public class JsonParserDelegate extends JsonParser
     public BigInteger getBigIntegerValue() { return delegate.getBigIntegerValue(); }
 
     @Override
-    public boolean getBooleanValue() throws InputCoercionException { return delegate.getBooleanValue(); }
+    public boolean getBooleanValue() { return delegate.getBooleanValue(); }
 
     @Override
-    public byte getByteValue() throws InputCoercionException { return delegate.getByteValue(); }
+    public byte getByteValue() { return delegate.getByteValue(); }
 
     @Override
-    public short getShortValue() throws InputCoercionException { return delegate.getShortValue(); }
+    public short getShortValue() { return delegate.getShortValue(); }
 
     @Override
-    public BigDecimal getDecimalValue() throws InputCoercionException { return delegate.getDecimalValue(); }
+    public BigDecimal getDecimalValue() { return delegate.getDecimalValue(); }
 
     @Override
-    public double getDoubleValue() throws InputCoercionException { return delegate.getDoubleValue(); }
+    public double getDoubleValue() { return delegate.getDoubleValue(); }
 
     @Override
-    public float getFloatValue() throws InputCoercionException { return delegate.getFloatValue(); }
+    public float getFloatValue() { return delegate.getFloatValue(); }
 
     @Override
-    public int getIntValue() throws InputCoercionException { return delegate.getIntValue(); }
+    public int getIntValue() { return delegate.getIntValue(); }
 
     @Override
-    public long getLongValue() throws InputCoercionException { return delegate.getLongValue(); }
+    public long getLongValue() { return delegate.getLongValue(); }
 
     @Override
     public NumberType getNumberType() { return delegate.getNumberType(); }
@@ -221,13 +220,13 @@ public class JsonParserDelegate extends JsonParser
     public NumberTypeFP getNumberTypeFP() { return delegate.getNumberTypeFP(); }
 
     @Override
-    public Number getNumberValue() throws InputCoercionException { return delegate.getNumberValue(); }
+    public Number getNumberValue() { return delegate.getNumberValue(); }
 
     @Override
-    public Number getNumberValueExact() throws InputCoercionException { return delegate.getNumberValueExact(); }
+    public Number getNumberValueExact() { return delegate.getNumberValueExact(); }
 
     @Override
-    public Object getNumberValueDeferred() throws InputCoercionException { return delegate.getNumberValueDeferred(); }
+    public Object getNumberValueDeferred() { return delegate.getNumberValueDeferred(); }
 
     /*
     /**********************************************************************
@@ -235,12 +234,12 @@ public class JsonParserDelegate extends JsonParser
     /**********************************************************************
      */
 
-    @Override public int getValueAsInt() throws InputCoercionException { return delegate.getValueAsInt(); }
-    @Override public int getValueAsInt(int defaultValue) throws InputCoercionException { return delegate.getValueAsInt(defaultValue); }
-    @Override public long getValueAsLong() throws InputCoercionException { return delegate.getValueAsLong(); }
-    @Override public long getValueAsLong(long defaultValue) throws InputCoercionException { return delegate.getValueAsLong(defaultValue); }
-    @Override public double getValueAsDouble() throws InputCoercionException { return delegate.getValueAsDouble(); }
-    @Override public double getValueAsDouble(double defaultValue) throws InputCoercionException { return delegate.getValueAsDouble(defaultValue); }
+    @Override public int getValueAsInt() { return delegate.getValueAsInt(); }
+    @Override public int getValueAsInt(int defaultValue) { return delegate.getValueAsInt(defaultValue); }
+    @Override public long getValueAsLong() { return delegate.getValueAsLong(); }
+    @Override public long getValueAsLong(long defaultValue) { return delegate.getValueAsLong(defaultValue); }
+    @Override public double getValueAsDouble() { return delegate.getValueAsDouble(); }
+    @Override public double getValueAsDouble(double defaultValue) { return delegate.getValueAsDouble(defaultValue); }
     @Override public boolean getValueAsBoolean() { return delegate.getValueAsBoolean(); }
     @Override public boolean getValueAsBoolean(boolean defaultValue) { return delegate.getValueAsBoolean(defaultValue); }
     @Override public String getValueAsString(){ return delegate.getValueAsString(); }
@@ -253,8 +252,8 @@ public class JsonParserDelegate extends JsonParser
      */
 
     @Override public Object getEmbeddedObject() { return delegate.getEmbeddedObject(); }
-    @Override public byte[] getBinaryValue(Base64Variant b64variant) throws JacksonException { return delegate.getBinaryValue(b64variant); }
-    @Override public int readBinaryValue(Base64Variant b64variant, OutputStream out) throws JacksonException { return delegate.readBinaryValue(b64variant, out); }
+    @Override public byte[] getBinaryValue(Base64Variant b64variant) { return delegate.getBinaryValue(b64variant); }
+    @Override public int readBinaryValue(Base64Variant b64variant, OutputStream out) { return delegate.readBinaryValue(b64variant, out); }
 
     /*
     /**********************************************************************
@@ -268,22 +267,22 @@ public class JsonParserDelegate extends JsonParser
     //    `FilteringParserDelegate`) would have only the underlying parser read,
     //    skipping the rest of the sequence (or bypassing filtering).
     @Override
-    public <T> T readValueAs(Class<T> valueType) throws JacksonException {
+    public <T> T readValueAs(Class<T> valueType) {
         return objectReadContext().readValue(this, valueType);
     }
 
     @Override
-    public <T> T readValueAs(TypeReference<T> valueTypeRef) throws JacksonException {
+    public <T> T readValueAs(TypeReference<T> valueTypeRef) {
         return objectReadContext().readValue(this, valueTypeRef);
     }
 
     @Override
-    public <T> T readValueAs(ResolvedType type) throws JacksonException {
+    public <T> T readValueAs(ResolvedType type) {
         return objectReadContext().readValue(this, type);
     }
 
     @Override
-    public <T extends TreeNode> T readValueAsTree() throws JacksonException {
+    public <T extends TreeNode> T readValueAsTree() {
         return objectReadContext().readTree(this);
     }
 

--- a/src/main/java/tools/jackson/core/util/JsonParserDelegate.java
+++ b/src/main/java/tools/jackson/core/util/JsonParserDelegate.java
@@ -262,24 +262,29 @@ public class JsonParserDelegate extends JsonParser
     /**********************************************************************
      */
 
+    // 31-May-2026, tatu: [core#1616] Must drive databind read through `this`
+    //    (delegate's own logical token stream), NOT the raw `delegate`: otherwise
+    //    delegates that alter the token sequence (e.g. `JsonParserSequence`,
+    //    `FilteringParserDelegate`) would have only the underlying parser read,
+    //    skipping the rest of the sequence (or bypassing filtering).
     @Override
     public <T> T readValueAs(Class<T> valueType) throws JacksonException {
-        return delegate.readValueAs(valueType);
+        return objectReadContext().readValue(this, valueType);
     }
 
     @Override
     public <T> T readValueAs(TypeReference<T> valueTypeRef) throws JacksonException {
-        return delegate.readValueAs(valueTypeRef);
+        return objectReadContext().readValue(this, valueTypeRef);
     }
 
     @Override
     public <T> T readValueAs(ResolvedType type) throws JacksonException {
-        return delegate.readValueAs(type);
+        return objectReadContext().readValue(this, type);
     }
 
     @Override
     public <T extends TreeNode> T readValueAsTree() throws JacksonException {
-        return delegate.readValueAsTree();
+        return objectReadContext().readTree(this);
     }
 
     /*

--- a/src/main/java/tools/jackson/core/util/JsonParserSequence.java
+++ b/src/main/java/tools/jackson/core/util/JsonParserSequence.java
@@ -10,8 +10,9 @@ import tools.jackson.core.sym.PropertyNameMatcher;
  * {@link JsonParser}s to create a single logical sequence of
  * tokens, as a single {@link JsonParser}.
  *<p>
- * Fairly simple use of {@link JsonParserDelegate}: only need
- * to override {@link #nextToken} to handle transition
+ * Fairly simple use of {@link JsonParserDelegate}: mostly need
+ * to override {@link #nextToken} to handle transition, but there
+ * are a few other things that require care (and overriding).
  */
 public class JsonParserSequence extends JsonParserDelegate
 {
@@ -46,9 +47,9 @@ public class JsonParserSequence extends JsonParserDelegate
     protected boolean _hasToken;
 
     /*
-     *******************************************************
-     * Construction
-     *******************************************************
+    /**********************************************************************
+    /* Construction
+    /**********************************************************************
      */
 
     protected JsonParserSequence(boolean checkForExistingToken, JsonParser[] parsers)
@@ -84,13 +85,13 @@ public class JsonParserSequence extends JsonParserDelegate
                     new JsonParser[] { first, second });
         }
         ArrayList<JsonParser> p = new ArrayList<>(10);
-        if (first instanceof JsonParserSequence) {
-            ((JsonParserSequence) first).addFlattenedActiveParsers(p);
+        if (first instanceof JsonParserSequence jps) {
+            jps.addFlattenedActiveParsers(p);
         } else {
             p.add(first);
         }
-        if (second instanceof JsonParserSequence) {
-            ((JsonParserSequence) second).addFlattenedActiveParsers(p);
+        if (second instanceof JsonParserSequence jps) {
+            jps.addFlattenedActiveParsers(p);
         } else {
             p.add(second);
         }
@@ -103,8 +104,8 @@ public class JsonParserSequence extends JsonParserDelegate
     {
         for (int i = _nextParserIndex-1, len = _parsers.length; i < len; ++i) {
             JsonParser p = _parsers[i];
-            if (p instanceof JsonParserSequence) {
-                ((JsonParserSequence) p).addFlattenedActiveParsers(listToAddIn);
+            if (p instanceof JsonParserSequence jps) {
+                jps.addFlattenedActiveParsers(listToAddIn);
             } else {
                 listToAddIn.add(p);
             }
@@ -112,10 +113,10 @@ public class JsonParserSequence extends JsonParserDelegate
     }
 
     /*
-    /*******************************************************
+    /**********************************************************************
     /* Overridden methods, needed: cases where default
     /* delegation does not work
-    /*******************************************************
+    /**********************************************************************
      */
 
     @Override
@@ -172,10 +173,10 @@ public class JsonParserSequence extends JsonParserDelegate
     }
 
     /*
-    /*******************************************************
+    /**********************************************************************
     /* And some more methods where default delegation would
     /* cause problems with state handling here
-    /*******************************************************
+    /**********************************************************************
      */
 
     @Override
@@ -206,9 +207,9 @@ public class JsonParserSequence extends JsonParserDelegate
     }
 
     /*
-    /*******************************************************
+    /**********************************************************************
     /* Additional extended API
-    /*******************************************************
+    /**********************************************************************
      */
 
     /**
@@ -223,9 +224,9 @@ public class JsonParserSequence extends JsonParserDelegate
     }
 
     /*
-    /*******************************************************
+    /**********************************************************************
     /* Helper methods
-    /*******************************************************
+    /**********************************************************************
      */
 
     /**

--- a/src/test/java/tools/jackson/core/unittest/filter/BasicParserFilteringTest.java
+++ b/src/test/java/tools/jackson/core/unittest/filter/BasicParserFilteringTest.java
@@ -13,6 +13,7 @@ import tools.jackson.core.JsonToken;
 import tools.jackson.core.JsonTokenId;
 import tools.jackson.core.ObjectReadContext;
 import tools.jackson.core.ObjectWriteContext;
+import tools.jackson.core.TreeNode;
 import tools.jackson.core.filter.FilteringParserDelegate;
 import tools.jackson.core.filter.JsonPointerBasedFilter;
 import tools.jackson.core.filter.TokenFilter;
@@ -924,5 +925,41 @@ class BasicParserFilteringTest extends JacksonCoreTestBase
         assertEquals(
                 Arrays.asList("filterStartObject", "includeProperty: parent", "filterFinishObject"),
                 loggingFilter._log);
+    }
+
+    // [jackson-core#1616]: `readValueAsTree()` (and other read methods) must drive
+    // databind through the delegate's own (filtered) token stream, NOT the raw
+    // underlying parser -- otherwise filtering is silently bypassed.
+    @Test
+    void readValueAsTreeRespectsFiltering() throws Exception
+    {
+        CountingReadContext ctxt = new CountingReadContext();
+        // Raw input is 6 tokens; filtered down to `{'b':2}` it is 4
+        JsonParser p0 = JSON_F.createParser(ctxt, a2q("{'a':1,'b':2}"));
+        FilteringParserDelegate p = new FilteringParserDelegate(p0,
+                new NameMatchFilter("b"),
+                Inclusion.INCLUDE_ALL_AND_PATH,
+                false // multipleMatches
+        );
+
+        p.readValueAsTree();
+        assertEquals(4, ctxt.tokenCount,
+                "readValueAsTree() must read the filtered token stream, not the raw parser");
+        p.close();
+    }
+
+    // Helper context whose databind callback drains (and counts) every token of
+    // the parser handed to it; mimics how real databind drives the parser.
+    static class CountingReadContext extends ObjectReadContext.Base {
+        int tokenCount;
+
+        @Override
+        public <T extends TreeNode> T readTree(JsonParser p) {
+            tokenCount = 0;
+            while (p.nextToken() != null) {
+                ++tokenCount;
+            }
+            return null;
+        }
     }
 }

--- a/src/test/java/tools/jackson/core/unittest/read/ParserSequenceTest.java
+++ b/src/test/java/tools/jackson/core/unittest/read/ParserSequenceTest.java
@@ -128,4 +128,38 @@ class ParserSequenceTest
         assertNull(seq.nextToken());
         seq.close();
     }
+
+    // [jackson-core#1616]: read methods (readValueAsTree / readValueAs) must
+    // drive databind through the sequence's own token stream, so that parsers
+    // beyond the first one are actually used.
+    @Test
+    void readValueAsTreeUsesAllParsers() throws Exception
+    {
+        CountingReadContext ctxt = new CountingReadContext();
+        // First parser yields 3 tokens, second yields 2: 5 total
+        JsonParser p1 = JSON_FACTORY.createParser(ctxt, "1 2 3");
+        JsonParser p2 = JSON_FACTORY.createParser(ctxt, "4 5");
+        JsonParserSequence seq = JsonParserSequence.createFlattened(false, p1, p2);
+
+        seq.readValueAsTree();
+        assertEquals(5, ctxt.tokenCount,
+                "readValueAsTree() must consume tokens from all parsers in sequence");
+        seq.close();
+    }
+
+    // Helper context whose databind callbacks drain (and count) every token of
+    // the parser handed to them; mimics how real databind drives the parser.
+    static class CountingReadContext extends ObjectReadContext.Base {
+        int tokenCount;
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T extends tools.jackson.core.TreeNode> T readTree(JsonParser p) {
+            tokenCount = (p.currentToken() != null) ? 1 : 0;
+            while (p.nextToken() != null) {
+                ++tokenCount;
+            }
+            return null;
+        }
+    }
 }

--- a/src/test/java/tools/jackson/core/unittest/read/ParserSequenceTest.java
+++ b/src/test/java/tools/jackson/core/unittest/read/ParserSequenceTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import tools.jackson.core.JsonParser;
 import tools.jackson.core.JsonToken;
 import tools.jackson.core.ObjectReadContext;
+import tools.jackson.core.TreeNode;
 import tools.jackson.core.unittest.*;
 import tools.jackson.core.util.JsonParserSequence;
 
@@ -147,15 +148,35 @@ class ParserSequenceTest
         seq.close();
     }
 
+    // [jackson-core#1616]: same, but mirroring the actual failing scenario more
+    // closely -- as in `AsPropertyTypeDeserializer`, the sequence is built with
+    // `checkForExistingToken=true` over a first parser that already points at a
+    // token (a `TokenBuffer` in real usage). The existing-token path must still
+    // continue into the remaining parsers.
+    @Test
+    void readValueAsTreeUsesAllParsersWithExistingToken() throws Exception
+    {
+        CountingReadContext ctxt = new CountingReadContext();
+        JsonParser p1 = JSON_FACTORY.createParser(ctxt, "1 2 3");
+        JsonParser p2 = JSON_FACTORY.createParser(ctxt, "4 5");
+        // advance first parser so it already points at a token before sequencing
+        assertToken(JsonToken.VALUE_NUMBER_INT, p1.nextToken());
+        JsonParserSequence seq = JsonParserSequence.createFlattened(true, p1, p2);
+
+        seq.readValueAsTree();
+        assertEquals(5, ctxt.tokenCount,
+                "readValueAsTree() must consume tokens from all parsers in sequence");
+        seq.close();
+    }
+
     // Helper context whose databind callbacks drain (and count) every token of
     // the parser handed to them; mimics how real databind drives the parser.
     static class CountingReadContext extends ObjectReadContext.Base {
         int tokenCount;
 
         @Override
-        @SuppressWarnings("unchecked")
-        public <T extends tools.jackson.core.TreeNode> T readTree(JsonParser p) {
-            tokenCount = (p.currentToken() != null) ? 1 : 0;
+        public <T extends TreeNode> T readTree(JsonParser p) {
+            tokenCount = 0;
             while (p.nextToken() != null) {
                 ++tokenCount;
             }

--- a/src/test/java/tools/jackson/core/unittest/read/ParserSequenceTest.java
+++ b/src/test/java/tools/jackson/core/unittest/read/ParserSequenceTest.java
@@ -169,17 +169,43 @@ class ParserSequenceTest
         seq.close();
     }
 
+    // [jackson-core#1616]: the same routing must apply to the non-tree
+    // `readValueAs(...)` overloads, not just `readValueAsTree()`.
+    @Test
+    void readValueAsUsesAllParsers() throws Exception
+    {
+        CountingReadContext ctxt = new CountingReadContext();
+        JsonParser p1 = JSON_FACTORY.createParser(ctxt, "1 2 3");
+        JsonParser p2 = JSON_FACTORY.createParser(ctxt, "4 5");
+        JsonParserSequence seq = JsonParserSequence.createFlattened(false, p1, p2);
+
+        seq.readValueAs(Object.class);
+        assertEquals(5, ctxt.tokenCount,
+                "readValueAs(Class) must consume tokens from all parsers in sequence");
+        seq.close();
+    }
+
     // Helper context whose databind callbacks drain (and count) every token of
     // the parser handed to them; mimics how real databind drives the parser.
     static class CountingReadContext extends ObjectReadContext.Base {
         int tokenCount;
 
-        @Override
-        public <T extends TreeNode> T readTree(JsonParser p) {
+        private void _drain(JsonParser p) {
             tokenCount = 0;
             while (p.nextToken() != null) {
                 ++tokenCount;
             }
+        }
+
+        @Override
+        public <T extends TreeNode> T readTree(JsonParser p) {
+            _drain(p);
+            return null;
+        }
+
+        @Override
+        public <T> T readValue(JsonParser p, Class<T> valueType) {
+            _drain(p);
             return null;
         }
     }


### PR DESCRIPTION
Fixes #1616.