### PR TITLE
Fix #1640: validate numeric value separator in non-root context for non-blocking parser

### DIFF
--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -17,6 +17,10 @@ JSON library.
 
 3.3.0 (not yet released)
 
+#1640: Non-blocking (async) parser does not validate numeric value separator
+  in non-root context (Array/Object), unlike blocking parsers
+ (reported by @seonwooj0810)
+ (fix by @seonwooj0810)
 #1637: Add `JsonPointer.startsWith(JsonPointer)` to check prefix match
  (contributed by @scottslewis)
 #1646: Non-blocking ByteBuffer parser `releaseBuffered()` can write

--- a/src/main/java/tools/jackson/core/json/async/NonBlockingUtf8JsonParserBase.java
+++ b/src/main/java/tools/jackson/core/json/async/NonBlockingUtf8JsonParserBase.java
@@ -1355,6 +1355,8 @@ public abstract class NonBlockingUtf8JsonParserBase
         }
         _setIntLength(outPtr);
         _textBuffer.setCurrentLength(outPtr);
+        // 08-Aug-2026, tatu: [core#1640] Verify separator in both root and non-root context
+        _verifyNumberSeparator(ch);
         return _valueComplete(JsonToken.VALUE_NUMBER_INT);
     }
 
@@ -1422,6 +1424,8 @@ public abstract class NonBlockingUtf8JsonParserBase
         }
         _setIntLength(outPtr-1);
         _textBuffer.setCurrentLength(outPtr);
+        // 08-Aug-2026, tatu: [core#1640] Verify separator in both root and non-root context
+        _verifyNumberSeparator(ch & 0xFF);
         return _valueComplete(JsonToken.VALUE_NUMBER_INT);
     }
 
@@ -1495,6 +1499,8 @@ public abstract class NonBlockingUtf8JsonParserBase
         }
         _setIntLength(outPtr-1);
         _textBuffer.setCurrentLength(outPtr);
+        // 08-Aug-2026, tatu: [core#1640] Verify separator in both root and non-root context
+        _verifyNumberSeparator(ch & 0xFF);
         return _valueComplete(JsonToken.VALUE_NUMBER_INT);
     }
 
@@ -1797,9 +1803,8 @@ public abstract class NonBlockingUtf8JsonParserBase
         final int hexLen = outPtr - prefixLen;
         // As per #105, need separating space between root values; check here.
         // Note: _inputPtr currently points AT the terminator (we did not consume it).
-        if (_streamReadContext.inRoot()) {
-            _verifyRootSpace(getByteFromBuffer(_inputPtr) & 0xFF);
-        }
+        // 08-Aug-2026, tatu: [core#1640] Also verify separator in non-root context (#1615)
+        _verifyNumberSeparator(getByteFromBuffer(_inputPtr) & 0xFF);
         resetIntHex(_numberNegative, hexLen);
         return _valueComplete(JsonToken.VALUE_NUMBER_INT);
     }
@@ -1857,9 +1862,8 @@ public abstract class NonBlockingUtf8JsonParserBase
         _setIntLength(outPtr+negMod);
         _textBuffer.setCurrentLength(outPtr);
         // As per #105, need separating space between root values; check here
-        if (_streamReadContext.inRoot()) {
-            _verifyRootSpace(ch);
-        }
+        // 08-Aug-2026, tatu: [core#1640] Also verify separator in non-root context (#1615)
+        _verifyNumberSeparator(ch);
         return _valueComplete(JsonToken.VALUE_NUMBER_INT);
     }
 
@@ -1950,9 +1954,8 @@ public abstract class NonBlockingUtf8JsonParserBase
         _textBuffer.setCurrentLength(outPtr);
         // negative, int-length, fract-length already set, so...
         // As per #105, need separating space between root values; check here
-        if (_streamReadContext.inRoot()) {
-            _verifyRootSpace(ch);
-        }
+        // 08-Aug-2026, tatu: [core#1640] Also verify separator in non-root context (#1615)
+        _verifyNumberSeparator(ch);
         _setExpLength(expLen);
         return _valueComplete(JsonToken.VALUE_NUMBER_FLOAT);
     }
@@ -2022,9 +2025,8 @@ public abstract class NonBlockingUtf8JsonParserBase
         // negative, int-length, fract-length already set, so...
         _expLength = 0;
         // As per #105, need separating space between root values; check here
-        if (_streamReadContext.inRoot()) {
-            _verifyRootSpace(ch);
-        }
+        // 08-Aug-2026, tatu: [core#1640] Also verify separator in non-root context (#1615)
+        _verifyNumberSeparator(ch & 0xFF);
         return _valueComplete(JsonToken.VALUE_NUMBER_FLOAT);
     }
 
@@ -2070,9 +2072,8 @@ public abstract class NonBlockingUtf8JsonParserBase
         _textBuffer.setCurrentLength(outPtr);
         // negative, int-length, fract-length already set, so...
         // As per #105, need separating space between root values; check here
-        if (_streamReadContext.inRoot()) {
-            _verifyRootSpace(ch);
-        }
+        // 08-Aug-2026, tatu: [core#1640] Also verify separator in non-root context (#1615)
+        _verifyNumberSeparator(ch);
         _setExpLength(expLen);
         return _valueComplete(JsonToken.VALUE_NUMBER_FLOAT);
     }
@@ -3312,6 +3313,54 @@ public abstract class NonBlockingUtf8JsonParserBase
             _reportInvalidOther(f & 0xFF, _inputPtr);
         }
         return ((c << 6) | (f & 0x3F)) - 0x10000;
+    }
+
+    /**
+     * Method called to verify that a number value is followed by a valid separator
+     * (whitespace, comma, closing bracket or brace) when not at root level, or by
+     * whitespace when at root level.
+     *<p>
+     * NOTE: caller MUST ensure there is at least one character available;
+     * and that input pointer is AT given char (not past). For non-root contexts,
+     * the separator is left unconsumed (so the outer loop can handle it).
+     *
+     * @param ch Character after number value (unsigned byte, 0-255)
+     *
+     * @throws JacksonException for decoding problems (unexpected character)
+     *
+     * @since 3.3
+     */
+    // 08-Aug-2026, tatu: [core#1640] Non-root check, equivalent to blocking parsers (see #1615)
+    private final void _verifyNumberSeparator(int ch) throws JacksonException {
+        if (_streamReadContext.inRoot()) {
+            _verifyRootSpace(ch);
+            return;
+        }
+        switch (ch) {
+        case ' ':
+        case '\t':
+        case '\r':
+        case '\n':
+        case ',':
+        case ']':
+        case '}':
+            return;
+        case '/':
+            if (isEnabled(JsonReadFeature.ALLOW_JAVA_COMMENTS)) {
+                return;
+            }
+            break;
+        case '#':
+            if (isEnabled(JsonReadFeature.ALLOW_YAML_COMMENTS)) {
+                return;
+            }
+            break;
+        }
+        ++_inputPtr;
+        if (ch == '/') {
+            _reportUnexpectedChar(ch, "maybe a (non-standard) comment? (not recognized as one since Feature 'ALLOW_COMMENTS' not enabled for parser)");
+        }
+        _reportUnexpectedChar(ch, "Expected space, comma or closing bracket/brace after numeric value");
     }
 
     /**

--- a/src/test/java/tools/jackson/core/unittest/json/async/AsyncNumberSeparator1640Test.java
+++ b/src/test/java/tools/jackson/core/unittest/json/async/AsyncNumberSeparator1640Test.java
@@ -1,0 +1,97 @@
+package tools.jackson.core.unittest.json.async;
+
+import org.junit.jupiter.api.Test;
+
+import tools.jackson.core.JsonToken;
+import tools.jackson.core.exc.StreamReadException;
+import tools.jackson.core.json.JsonFactory;
+import tools.jackson.core.unittest.async.AsyncTestBase;
+import tools.jackson.core.unittest.testutil.AsyncReaderWrapper;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+// Tests for [core#1640]: non-blocking (async) parser should reject numeric values
+// not followed by a valid separator in non-root context, matching blocking parsers (#1615).
+class AsyncNumberSeparator1640Test extends AsyncTestBase
+{
+    private final JsonFactory JSON_F = new JsonFactory();
+
+    @Test
+    void mangledIntInArray() throws Exception {
+        for (int readSize : new int[]{90, 3, 1}) {
+            _testMangledNumber("[123true]", readSize);
+            _testMangledNumber("[123false]", readSize);
+            _testMangledNumber("[123null]", readSize);
+            _testMangledNumber("[-99z]", readSize);
+        }
+    }
+
+    @Test
+    void mangledFloatFractionInArray() throws Exception {
+        for (int readSize : new int[]{90, 3, 1}) {
+            _testMangledNumber("[1.5true]", readSize);
+            _testMangledNumber("[0.25x]", readSize);
+        }
+    }
+
+    @Test
+    void mangledFloatExponentInArray() throws Exception {
+        for (int readSize : new int[]{90, 3, 1}) {
+            _testMangledNumber("[1.5e2x]", readSize);
+            _testMangledNumber("[9e3k]", readSize);
+            _testMangledNumber("[1e10z]", readSize);
+        }
+    }
+
+    // Valid JSON should still parse without error
+    @Test
+    void validSeparatorsInArray() throws Exception {
+        for (int readSize : new int[]{90, 3, 1}) {
+            _testValidInt("[123]", 123, readSize);
+            _testValidInt("[123,456]", 123, readSize);
+            _testValidInt("[ 123 ]", 123, readSize);
+            _testValidDouble("[1.5]", 1.5, readSize);
+            _testValidDouble("[1.5,2.5]", 1.5, readSize);
+            _testValidDouble("[1.5e2]", 150.0, readSize);
+            _testValidDouble("[ 1.5e2 ]", 150.0, readSize);
+        }
+    }
+
+    private void _testMangledNumber(String doc, int readSize) throws Exception {
+        _testMangledNumber(doc, readSize, "Expected space");
+    }
+
+    private void _testMangledNumber(String doc, int readSize, String expectedMsg) throws Exception
+    {
+        byte[] input = _jsonDoc(doc);
+        try (AsyncReaderWrapper p = asyncForBytes(JSON_F, readSize, input, 0)) {
+            assertToken(JsonToken.START_ARRAY, p.nextToken());
+            try {
+                JsonToken t = p.nextToken();
+                fail("Should have failed on '" + doc + "' (readSize=" + readSize + "); got: " + t);
+            } catch (StreamReadException e) {
+                verifyException(e, expectedMsg);
+            }
+        }
+    }
+
+    private void _testValidInt(String doc, int expected, int readSize) throws Exception {
+        byte[] input = _jsonDoc(doc);
+        try (AsyncReaderWrapper p = asyncForBytes(JSON_F, readSize, input, 0)) {
+            assertToken(JsonToken.START_ARRAY, p.nextToken());
+            assertToken(JsonToken.VALUE_NUMBER_INT, p.nextToken());
+            assertEquals(expected, p.getIntValue(),
+                    "Int value mismatch for '" + doc + "' (readSize=" + readSize + ")");
+        }
+    }
+
+    private void _testValidDouble(String doc, double expected, int readSize) throws Exception {
+        byte[] input = _jsonDoc(doc);
+        try (AsyncReaderWrapper p = asyncForBytes(JSON_F, readSize, input, 0)) {
+            assertToken(JsonToken.START_ARRAY, p.nextToken());
+            assertToken(JsonToken.VALUE_NUMBER_FLOAT, p.nextToken());
+            assertEquals(expected, p.getDoubleValue(), 0.001,
+                    "Double value mismatch for '" + doc + "' (readSize=" + readSize + ")");
+        }
+    }
+}

--- a/src/test/java/tools/jackson/core/unittest/tofix/async/AsyncTokenBranchNumberErrorTest.java
+++ b/src/test/java/tools/jackson/core/unittest/tofix/async/AsyncTokenBranchNumberErrorTest.java
@@ -17,7 +17,6 @@ class AsyncTokenBranchNumberErrorTest extends AsyncTestBase
 {
     private final JsonFactory JSON_F = newStreamFactory();
 
-    @JacksonTestFailureExpected
     @Test
     void mangledNonRootInts() throws Exception
     {


### PR DESCRIPTION
## Summary

Follow-up to #1615 (which fixed the three blocking parsers) and per @cowtowncoder's comment in that PR confirming a separate fix for the non-blocking path is warranted.

The non-blocking (`async`) parser did not verify that numeric values are followed by a valid separator (whitespace, comma, `]`, `}`) when parsed inside an Array or Object context, silently accepting malformed inputs that blocking parsers rejected:

```java
// Blocking parsers (fixed in #1615): correctly throw
// Async parser (this PR): previously returned VALUE_NUMBER_INT
JsonParser p = factory.createNonBlockingByteArrayParser(...);
feeder.feedInput(new byte[]{'[','1','2','3','t','r','u','e',']'}, 0, 9);
feeder.endOfInput();
p.nextToken(); // START_ARRAY
p.nextToken(); // was VALUE_NUMBER_INT, should throw StreamReadException
```

## Root cause

Five integer-completion sites and three float-completion sites in `NonBlockingUtf8JsonParserBase` called `_valueComplete(JsonToken.VALUE_NUMBER_*)` without a separator check:

- `_startPositiveNumber(int ch)` — inline digit loop
- `_startNegativeNumber()` — inline digit loop
- `_startPositiveNumber()` — inline digit loop (+ sign variant)
- `_finishNumberIntegralPart(...)` — resumption path (chunk boundary)
- Hex number completion (via `resetIntHex`)
- `_startFloat(...)` — inline fraction/exponent loop
- `_finishFloatFraction()` — resumption path (fraction digits)
- `_finishFloatExponent(...)` — resumption path (exponent digits)

## Fix

Adds `_verifyNumberSeparator(int ch)` to `NonBlockingUtf8JsonParserBase`, mirroring the same method added to the three blocking parsers in #1615. For root context it delegates to the existing `_verifyRootSpace(ch)`; for non-root context it validates the separator is one of ` \t\r\n,]}` (or a comment-start character if the respective feature is enabled), consistent with the blocking-parser behavior.

All 8 completion sites now call `_verifyNumberSeparator(ch)` before `_valueComplete(...)`.

## Testing

- New test class `AsyncNumberSeparator1640Test` covering int, float-fraction, and float-exponent mangled cases across `bytesPerRead` values of 90, 3, and 1 (to exercise both inline and resumption paths).
- `AsyncTokenBranchNumberErrorTest.mangledNonRootInts` in `tofix/` now passes; removed its `@JacksonTestFailureExpected` annotation. The `mangledNonRootFloats` test remains in `tofix/` (the 'f'/'d' suffix case still uses a dedicated code path with a different error message).
- Full test suite: 1813 tests, 0 failures, 0 errors.

Fixes #1640