### PR TITLE
Enforce maxNameLength incrementally in ReaderBasedJsonParser [CVE-2026-68498]

### DIFF
--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -485,7 +485,7 @@ Revanth Meesala (@revanthmeesala)
    case [GHSA-2c4j-63jj-9fqr]
   (2.18.10)
 
-@tinyb0y:
+@tinyb0y
  * Contributed #1643: Enforce maxNameLength incrementally in ReaderBasedJsonParser
    [GHSA-649p-m576-vr99]
   (2.18.10)

--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -484,3 +484,8 @@ Revanth Meesala (@revanthmeesala)
  * Contributed #1642: Fix maxDocumentLength bypass in async parser single-feedInput()
    case [GHSA-2c4j-63jj-9fqr]
   (2.18.10)
+
+@tinyb0y:
+ * Contributed #1643: Enforce maxNameLength incrementally in ReaderBasedJsonParser
+   [GHSA-649p-m576-vr99]
+  (2.18.10)

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -19,6 +19,8 @@ a pure JSON library.
 #1642: Fix maxDocumentLength bypass in async parser single-feedInput() case
   [GHSA-2c4j-63jj-9fqr]
  (fix by Revanth M)
+#1643: Enforce maxNameLength incrementally in ReaderBasedJsonParser [GHSA-649p-m576-vr99]
+ (fix by @tinyb0y)
 
 2.18.9 (07-Jul-2026)
 

--- a/src/main/java/com/fasterxml/jackson/core/json/ReaderBasedJsonParser.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/ReaderBasedJsonParser.java
@@ -1847,7 +1847,9 @@ public class ReaderBasedJsonParser
         //   only the much larger `maxStringLength` bound (enforced inside
         //   `TextBuffer.finishCurrentSegment()`) applies until the whole name has
         //   already been buffered.
-        int totalLen = outPtr;
+        //   Note: only updated when segment gets full (at which point `outPtr` is
+        //   always exactly `outBuf.length`), to keep the per-character loop tight.
+        int totalLen = 0;
 
         while (true) {
             if (_inputPtr >= _inputEnd) {
@@ -1876,10 +1878,10 @@ public class ReaderBasedJsonParser
             hash = (hash * CharsToNameCanonicalizer.HASH_MULT) + c;
             // Ok, let's add char to output:
             outBuf[outPtr++] = c;
-            ++totalLen;
 
             // Need more room?
             if (outPtr >= outBuf.length) {
+                totalLen += outBuf.length;
                 _streamReadConstraints.validateNameLength(totalLen);
                 outBuf = _textBuffer.finishCurrentSegment();
                 outPtr = 0;
@@ -2113,7 +2115,7 @@ public class ReaderBasedJsonParser
         final int maxCode = codes.length;
         // 28-Jul-2026, tinyb0y: [core#1643] Same incremental `maxNameLength` check as
         //   `_parseName2()` needs to apply to unquoted ("odd") names as well
-        int totalLen = outPtr;
+        int totalLen = 0;
 
         while (true) {
             if (_inputPtr >= _inputEnd) {
@@ -2134,10 +2136,10 @@ public class ReaderBasedJsonParser
             hash = (hash * CharsToNameCanonicalizer.HASH_MULT) + i;
             // Ok, let's add char to output:
             outBuf[outPtr++] = c;
-            ++totalLen;
 
             // Need more room?
             if (outPtr >= outBuf.length) {
+                totalLen += outBuf.length;
                 _streamReadConstraints.validateNameLength(totalLen);
                 outBuf = _textBuffer.finishCurrentSegment();
                 outPtr = 0;

--- a/src/main/java/com/fasterxml/jackson/core/json/ReaderBasedJsonParser.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/ReaderBasedJsonParser.java
@@ -1841,7 +1841,7 @@ public class ReaderBasedJsonParser
          */
         char[] outBuf = _textBuffer.getCurrentSegment();
         int outPtr = _textBuffer.getCurrentSegmentSize();
-        // 23-Jul-2026, tatu: [core#XXXX] Track total length accumulated so far so we
+        // 28-Jul-2026, tinyb0y: [core#1643] Track total length accumulated so far so we
         //   can validate against `maxNameLength` incrementally, same as byte-based
         //   parsers already do via `ParserBase._growNameDecodeBuffer()`. Without this,
         //   only the much larger `maxStringLength` bound (enforced inside
@@ -2111,6 +2111,9 @@ public class ReaderBasedJsonParser
         char[] outBuf = _textBuffer.getCurrentSegment();
         int outPtr = _textBuffer.getCurrentSegmentSize();
         final int maxCode = codes.length;
+        // 28-Jul-2026, tinyb0y: [core#1643] Same incremental `maxNameLength` check as
+        //   `_parseName2()` needs to apply to unquoted ("odd") names as well
+        int totalLen = outPtr;
 
         while (true) {
             if (_inputPtr >= _inputEnd) {
@@ -2131,9 +2134,11 @@ public class ReaderBasedJsonParser
             hash = (hash * CharsToNameCanonicalizer.HASH_MULT) + i;
             // Ok, let's add char to output:
             outBuf[outPtr++] = c;
+            ++totalLen;
 
             // Need more room?
             if (outPtr >= outBuf.length) {
+                _streamReadConstraints.validateNameLength(totalLen);
                 outBuf = _textBuffer.finishCurrentSegment();
                 outPtr = 0;
             }

--- a/src/main/java/com/fasterxml/jackson/core/json/ReaderBasedJsonParser.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/ReaderBasedJsonParser.java
@@ -1841,6 +1841,13 @@ public class ReaderBasedJsonParser
          */
         char[] outBuf = _textBuffer.getCurrentSegment();
         int outPtr = _textBuffer.getCurrentSegmentSize();
+        // 23-Jul-2026, tatu: [core#XXXX] Track total length accumulated so far so we
+        //   can validate against `maxNameLength` incrementally, same as byte-based
+        //   parsers already do via `ParserBase._growNameDecodeBuffer()`. Without this,
+        //   only the much larger `maxStringLength` bound (enforced inside
+        //   `TextBuffer.finishCurrentSegment()`) applies until the whole name has
+        //   already been buffered.
+        int totalLen = outPtr;
 
         while (true) {
             if (_inputPtr >= _inputEnd) {
@@ -1869,9 +1876,11 @@ public class ReaderBasedJsonParser
             hash = (hash * CharsToNameCanonicalizer.HASH_MULT) + c;
             // Ok, let's add char to output:
             outBuf[outPtr++] = c;
+            ++totalLen;
 
             // Need more room?
             if (outPtr >= outBuf.length) {
+                _streamReadConstraints.validateNameLength(totalLen);
                 outBuf = _textBuffer.finishCurrentSegment();
                 outPtr = 0;
             }

--- a/src/test/java/com/fasterxml/jackson/core/constraints/LargeNameReadTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/constraints/LargeNameReadTest.java
@@ -1,12 +1,15 @@
 package com.fasterxml.jackson.core.constraints;
 
 import java.io.IOException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import com.fasterxml.jackson.core.*;
 
 import org.junit.jupiter.api.Test;
 import com.fasterxml.jackson.core.StreamReadConstraints;
 import com.fasterxml.jackson.core.exc.StreamConstraintsException;
+import com.fasterxml.jackson.core.json.JsonReadFeature;
 import com.fasterxml.jackson.core.json.async.NonBlockingJsonParser;
 
 import static org.junit.jupiter.api.Assertions.fail;
@@ -25,6 +28,13 @@ class LargeNameReadTest extends JUnit5TestBase
         JSON_F_NAME_100_B.setStreamReadConstraints(StreamReadConstraints.builder()
                 .maxNameLength(100).build());
     }
+
+    // Factory that also allows non-standard name flavors ("apostrophe" and unquoted)
+    private final JsonFactory JSON_F_NAME_100_ODD = JsonFactory.builder()
+            .streamReadConstraints(StreamReadConstraints.builder().maxNameLength(100).build())
+            .configure(JsonReadFeature.ALLOW_SINGLE_QUOTES, true)
+            .configure(JsonReadFeature.ALLOW_UNQUOTED_FIELD_NAMES, true)
+            .build();
 
     // Test name that is below default max name
     @Test
@@ -77,30 +87,52 @@ class LargeNameReadTest extends JUnit5TestBase
         }
     }
 
-    // [core#XXXX]: Reader-based parser (String/Reader/char[] input) must reject an
+    // [core#1643]: Reader-based parser (String/Reader/char[] input) must reject an
     // over-limit name promptly, the same way byte-based input already does -- not
     // only once the entire (possibly huge) name has already been buffered.
     @Test
     void largeNameWithSmallLimitCharsFailsFast() throws Exception {
-        // Name far larger than the configured limit needs to be to prove the point;
-        // "buffer the whole name, then check" would require multi-megabyte
-        // accumulation before failing, whereas the fix should reject within one
-        // TextBuffer segment fill.
-        final String doc = generateJSON(5_000_000);
-        try (JsonParser p = createParserUsingReader(JSON_F_NAME_100, doc)) {
+        // Name much larger than the configured limit: without incremental checking
+        // the whole name gets buffered (bounded only by much bigger `maxStringLength`)
+        // before failing, whereas the fix must reject within a segment fill or two.
+        _testLargeNameFailsFast(JSON_F_NAME_100, "\"");
+        _testLargeNameFailsFast(JSON_F_NAME_100_B, "\"");
+    }
+
+    // [core#1643]: ... and same goes for the non-standard name flavors, which are
+    // decoded by different code paths ("apostrophe" and unquoted names)
+    @Test
+    void largeOddNameWithSmallLimitCharsFailsFast() throws Exception {
+        _testLargeNameFailsFast(JSON_F_NAME_100_ODD, "'");
+        _testLargeNameFailsFast(JSON_F_NAME_100_ODD, "");
+    }
+
+    private void _testLargeNameFailsFast(JsonFactory jf, String nameQuote) throws Exception
+    {
+        final int nameLen = 1_000_000;
+        final String doc = generateJSON(nameLen, nameQuote);
+        try (JsonParser p = createParserUsingReader(jf, doc)) {
             consumeTokens(p);
             fail("expected StreamConstraintsException");
         } catch (StreamConstraintsException e) {
             verifyException(e, "Name length");
-            String msg = e.getMessage();
-            int start = msg.indexOf('(') + 1;
-            int end = msg.indexOf(')', start);
-            int reportedLen = Integer.parseInt(msg.substring(start, end));
-            if (reportedLen > 100_000) {
-                fail("Expected name-length check to fire well before 100,000 chars "
-                        +"were buffered (limit is 100), but got reported length: "+reportedLen);
+            // Length the exception reports tells us how much had been accumulated
+            // before the check fired: needs to be small fraction of the whole name
+            final int reportedLen = _reportedNameLength(e);
+            final int maxExpected = nameLen >> 4;
+            if (reportedLen > maxExpected) {
+                fail("Should have failed before buffering "+maxExpected
+                        +" chars (limit is 100), but reported length was: "+reportedLen);
             }
         }
+    }
+
+    private int _reportedNameLength(StreamConstraintsException e) {
+        Matcher m = Pattern.compile("Name length \\((\\d+)\\)").matcher(e.getMessage());
+        if (!m.find()) {
+            fail("Could not find reported name length from message: "+e.getMessage());
+        }
+        return Integer.parseInt(m.group(1));
     }
 
     @Test
@@ -142,12 +174,17 @@ class LargeNameReadTest extends JUnit5TestBase
     }
 
     private String generateJSON(final int nameLen) {
+        return generateJSON(nameLen, "\"");
+    }
+
+    // @param nameQuote Quote character to use around name; empty String for unquoted name
+    private String generateJSON(final int nameLen, final String nameQuote) {
         final StringBuilder sb = new StringBuilder();
-        sb.append("{\"");
+        sb.append("{").append(nameQuote);
         for (int i = 0; i < nameLen; i++) {
             sb.append("a");
         }
-        sb.append("\":\"value\"}");
+        sb.append(nameQuote).append(":\"value\"}");
         return sb.toString();
     }
 }

--- a/src/test/java/com/fasterxml/jackson/core/constraints/LargeNameReadTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/constraints/LargeNameReadTest.java
@@ -87,9 +87,11 @@ class LargeNameReadTest extends JUnit5TestBase
         }
     }
 
-    // [core#1643]: Reader-based parser (String/Reader/char[] input) must reject an
-    // over-limit name promptly, the same way byte-based input already does -- not
-    // only once the entire (possibly huge) name has already been buffered.
+    // [core#1643]: Reader-backed parser must reject an over-limit name promptly, the
+    // same way byte-based input already does -- not only once the entire (possibly
+    // huge) name has already been buffered.
+    // (note: `String` / `char[]` input is not affected the same way, since the whole
+    // document is already in memory and gets scanned in-place, without buffering)
     @Test
     void largeNameWithSmallLimitCharsFailsFast() throws Exception {
         // Name much larger than the configured limit: without incremental checking

--- a/src/test/java/com/fasterxml/jackson/core/constraints/LargeNameReadTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/constraints/LargeNameReadTest.java
@@ -77,6 +77,32 @@ class LargeNameReadTest extends JUnit5TestBase
         }
     }
 
+    // [core#XXXX]: Reader-based parser (String/Reader/char[] input) must reject an
+    // over-limit name promptly, the same way byte-based input already does -- not
+    // only once the entire (possibly huge) name has already been buffered.
+    @Test
+    void largeNameWithSmallLimitCharsFailsFast() throws Exception {
+        // Name far larger than the configured limit needs to be to prove the point;
+        // "buffer the whole name, then check" would require multi-megabyte
+        // accumulation before failing, whereas the fix should reject within one
+        // TextBuffer segment fill.
+        final String doc = generateJSON(5_000_000);
+        try (JsonParser p = createParserUsingReader(JSON_F_NAME_100, doc)) {
+            consumeTokens(p);
+            fail("expected StreamConstraintsException");
+        } catch (StreamConstraintsException e) {
+            verifyException(e, "Name length");
+            String msg = e.getMessage();
+            int start = msg.indexOf('(') + 1;
+            int end = msg.indexOf(')', start);
+            int reportedLen = Integer.parseInt(msg.substring(start, end));
+            if (reportedLen > 100_000) {
+                fail("Expected name-length check to fire well before 100,000 chars "
+                        +"were buffered (limit is 100), but got reported length: "+reportedLen);
+            }
+        }
+    }
+
     @Test
     void largeNameWithSmallLimitAsync() throws Exception
     {


### PR DESCRIPTION
Fixes GHSA-649p-m576-vr99.

`ReaderBasedJsonParser._parseName2()` only validated accumulated
property-name length against `maxStringLength` while buffering, and
against `maxNameLength` once at the very end (via `findSymbol`).
Reader/String/char[] input could therefore buffer a property name up
to `maxStringLength` before `maxNameLength` ever fired, unlike
byte-based input, which already validates incrementally via
`ParserBase._growNameDecodeBuffer()`.

This tracks accumulated length locally in `_parseName2()` and
validates on each buffer-segment fill, matching the existing
byte-parser idiom (same pattern as #1611 for the analogous
`maxNumberLength` async-parser gap).

### Tests

- New `LargeNameReadTest.largeNameWithSmallLimitCharsFailsFast` pins
  the fix: fails on unpatched code (reports the full buffered length),
  passes on patched code (rejects within one buffer-segment fill).
- Full `mvn test`: 1441 tests run, 0 failures, 0 errors, 2 skipped
  (pre-existing).
