### PR TITLE
Fix object context handling for buffered `INCLUDE_NON_NULL` tokens

### DIFF
--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -54,3 +54,7 @@ Revanth Meesala (@revanthmeesala)
  * Contributed #1643: Enforce maxNameLength incrementally in ReaderBasedJsonParser
    [GHSA-649p-m576-vr99]
   (3.1.6)
+
+Lee Dongnyoung (@DongNyoung)
+ * Contributed #1651: Fix object context handling for buffered `INCLUDE_NON_NULL` tokens
+  (3.1.6)

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -26,6 +26,8 @@ JSON library.
  (fix by Revanth M)
 #1643: Enforce maxNameLength incrementally in ReaderBasedJsonParser [CVE-2026-68498]
  (fix by @tinyb0y)
+#1651: Fix object context handling for buffered `INCLUDE_NON_NULL` tokens
+ (contributed by @Dongnyoung)
 
 3.1.5 (07-Jul-2026)
 

--- a/src/main/java/tools/jackson/core/filter/FilteringParserDelegate.java
+++ b/src/main/java/tools/jackson/core/filter/FilteringParserDelegate.java
@@ -763,7 +763,7 @@ public class FilteringParserDelegate extends JsonParserDelegate
                     return _nextBuffered(buffRoot);
                 } else if (f != null && _inclusion == Inclusion.INCLUDE_NON_NULL) {
                     // TODO don't count as match?
-                    _headContext = _headContext.createChildArrayContext(f, null, true);
+                    _headContext = _headContext.createChildObjectContext(f, null, true);
                     return _nextBuffered(buffRoot);
                 }
                 _headContext = _headContext.createChildObjectContext(f, null, false);

--- a/src/main/java/tools/jackson/core/filter/FilteringParserDelegate.java
+++ b/src/main/java/tools/jackson/core/filter/FilteringParserDelegate.java
@@ -741,8 +741,10 @@ public class FilteringParserDelegate extends JsonParserDelegate
             case ID_START_OBJECT:
                 f = _itemFilter;
                 if (f == TokenFilter.INCLUDE_ALL) {
+                    // 14-Aug-2026, tatu: [core#1651] Must replay buffered tokens
+                    //    (like enclosing Property name), not just return START_OBJECT
                     _headContext = _headContext.createChildObjectContext(f, null, true);
-                    return t;
+                    return _nextBuffered(buffRoot);
                 }
                 if (f == null) { // does this occur?
                     delegate.skipChildren();

--- a/src/test/java/tools/jackson/core/unittest/filter/BasicParserFilteringTest.java
+++ b/src/test/java/tools/jackson/core/unittest/filter/BasicParserFilteringTest.java
@@ -472,8 +472,8 @@ class BasicParserFilteringTest extends JacksonCoreTestBase
     @Test
     void includeNonNullWithNestedObjectContext() throws Exception
     {
-        JsonParser p0 = JSON_F.createParser(ObjectReadContext.empty(), """
-                {"a":{"b":1}}""");
+        JsonParser p0 = JSON_F.createParser(ObjectReadContext.empty(),
+                a2q("{'a':{'b':1}}"));
         JsonParser p = new FilteringParserDelegate(p0,
                 new TokenFilter() { },
                 Inclusion.INCLUDE_NON_NULL,

--- a/src/test/java/tools/jackson/core/unittest/filter/BasicParserFilteringTest.java
+++ b/src/test/java/tools/jackson/core/unittest/filter/BasicParserFilteringTest.java
@@ -501,6 +501,20 @@ class BasicParserFilteringTest extends JacksonCoreTestBase
         assertNull(p.nextToken());
     }
 
+    // [core#1651]: buffered START_OBJECT with INCLUDE_ALL filter must replay
+    // the enclosing (buffered) Property name
+    @Test
+    void includeNonNullWithBufferedIncludeAllObject() throws Exception
+    {
+        JsonParser p0 = JSON_F.createParser(ObjectReadContext.empty(),
+                a2q("{'a':{'b':1}}"));
+        FilteringParserDelegate p = new FilteringParserDelegate(p0,
+                new StrictNameMatchFilter("a"),
+                Inclusion.INCLUDE_NON_NULL, true);
+        String result = readAndWrite(JSON_F, p);
+        assertEquals(a2q("{'a':{'b':1}}"), result);
+    }
+
     @Test
     void noMatchFiltering1() throws Exception
     {

--- a/src/test/java/tools/jackson/core/unittest/filter/BasicParserFilteringTest.java
+++ b/src/test/java/tools/jackson/core/unittest/filter/BasicParserFilteringTest.java
@@ -470,6 +470,38 @@ class BasicParserFilteringTest extends JacksonCoreTestBase
     }
 
     @Test
+    void includeNonNullWithNestedObjectContext() throws Exception
+    {
+        JsonParser p0 = JSON_F.createParser(ObjectReadContext.empty(), """
+                {"a":{"b":1}}""");
+        JsonParser p = new FilteringParserDelegate(p0,
+                new TokenFilter() { },
+                Inclusion.INCLUDE_NON_NULL,
+                true // multipleMatches
+        );
+
+        assertToken(JsonToken.START_OBJECT, p.nextToken());
+        assertTrue(p.streamReadContext().inObject());
+
+        assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
+        assertEquals("a", p.currentName());
+
+        assertToken(JsonToken.START_OBJECT, p.nextToken());
+        assertTrue(p.streamReadContext().inObject());
+        assertEquals("a", p.currentName());
+
+        assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
+        assertEquals("b", p.currentName());
+
+        assertToken(JsonToken.VALUE_NUMBER_INT, p.nextToken());
+        assertEquals(1, p.getIntValue());
+
+        assertToken(JsonToken.END_OBJECT, p.nextToken());
+        assertToken(JsonToken.END_OBJECT, p.nextToken());
+        assertNull(p.nextToken());
+    }
+
+    @Test
     void noMatchFiltering1() throws Exception
     {
         String jsonString = a2q("{'a':123,'array':[1,2],'ob':{'value0':2,'value':3,'value2':4},'b':true}");


### PR DESCRIPTION
## Summary

Fixes a `FilteringParserDelegate` buffering path that handled a `START_OBJECT`
token by creating an array context when using `TokenFilter.Inclusion.INCLUDE_NON_NULL`.

This could leave the exposed parser context inconsistent with the current token:
the parser returned `START_OBJECT`, but `streamReadContext()` reported an array
context. In nested object cases this could also lead to an internal buffering
error.

## Changes

- Add regression coverage for `INCLUDE_NON_NULL` with a nested object.
- Change the buffered `START_OBJECT` / `INCLUDE_NON_NULL` path to create an
  object context instead of an array context.

## Testing

```powershell
.\mvnw.cmd "-Dtest=BasicParserFilteringTest,ParserFilterEmpty1418Test,ParserFilterEmpty708Test,ParserFiltering700Test" "-Dsurefire.useModulePath=false" test
Result: 59 tests passed.