### PR TITLE
New JsonPointer method:  public boolean startsWith(JsonPointer other) 

### DIFF
--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -58,3 +58,8 @@ Max Paulus (@maxpaulus43)
 Antonin Janec (@xtonik)
  * Contributed #1576: Use Java 17 intrinstics for long multiplication
   (3.2.0)
+
+Scott Lewis (@scottslewis)
+ * Contributed #1637: Add `JsonPointer.startsWith(JsonPointer)` to check
+   prefix match
+  (3.3.0)

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -17,7 +17,8 @@ JSON library.
 
 3.3.0 (not yet released)
 
-No changes since 3.2
+#1637: Add `JsonPointer.startsWith(JsonPointer)` to check prefix match
+ (contributed by @scottslewis)
 
 3.2.1 (10-Jul-2026)
 

--- a/src/main/java/tools/jackson/core/JsonPointer.java
+++ b/src/main/java/tools/jackson/core/JsonPointer.java
@@ -691,6 +691,50 @@ public class JsonPointer implements Serializable
         return true;
     }
 
+    /**
+     * Method added to check whether this pointer starts with the given other pointer.
+     *
+     * This implementation compares logical segments rather than raw string prefix:
+     * it iterates through segments of 'other' and ensures corresponding segments
+     * of 'this' match exactly (either same property name or same element index).
+     *
+     * @param other Pointer to check as prefix
+     * @return true if this pointer starts with the given other pointer
+     */
+    public boolean startsWith(JsonPointer other) {
+        if (other == null) {
+            return false;
+        }
+        if (other == EMPTY) {
+            return true;
+        }
+        JsonPointer a = this;
+        JsonPointer b = other;
+        while (b != EMPTY) {
+            if (a == EMPTY) {
+                // 'other' has more segments than 'this'
+                return false;
+            }
+            // Compare element index if present in 'b'
+            if (b._matchingElementIndex >= 0) {
+                if (a._matchingElementIndex != b._matchingElementIndex) {
+                    return false;
+                }
+            } else {
+                // Compare property names (may be empty string)
+                if (a._matchingPropertyName == null) {
+                    return false;
+                }
+                if (!a._matchingPropertyName.equals(b._matchingPropertyName)) {
+                    return false;
+                }
+            }
+            a = a._nextSegment;
+            b = b._nextSegment;
+        }
+        return true;
+    }
+
     /*
     /**********************************************************************
     /* Internal methods

--- a/src/main/java/tools/jackson/core/JsonPointer.java
+++ b/src/main/java/tools/jackson/core/JsonPointer.java
@@ -692,14 +692,23 @@ public class JsonPointer implements Serializable
     }
 
     /**
-     * Method added to check whether this pointer starts with the given other pointer.
+     * Method for checking whether this pointer starts with (that is, is prefixed by)
+     * the given other pointer. Every pointer starts with the "empty" pointer, and
+     * with itself.
+     *<p>
+     * Matching is done on decoded logical segments -- each segment must match either
+     * as same property name or as same element index -- and not as a raw String prefix.
+     * Note that this means results may differ from {@link #equals}, which compares the
+     * String representation: two pointers that differ only by escaping of an invalid
+     * escape sequence (like {@code "/a~0b"} vs {@code "/a~b"}) decode to the same
+     * segment and hence match here, but are not {@code equals}.
      *
-     * This implementation compares logical segments rather than raw string prefix:
-     * it iterates through segments of 'other' and ensures corresponding segments
-     * of 'this' match exactly (either same property name or same element index).
+     * @param other Pointer to check as prefix; {@code null} results in {@code false}
      *
-     * @param other Pointer to check as prefix
-     * @return true if this pointer starts with the given other pointer
+     * @return {@code True} if this pointer starts with the given other pointer;
+     *    {@code false} otherwise (including case of {@code null} argument)
+     *
+     * @since 3.3
      */
     public boolean startsWith(JsonPointer other) {
         if (other == null) {

--- a/src/main/java/tools/jackson/core/JsonPointer.java
+++ b/src/main/java/tools/jackson/core/JsonPointer.java
@@ -730,10 +730,8 @@ public class JsonPointer implements Serializable
                     return false;
                 }
             } else {
-                // Compare property names (may be empty string)
-                if (a._matchingPropertyName == null) {
-                    return false;
-                }
+                // Compare property names (may be empty string; only EMPTY has `null`
+                // name and that case was already handled above)
                 if (!a._matchingPropertyName.equals(b._matchingPropertyName)) {
                     return false;
                 }

--- a/src/test/java/tools/jackson/core/unittest/jsonptr/JsonPointerStartsWithTest.java
+++ b/src/test/java/tools/jackson/core/unittest/jsonptr/JsonPointerStartsWithTest.java
@@ -40,7 +40,7 @@ public class JsonPointerStartsWithTest {
     public void testStartsWithValidPrefix(String full, String prefix) {
         JsonPointer fullPtr = JsonPointer.compile(full);
         JsonPointer prefixPtr = JsonPointer.compile(prefix);
-        assertTrue(fullPtr.startsWith(prefixPtr), 
+        assertTrue(fullPtr.startsWith(prefixPtr),
             String.format("Pointer '%s' should start with '%s'", full, prefix));
     }
 
@@ -59,7 +59,7 @@ public class JsonPointerStartsWithTest {
     public void testStartsWithInvalidPrefix(String full, String prefix) {
         JsonPointer fullPtr = JsonPointer.compile(full);
         JsonPointer prefixPtr = JsonPointer.compile(prefix);
-        assertFalse(fullPtr.startsWith(prefixPtr), 
+        assertFalse(fullPtr.startsWith(prefixPtr),
             String.format("Pointer '%s' should NOT start with '%s'", full, prefix));
     }
 
@@ -67,10 +67,10 @@ public class JsonPointerStartsWithTest {
     @DisplayName("Should handle complex escaped characters correctly")
     public void testStartsWithEscaped() {
         JsonPointer fullPtr = JsonPointer.compile("/~1part1/~0part2/end");
-        
+
         assertTrue(fullPtr.startsWith(JsonPointer.compile("/~1part1")));
         assertTrue(fullPtr.startsWith(JsonPointer.compile("/~1part1/~0part2")));
-        
+
         // Mismatch in escaping
         assertFalse(fullPtr.startsWith(JsonPointer.compile("/part1")));
     }
@@ -84,7 +84,7 @@ public class JsonPointerStartsWithTest {
 
         assertTrue(indexPtr.startsWith(JsonPointer.compile("/0")));
         assertFalse(indexPtr.startsWith(JsonPointer.compile("/00")));
-        
+
         assertTrue(propPtr.startsWith(JsonPointer.compile("/00")));
         assertFalse(propPtr.startsWith(JsonPointer.compile("/0")));
     }

--- a/src/test/java/tools/jackson/core/unittest/jsonptr/JsonPointerStartsWithTest.java
+++ b/src/test/java/tools/jackson/core/unittest/jsonptr/JsonPointerStartsWithTest.java
@@ -1,0 +1,99 @@
+package tools.jackson.core.unittest.jsonptr;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import tools.jackson.core.JsonPointer;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class JsonPointerStartsWithTest {
+
+    @Test
+    @DisplayName("Should return true when comparing against the EMPTY pointer")
+    public void testStartsWithEmpty() {
+        JsonPointer ptr = JsonPointer.compile("/a/b/c");
+        assertTrue(ptr.startsWith(JsonPointer.empty()), "Any pointer should start with the empty pointer");
+        assertTrue(JsonPointer.empty().startsWith(JsonPointer.empty()), "Empty pointer should start with empty pointer");
+    }
+
+    @Test
+    @DisplayName("Should return false when the other pointer is null")
+    public void testStartsWithNull() {
+        JsonPointer ptr = JsonPointer.compile("/a/b/c");
+        assertFalse(ptr.startsWith(null), "Should return false for null input");
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "/a/b/c, /a",
+        "/a/b/c, /a/b",
+        "/a/b/c, /a/b/c",
+        "/1/2/3, /1",
+        "/1/2/3, /1/2",
+        "/prop/0/leaf, /prop/0",
+        "/~1slash/~0tilde, /~1slash"
+    })
+    @DisplayName("Should return true for valid prefixes")
+    public void testStartsWithValidPrefix(String full, String prefix) {
+        JsonPointer fullPtr = JsonPointer.compile(full);
+        JsonPointer prefixPtr = JsonPointer.compile(prefix);
+        assertTrue(fullPtr.startsWith(prefixPtr), 
+            String.format("Pointer '%s' should start with '%s'", full, prefix));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "/a/b/c, /b",
+        "/a/b/c, /a/c",
+        "/a/b/c, /a/b/c/d",
+        "/1/2/3, /2",
+        "/1/2/3, /1/3",
+        "/1/2/3, /1/2/3/4",
+        "/prop/0, /prop/1",
+        "/a, /b"
+    })
+    @DisplayName("Should return false for invalid prefixes")
+    public void testStartsWithInvalidPrefix(String full, String prefix) {
+        JsonPointer fullPtr = JsonPointer.compile(full);
+        JsonPointer prefixPtr = JsonPointer.compile(prefix);
+        assertFalse(fullPtr.startsWith(prefixPtr), 
+            String.format("Pointer '%s' should NOT start with '%s'", full, prefix));
+    }
+
+    @Test
+    @DisplayName("Should handle complex escaped characters correctly")
+    public void testStartsWithEscaped() {
+        JsonPointer fullPtr = JsonPointer.compile("/~1part1/~0part2/end");
+        
+        assertTrue(fullPtr.startsWith(JsonPointer.compile("/~1part1")));
+        assertTrue(fullPtr.startsWith(JsonPointer.compile("/~1part1/~0part2")));
+        
+        // Mismatch in escaping
+        assertFalse(fullPtr.startsWith(JsonPointer.compile("/part1")));
+    }
+
+    @Test
+    @DisplayName("Should distinguish between property names and array indices")
+    public void testStartsWithTypeSafety() {
+        // "/0" is index 0, "/00" is property name "00"
+        JsonPointer indexPtr = JsonPointer.compile("/0/next");
+        JsonPointer propPtr = JsonPointer.compile("/00/next");
+
+        assertTrue(indexPtr.startsWith(JsonPointer.compile("/0")));
+        assertFalse(indexPtr.startsWith(JsonPointer.compile("/00")));
+        
+        assertTrue(propPtr.startsWith(JsonPointer.compile("/00")));
+        assertFalse(propPtr.startsWith(JsonPointer.compile("/0")));
+    }
+
+    @Test
+    @DisplayName("Should return false if prefix is longer than the pointer")
+    public void testStartsWithLongerPrefix() {
+        JsonPointer ptr = JsonPointer.compile("/a/b");
+        JsonPointer longer = JsonPointer.compile("/a/b/c");
+        assertFalse(ptr.startsWith(longer), "Pointer should not start with a longer pointer");
+    }
+}

--- a/src/test/java/tools/jackson/core/unittest/jsonptr/JsonPointerStartsWithTest.java
+++ b/src/test/java/tools/jackson/core/unittest/jsonptr/JsonPointerStartsWithTest.java
@@ -6,10 +6,11 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
 import tools.jackson.core.JsonPointer;
+import tools.jackson.core.unittest.JacksonCoreTestBase;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class JsonPointerStartsWithTest {
+public class JsonPointerStartsWithTest extends JacksonCoreTestBase {
 
     @Test
     @DisplayName("Should return true when comparing against the EMPTY pointer")
@@ -95,5 +96,23 @@ public class JsonPointerStartsWithTest {
         JsonPointer ptr = JsonPointer.compile("/a/b");
         JsonPointer longer = JsonPointer.compile("/a/b/c");
         assertFalse(ptr.startsWith(longer), "Pointer should not start with a longer pointer");
+    }
+
+    // [core#788]: empty String ("") is a valid property name, distinct from EMPTY pointer
+    @Test
+    @DisplayName("Should handle empty-String property segments")
+    public void testStartsWithEmptyStringProperty() {
+        // "/" is a single segment matching property with empty-String name
+        JsonPointer emptyProp = JsonPointer.compile("/");
+        JsonPointer emptyPropChild = JsonPointer.compile("//leaf");
+
+        assertTrue(emptyProp.startsWith(JsonPointer.compile("/")));
+        assertTrue(emptyPropChild.startsWith(JsonPointer.compile("/")));
+        assertTrue(emptyPropChild.startsWith(JsonPointer.compile("//leaf")));
+
+        // empty-String property "/" is NOT the same as the EMPTY (root) pointer as a prefix source:
+        assertFalse(JsonPointer.empty().startsWith(emptyProp));
+        // ...but every pointer (incl. "/") starts with the EMPTY pointer
+        assertTrue(emptyProp.startsWith(JsonPointer.empty()));
     }
 }

--- a/src/test/java/tools/jackson/core/unittest/jsonptr/JsonPointerStartsWithTest.java
+++ b/src/test/java/tools/jackson/core/unittest/jsonptr/JsonPointerStartsWithTest.java
@@ -1,28 +1,32 @@
 package tools.jackson.core.unittest.jsonptr;
 
-import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
+import tools.jackson.core.JsonParser;
 import tools.jackson.core.JsonPointer;
-import tools.jackson.core.unittest.JacksonCoreTestBase;
+import tools.jackson.core.JsonToken;
+import tools.jackson.core.ObjectReadContext;
+import tools.jackson.core.json.JsonFactory;
+import tools.jackson.core.unittest.*;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class JsonPointerStartsWithTest extends JacksonCoreTestBase {
+// Tests for [core#1637]: `JsonPointer.startsWith(JsonPointer)`
+class JsonPointerStartsWithTest extends JacksonCoreTestBase
+{
+    private final JsonFactory JSON_F = new JsonFactory();
 
     @Test
-    @DisplayName("Should return true when comparing against the EMPTY pointer")
-    public void testStartsWithEmpty() {
+    void startsWithEmpty() {
         JsonPointer ptr = JsonPointer.compile("/a/b/c");
         assertTrue(ptr.startsWith(JsonPointer.empty()), "Any pointer should start with the empty pointer");
         assertTrue(JsonPointer.empty().startsWith(JsonPointer.empty()), "Empty pointer should start with empty pointer");
     }
 
     @Test
-    @DisplayName("Should return false when the other pointer is null")
-    public void testStartsWithNull() {
+    void startsWithNull() {
         JsonPointer ptr = JsonPointer.compile("/a/b/c");
         assertFalse(ptr.startsWith(null), "Should return false for null input");
     }
@@ -37,8 +41,7 @@ public class JsonPointerStartsWithTest extends JacksonCoreTestBase {
         "/prop/0/leaf, /prop/0",
         "/~1slash/~0tilde, /~1slash"
     })
-    @DisplayName("Should return true for valid prefixes")
-    public void testStartsWithValidPrefix(String full, String prefix) {
+    void startsWithValidPrefix(String full, String prefix) {
         JsonPointer fullPtr = JsonPointer.compile(full);
         JsonPointer prefixPtr = JsonPointer.compile(prefix);
         assertTrue(fullPtr.startsWith(prefixPtr),
@@ -54,10 +57,14 @@ public class JsonPointerStartsWithTest extends JacksonCoreTestBase {
         "/1/2/3, /1/3",
         "/1/2/3, /1/2/3/4",
         "/prop/0, /prop/1",
-        "/a, /b"
+        "/a, /b",
+        // Matching is by segment, not by raw String prefix:
+        "/abc, /ab",
+        "/abc/d, /ab",
+        "/abc/d, /abc/d/e",
+        "/12/3, /1"
     })
-    @DisplayName("Should return false for invalid prefixes")
-    public void testStartsWithInvalidPrefix(String full, String prefix) {
+    void startsWithInvalidPrefix(String full, String prefix) {
         JsonPointer fullPtr = JsonPointer.compile(full);
         JsonPointer prefixPtr = JsonPointer.compile(prefix);
         assertFalse(fullPtr.startsWith(prefixPtr),
@@ -65,8 +72,7 @@ public class JsonPointerStartsWithTest extends JacksonCoreTestBase {
     }
 
     @Test
-    @DisplayName("Should handle complex escaped characters correctly")
-    public void testStartsWithEscaped() {
+    void startsWithEscaped() {
         JsonPointer fullPtr = JsonPointer.compile("/~1part1/~0part2/end");
 
         assertTrue(fullPtr.startsWith(JsonPointer.compile("/~1part1")));
@@ -74,11 +80,28 @@ public class JsonPointerStartsWithTest extends JacksonCoreTestBase {
 
         // Mismatch in escaping
         assertFalse(fullPtr.startsWith(JsonPointer.compile("/part1")));
+        // Escaped slash is part of one segment, not a segment separator
+        assertFalse(fullPtr.startsWith(JsonPointer.compile("/")));
+    }
+
+    // Matching is on decoded segments, so equal-decoding pointers match even
+    // when their String representations (and hence `equals()`) differ
+    @Test
+    void startsWithNotSameAsEquals() {
+        JsonPointer valid = JsonPointer.compile("/a~0b");
+        // "~b" is not a valid escape and is decoded as-is; same segment as above
+        JsonPointer invalidEsc = JsonPointer.compile("/a~b");
+
+        assertEquals("a~b", valid.getMatchingProperty());
+        assertEquals("a~b", invalidEsc.getMatchingProperty());
+        assertNotEquals(valid, invalidEsc);
+
+        assertTrue(valid.startsWith(invalidEsc));
+        assertTrue(invalidEsc.startsWith(valid));
     }
 
     @Test
-    @DisplayName("Should distinguish between property names and array indices")
-    public void testStartsWithTypeSafety() {
+    void startsWithTypeSafety() {
         // "/0" is index 0, "/00" is property name "00"
         JsonPointer indexPtr = JsonPointer.compile("/0/next");
         JsonPointer propPtr = JsonPointer.compile("/00/next");
@@ -91,8 +114,7 @@ public class JsonPointerStartsWithTest extends JacksonCoreTestBase {
     }
 
     @Test
-    @DisplayName("Should return false if prefix is longer than the pointer")
-    public void testStartsWithLongerPrefix() {
+    void startsWithLongerPrefix() {
         JsonPointer ptr = JsonPointer.compile("/a/b");
         JsonPointer longer = JsonPointer.compile("/a/b/c");
         assertFalse(ptr.startsWith(longer), "Pointer should not start with a longer pointer");
@@ -100,8 +122,7 @@ public class JsonPointerStartsWithTest extends JacksonCoreTestBase {
 
     // [core#788]: empty String ("") is a valid property name, distinct from EMPTY pointer
     @Test
-    @DisplayName("Should handle empty-String property segments")
-    public void testStartsWithEmptyStringProperty() {
+    void startsWithEmptyStringProperty() {
         // "/" is a single segment matching property with empty-String name
         JsonPointer emptyProp = JsonPointer.compile("/");
         JsonPointer emptyPropChild = JsonPointer.compile("//leaf");
@@ -114,5 +135,59 @@ public class JsonPointerStartsWithTest extends JacksonCoreTestBase {
         assertFalse(JsonPointer.empty().startsWith(emptyProp));
         // ...but every pointer (incl. "/") starts with the EMPTY pointer
         assertTrue(emptyProp.startsWith(JsonPointer.empty()));
+    }
+
+    // Pointers constructed by mutant factories build fresh segment chains: verify
+    // those work as both receiver and argument
+    @Test
+    void startsWithDerivedPointers() {
+        final JsonPointer full = JsonPointer.compile("/a/b/c/d");
+
+        JsonPointer head = full.head(); // "/a/b/c"
+        assertEquals("/a/b/c", head.toString());
+        assertTrue(full.startsWith(head));
+        assertTrue(head.startsWith(head.head()));
+        assertFalse(head.startsWith(full));
+
+        JsonPointer tail = full.tail(); // "/b/c/d"
+        assertTrue(tail.startsWith(JsonPointer.compile("/b/c")));
+        assertFalse(tail.startsWith(JsonPointer.compile("/a")));
+
+        JsonPointer appended = JsonPointer.compile("/a/b").append(JsonPointer.compile("/c"));
+        assertTrue(appended.startsWith(JsonPointer.compile("/a/b")));
+        assertTrue(full.startsWith(appended));
+
+        JsonPointer built = JsonPointer.compile("/a").appendIndex(3).appendProperty("x/y");
+        assertTrue(built.startsWith(JsonPointer.compile("/a/3")));
+        assertTrue(built.startsWith(JsonPointer.compile("/a").appendIndex(3)));
+        assertTrue(built.startsWith(built));
+        // "/03" is a property name, not index 3
+        assertFalse(built.startsWith(JsonPointer.compile("/a/03")));
+    }
+
+    // Pointers from parsing context are built via `JsonPointer.forPath()`, another
+    // separate construction path
+    @Test
+    void startsWithPointerFromContext() throws Exception
+    {
+        final String DOC = a2q("{'ob':{'array':[1,{'leaf':true}]}}");
+
+        try (JsonParser p = JSON_F.createParser(ObjectReadContext.empty(), DOC)) {
+            while (p.nextToken() != null) {
+                if (p.currentToken() == JsonToken.VALUE_TRUE) {
+                    break;
+                }
+            }
+            JsonPointer ptr = p.streamReadContext().pathAsPointer();
+            assertEquals("/ob/array/1/leaf", ptr.toString());
+
+            assertTrue(ptr.startsWith(JsonPointer.empty()));
+            assertTrue(ptr.startsWith(JsonPointer.compile("/ob")));
+            assertTrue(ptr.startsWith(JsonPointer.compile("/ob/array/1")));
+            assertTrue(ptr.startsWith(ptr));
+            assertFalse(ptr.startsWith(JsonPointer.compile("/ob/array/0")));
+            // and works as prefix argument as well:
+            assertTrue(JsonPointer.compile("/ob/array/1/leaf/deeper").startsWith(ptr));
+        }
     }
 }

--- a/src/test/java/tools/jackson/core/unittest/jsonptr/PointerFromContextTest.java
+++ b/src/test/java/tools/jackson/core/unittest/jsonptr/PointerFromContextTest.java
@@ -2,6 +2,8 @@ package tools.jackson.core.unittest.jsonptr;
 
 import java.io.StringWriter;
 
+import org.junit.jupiter.api.Test;
+
 import tools.jackson.core.JsonGenerator;
 import tools.jackson.core.JsonParser;
 import tools.jackson.core.JsonPointer;
@@ -25,7 +27,8 @@ public class PointerFromContextTest extends JacksonCoreTestBase
 
     private final JsonPointer EMPTY_PTR = JsonPointer.empty();
 
-    public void testViaParser() throws Exception
+    @Test
+    void testViaParser() throws Exception
     {
         final String SIMPLE = """
                 {"a":123,"array":[1,2,[3],5,{"obInArray":4}],"ob":{"first":[false,true],"second":{"sub":37}},"b":true}""";
@@ -110,7 +113,8 @@ public class PointerFromContextTest extends JacksonCoreTestBase
         p.close();
     }
 
-    public void testViaGenerator() throws Exception
+    @Test
+    void testViaGenerator() throws Exception
     {
         StringWriter w = new StringWriter();
         JsonGenerator g = JSON_F.createGenerator(ObjectWriteContext.empty(), w);
@@ -154,7 +158,8 @@ public class PointerFromContextTest extends JacksonCoreTestBase
     /**********************************************************
      */
 
-    public void testParserWithRoot() throws Exception
+    @Test
+    void testParserWithRoot() throws Exception
     {
         final String JSON = """
                 {"a":1,"b":3}\n{"a":5,"c":[1,2]}\n[1,2]\n""";
@@ -217,7 +222,8 @@ public class PointerFromContextTest extends JacksonCoreTestBase
         p.close();
     }
 
-    public void testGeneratorWithRoot() throws Exception
+    @Test
+    void testGeneratorWithRoot() throws Exception
     {
         StringWriter w = new StringWriter();
         JsonGenerator g = JSON_F.createGenerator(ObjectWriteContext.empty(), w);


### PR DESCRIPTION
See https://github.com/FasterXML/jackson-databind/pull/6045#issuecomment-5028071274 for context for this addition.
Fixes #1637.

Also added JsonPointerStartsWithTest to test startsWith method.