### PR TITLE
Fix ByteBuffer-backed async `releaseBuffered()` output

### DIFF
--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -73,3 +73,9 @@ Scott Lewis (@scottslewis)
  * Contributed #1637: Add `JsonPointer.startsWith(JsonPointer)` to check
    prefix match
   (3.3.0)
+
+DongNyoung Lee (@Dongnyoung)
+ * Reported, fixed #1646: Non-blocking ByteBuffer parser `releaseBuffered()` can write
+   already-consumed bytes
+  (3.3.0)
+

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -19,6 +19,9 @@ JSON library.
 
 #1637: Add `JsonPointer.startsWith(JsonPointer)` to check prefix match
  (contributed by @scottslewis)
+#1646: Non-blocking ByteBuffer parser `releaseBuffered()` can write
+  already-consumed bytes
+ (reported, fix by DongNyoung L)
 
 3.2.2 (not yet released)
 

--- a/src/main/java/tools/jackson/core/json/async/NonBlockingByteBufferJsonParser.java
+++ b/src/main/java/tools/jackson/core/json/async/NonBlockingByteBufferJsonParser.java
@@ -81,11 +81,15 @@ public class NonBlockingByteBufferJsonParser
         final int avail = _inputEnd - _inputPtr;
         if (avail > 0) {
             final WritableByteChannel channel = Channels.newChannel(out);
+            // 05-Aug-2026, dnlee: [core#1646] Must write unconsumed range only, and via
+            //   duplicate() so that buffer caller fed us is left untouched.
+            //   NOTE: must call methods via `Buffer`, not `ByteBuffer`: covariant overrides
+            //   are Java 9+ and animal-sniffer checks us against Android SDK 26.
+            //   Also: limit() before position(), as former never fails for valid range.
             final ByteBuffer buffer = _inputBuffer.duplicate();
-            // Use Buffer methods for Java 8/Android signature compatibility.
             final Buffer baseBuffer = buffer;
-            baseBuffer.position(_inputPtr);
             baseBuffer.limit(_inputEnd);
+            baseBuffer.position(_inputPtr);
             try {
                 channel.write(buffer);
             } catch (IOException e) {

--- a/src/main/java/tools/jackson/core/json/async/NonBlockingByteBufferJsonParser.java
+++ b/src/main/java/tools/jackson/core/json/async/NonBlockingByteBufferJsonParser.java
@@ -80,8 +80,11 @@ public class NonBlockingByteBufferJsonParser
         final int avail = _inputEnd - _inputPtr;
         if (avail > 0) {
             final WritableByteChannel channel = Channels.newChannel(out);
+            final ByteBuffer buffer = _inputBuffer.duplicate();
+            buffer.position(_inputPtr);
+            buffer.limit(_inputEnd);
             try {
-                channel.write(_inputBuffer);
+                channel.write(buffer);
             } catch (IOException e) {
                 throw _wrapIOFailure(e);
             }

--- a/src/main/java/tools/jackson/core/json/async/NonBlockingByteBufferJsonParser.java
+++ b/src/main/java/tools/jackson/core/json/async/NonBlockingByteBufferJsonParser.java
@@ -2,6 +2,7 @@ package tools.jackson.core.json.async;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.channels.Channels;
 import java.nio.channels.WritableByteChannel;
@@ -81,8 +82,10 @@ public class NonBlockingByteBufferJsonParser
         if (avail > 0) {
             final WritableByteChannel channel = Channels.newChannel(out);
             final ByteBuffer buffer = _inputBuffer.duplicate();
-            buffer.position(_inputPtr);
-            buffer.limit(_inputEnd);
+            // Use Buffer methods for Java 8/Android signature compatibility.
+            final Buffer baseBuffer = buffer;
+            baseBuffer.position(_inputPtr);
+            baseBuffer.limit(_inputEnd);
             try {
                 channel.write(buffer);
             } catch (IOException e) {

--- a/src/test/java/tools/jackson/core/unittest/json/async/AsyncParserConfigTest.java
+++ b/src/test/java/tools/jackson/core/unittest/json/async/AsyncParserConfigTest.java
@@ -39,4 +39,21 @@ class AsyncParserConfigTest extends AsyncTestBase
 
         p.close();
     }
+
+    @Test
+    void asyncByteBufferReleaseBuffered() throws IOException
+    {
+        byte[] data = _jsonDoc("[true,false]");
+        AsyncReaderWrapper r = asyncForByteBuffer(DEFAULT_F, 100, data, 0);
+        JsonParser p = r.parser();
+
+        assertToken(JsonToken.START_ARRAY, r.nextToken());
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        byte[] expected = utf8Bytes("true,false]");
+        assertEquals(expected.length, p.releaseBuffered(out));
+        assertArrayEquals(expected, out.toByteArray());
+
+        p.close();
+    }
 }

--- a/src/test/java/tools/jackson/core/unittest/json/async/AsyncParserConfigTest.java
+++ b/src/test/java/tools/jackson/core/unittest/json/async/AsyncParserConfigTest.java
@@ -1,11 +1,14 @@
 package tools.jackson.core.unittest.json.async;
 
 import java.io.*;
+import java.nio.ByteBuffer;
 
 import org.junit.jupiter.api.Test;
 
 import tools.jackson.core.JsonParser;
 import tools.jackson.core.JsonToken;
+import tools.jackson.core.ObjectReadContext;
+import tools.jackson.core.async.ByteBufferFeeder;
 import tools.jackson.core.json.JsonFactory;
 import tools.jackson.core.unittest.async.AsyncTestBase;
 import tools.jackson.core.unittest.testutil.AsyncReaderWrapper;
@@ -40,19 +43,35 @@ class AsyncParserConfigTest extends AsyncTestBase
         p.close();
     }
 
+    // [core#1646]: must only release unconsumed bytes
     @Test
     void asyncByteBufferReleaseBuffered() throws IOException
     {
-        byte[] data = _jsonDoc("[true,false]");
-        AsyncReaderWrapper r = asyncForByteBuffer(DEFAULT_F, 100, data, 0);
-        JsonParser p = r.parser();
+        _testByteBufferReleaseBuffered(0);
+        // and with non-zero offset, to verify absolute-index handling:
+        _testByteBufferReleaseBuffered(3);
+    }
 
-        assertToken(JsonToken.START_ARRAY, r.nextToken());
+    private void _testByteBufferReleaseBuffered(int offset) throws IOException
+    {
+        byte[] data = _jsonDoc("[true,false]");
+        byte[] input = new byte[offset + data.length + offset];
+        System.arraycopy(data, 0, input, offset, data.length);
+        ByteBuffer bb = ByteBuffer.wrap(input, offset, data.length);
+
+        JsonParser p = DEFAULT_F.createNonBlockingByteBufferParser(ObjectReadContext.empty());
+        ((ByteBufferFeeder) p.nonBlockingInputFeeder()).feedInput(bb);
+
+        assertToken(JsonToken.START_ARRAY, p.nextToken());
 
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         byte[] expected = utf8Bytes("true,false]");
         assertEquals(expected.length, p.releaseBuffered(out));
         assertArrayEquals(expected, out.toByteArray());
+
+        // and buffer caller fed must be left as-is
+        assertEquals(offset, bb.position());
+        assertEquals(offset + data.length, bb.limit());
 
         p.close();
     }


### PR DESCRIPTION
Fixes #1646.

`JsonParser.releaseBuffered(OutputStream)` should release buffered input that has been read but not consumed by the parser.

The non-blocking byte-array parser already writes from `_inputPtr` for `_inputEnd - _inputPtr` bytes. The ByteBuffer-backed parser calculated the returned byte count the same way, but wrote the underlying `ByteBuffer` directly. Since this parser reads from the `ByteBuffer` using absolute indexes and tracks progress with `_inputPtr`, the `ByteBuffer`'s own `position()` may still point before the unconsumed range.

As a result, `releaseBuffered()` could return the correct unconsumed byte count while also writing already-consumed bytes.

This change writes using a duplicate `ByteBuffer` view whose position and limit are set to the unconsumed range:

```java
buffer.position(_inputPtr);
buffer.limit(_inputEnd);
```

This preserves the original input buffer state while ensuring that the written bytes match the returned count.

### Tests

Added a regression test for the ByteBuffer-backed non-blocking parser. After reading `START_ARRAY` from `[true,false]`, `releaseBuffered()` now returns and writes only `true,false]`.

Tested with:

```text
./mvnw -q -Dtest=AsyncParserConfigTest "-Dsurefire.useModulePath=false" test
```
