### PR TITLE
Add lifecycle and bounded-capacity coverage for BufferRecycler pools

### DIFF
--- a/src/test/java/tools/jackson/core/unittest/io/BufferRecyclerPoolTest.java
+++ b/src/test/java/tools/jackson/core/unittest/io/BufferRecyclerPoolTest.java
@@ -3,7 +3,9 @@ package tools.jackson.core.unittest.io;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.ArrayList;
+import java.util.Set;
 import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.jupiter.api.Test;
 
@@ -11,7 +13,6 @@ import tools.jackson.core.JsonGenerator;
 import tools.jackson.core.JsonParser;
 import tools.jackson.core.ObjectWriteContext;
 import tools.jackson.core.base.GeneratorBase;
-import tools.jackson.core.io.IOContext;
 import tools.jackson.core.json.JsonFactory;
 import tools.jackson.core.unittest.*;
 import tools.jackson.core.util.BufferRecycler;
@@ -111,17 +112,15 @@ class BufferRecyclerPoolTest extends JacksonCoreTestBase
 
         JsonGenerator gen = jsonFactory.createGenerator(ObjectWriteContext.empty(),
                 new NopOutputStream());
-        IOContext ioContext = ((GeneratorBase) gen).ioContext();
         gen.writeString("test");
         gen.close();
         gen.close();
-        ioContext.close();
 
         assertEquals(1, pool.pooledCount());
     }
 
     @Test
-    void boundedPoolConcurrentParserGeneratorUseDoesNotExceedCapacity() throws Exception {
+    void boundedPoolConcurrentUseDoesNotShareRecyclers() throws Exception {
         final int capacity = 4;
         final int threadCount = 8;
         final int iterations = 1_000;
@@ -131,6 +130,16 @@ class BufferRecyclerPoolTest extends JacksonCoreTestBase
                 .recyclerPool(pool)
                 .build();
 
+        // Recyclers held by a live generator: pool must never hand the same instance
+        // to two holders at once. `BufferRecycler.withPool()` already throws on an
+        // overlapping acquisition; this tracks it independently, and also covers
+        // sharing that would slip past that linkage check. Identity-based since
+        // `BufferRecycler` does not override equals()/hashCode(). Parsers exercise the
+        // pool too, but only `GeneratorBase` exposes its `IOContext`, so only
+        // generators can be tracked.
+        final Set<BufferRecycler> inUse = ConcurrentHashMap.newKeySet();
+        final AtomicInteger sharedCount = new AtomicInteger();
+
         ExecutorService executor = Executors.newFixedThreadPool(threadCount);
         try {
             ArrayList<Future<?>> futures = new ArrayList<>();
@@ -138,11 +147,18 @@ class BufferRecyclerPoolTest extends JacksonCoreTestBase
                 futures.add(executor.submit(() -> {
                     for (int j = 0; j < iterations; ++j) {
                         read(jsonFactory);
-                        write("test", jsonFactory, 6);
 
-                        if (pool.pooledCount() > capacity) {
-                            throw new IllegalStateException("Bounded pool exceeded capacity");
+                        NopOutputStream out = new NopOutputStream();
+                        JsonGenerator gen = jsonFactory.createGenerator(
+                                ObjectWriteContext.empty(), out);
+                        BufferRecycler br = ((GeneratorBase) gen).ioContext().bufferRecycler();
+                        if (!inUse.add(br)) {
+                            sharedCount.incrementAndGet();
                         }
+                        gen.writeString("test");
+                        // Must stop tracking before close(), which returns it to the pool
+                        inUse.remove(br);
+                        gen.close();
                     }
                     return null;
                 }));
@@ -155,7 +171,13 @@ class BufferRecyclerPoolTest extends JacksonCoreTestBase
             executor.shutdownNow();
         }
 
-        assertTrue(pool.pooledCount() <= capacity);
+        assertEquals(0, sharedCount.get(),
+                "BufferRecycler handed out to more than one holder at a time");
+        assertEquals(0, inUse.size());
+        // Bounded queue must retain releases, up to but not beyond capacity
+        int pooled = pool.pooledCount();
+        assertTrue(pooled > 0 && pooled <= capacity,
+                "Unexpected pooledCount(): "+pooled);
     }
 
     @Test

--- a/src/test/java/tools/jackson/core/unittest/io/BufferRecyclerPoolTest.java
+++ b/src/test/java/tools/jackson/core/unittest/io/BufferRecyclerPoolTest.java
@@ -41,6 +41,37 @@ class BufferRecyclerPoolTest extends JacksonCoreTestBase
     }
 
     @Test
+    void boundedPoolDoesNotExceedCapacity() {
+        RecyclerPool<BufferRecycler> pool = JsonRecyclerPools.newBoundedPool(2);
+
+        BufferRecycler br1 = pool.acquireAndLinkPooled();
+        BufferRecycler br2 = pool.acquireAndLinkPooled();
+        BufferRecycler br3 = pool.acquireAndLinkPooled();
+
+        br1.releaseToPool();
+        br2.releaseToPool();
+        br3.releaseToPool();
+
+        assertEquals(2, pool.pooledCount());
+    }
+
+    @Test
+    void boundedPoolClearDropsRetainedRecyclers() {
+        RecyclerPool<BufferRecycler> pool = JsonRecyclerPools.newBoundedPool(2);
+
+        BufferRecycler br1 = pool.acquireAndLinkPooled();
+        BufferRecycler br2 = pool.acquireAndLinkPooled();
+
+        br1.releaseToPool();
+        br2.releaseToPool();
+
+        assertEquals(2, pool.pooledCount());
+
+        assertTrue(pool.clear());
+        assertEquals(0, pool.pooledCount());
+    }
+
+    @Test
     void pluggingPool() throws Exception {
         checkBufferRecyclerPoolImpl(new TestPool(), true, true);
     }

--- a/src/test/java/tools/jackson/core/unittest/io/BufferRecyclerPoolTest.java
+++ b/src/test/java/tools/jackson/core/unittest/io/BufferRecyclerPoolTest.java
@@ -2,6 +2,8 @@ package tools.jackson.core.unittest.io;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.concurrent.*;
 
 import org.junit.jupiter.api.Test;
 
@@ -119,6 +121,44 @@ class BufferRecyclerPoolTest extends JacksonCoreTestBase
     }
 
     @Test
+    void boundedPoolConcurrentParserGeneratorUseDoesNotExceedCapacity() throws Exception {
+        final int capacity = 4;
+        final int threadCount = 8;
+        final int iterations = 1_000;
+
+        RecyclerPool<BufferRecycler> pool = JsonRecyclerPools.newBoundedPool(capacity);
+        JsonFactory jsonFactory = JsonFactory.builder()
+                .recyclerPool(pool)
+                .build();
+
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        try {
+            ArrayList<Future<?>> futures = new ArrayList<>();
+            for (int i = 0; i < threadCount; ++i) {
+                futures.add(executor.submit(() -> {
+                    for (int j = 0; j < iterations; ++j) {
+                        read(jsonFactory);
+                        write("test", jsonFactory, 6);
+
+                        if (pool.pooledCount() > capacity) {
+                            throw new IllegalStateException("Bounded pool exceeded capacity");
+                        }
+                    }
+                    return null;
+                }));
+            }
+
+            for (Future<?> future : futures) {
+                future.get();
+            }
+        } finally {
+            executor.shutdownNow();
+        }
+
+        assertTrue(pool.pooledCount() <= capacity);
+    }
+
+    @Test
     void pluggingPool() throws Exception {
         checkBufferRecyclerPoolImpl(new TestPool(), true, true);
     }
@@ -152,6 +192,13 @@ class BufferRecyclerPoolTest extends JacksonCoreTestBase
             assertNotSame(usedBufferRecycler, br2);
         } else {
             assertFalse(pool.clear());
+        }
+    }
+
+    private void read(JsonFactory jsonFactory) throws Exception {
+        try (JsonParser p = createParser(jsonFactory, MODE_INPUT_STREAM,
+                a2q("{'a':123,'b':'foobar'}"))) {
+            while (p.nextToken() != null) { }
         }
     }
 

--- a/src/test/java/tools/jackson/core/unittest/io/BufferRecyclerPoolTest.java
+++ b/src/test/java/tools/jackson/core/unittest/io/BufferRecyclerPoolTest.java
@@ -87,37 +87,8 @@ class BufferRecyclerPoolTest extends JacksonCoreTestBase
         assertEquals(1, pool.pooledCount());
     }
 
-    @Test
-    void parserCloseReleasesRecyclerOnce() throws Exception {
-        TestPool pool = new TestPool();
-        JsonFactory jsonFactory = JsonFactory.builder()
-                .recyclerPool(pool)
-                .build();
-
-        JsonParser p = createParser(jsonFactory, MODE_INPUT_STREAM,
-                a2q("{'a':123,'b':'foobar'}"));
-        p.nextToken();
-        p.close();
-        p.close();
-
-        assertEquals(1, pool.pooledCount());
-    }
-
-    @Test
-    void generatorCloseReleasesRecyclerOnce() throws Exception {
-        TestPool pool = new TestPool();
-        JsonFactory jsonFactory = JsonFactory.builder()
-                .recyclerPool(pool)
-                .build();
-
-        JsonGenerator gen = jsonFactory.createGenerator(ObjectWriteContext.empty(),
-                new NopOutputStream());
-        gen.writeString("test");
-        gen.close();
-        gen.close();
-
-        assertEquals(1, pool.pooledCount());
-    }
+    // NOTE: parser/generator close() releasing the recycler exactly once is covered
+    // by `JsonBufferRecyclersTest`, for all pool implementations
 
     @Test
     void boundedPoolConcurrentUseDoesNotShareRecyclers() throws Exception {

--- a/src/test/java/tools/jackson/core/unittest/io/BufferRecyclerPoolTest.java
+++ b/src/test/java/tools/jackson/core/unittest/io/BufferRecyclerPoolTest.java
@@ -6,8 +6,10 @@ import java.io.OutputStream;
 import org.junit.jupiter.api.Test;
 
 import tools.jackson.core.JsonGenerator;
+import tools.jackson.core.JsonParser;
 import tools.jackson.core.ObjectWriteContext;
 import tools.jackson.core.base.GeneratorBase;
+import tools.jackson.core.io.IOContext;
 import tools.jackson.core.json.JsonFactory;
 import tools.jackson.core.unittest.*;
 import tools.jackson.core.util.BufferRecycler;
@@ -69,6 +71,51 @@ class BufferRecyclerPoolTest extends JacksonCoreTestBase
 
         assertTrue(pool.clear());
         assertEquals(0, pool.pooledCount());
+    }
+
+    @Test
+    void bufferRecyclerReleaseToPoolIsIdempotent() {
+        TestPool pool = new TestPool();
+        BufferRecycler recycler = pool.acquireAndLinkPooled();
+
+        recycler.releaseToPool();
+        recycler.releaseToPool();
+
+        assertEquals(1, pool.pooledCount());
+    }
+
+    @Test
+    void parserCloseReleasesRecyclerOnce() throws Exception {
+        TestPool pool = new TestPool();
+        JsonFactory jsonFactory = JsonFactory.builder()
+                .recyclerPool(pool)
+                .build();
+
+        JsonParser p = createParser(jsonFactory, MODE_INPUT_STREAM,
+                a2q("{'a':123,'b':'foobar'}"));
+        p.nextToken();
+        p.close();
+        p.close();
+
+        assertEquals(1, pool.pooledCount());
+    }
+
+    @Test
+    void generatorCloseReleasesRecyclerOnce() throws Exception {
+        TestPool pool = new TestPool();
+        JsonFactory jsonFactory = JsonFactory.builder()
+                .recyclerPool(pool)
+                .build();
+
+        JsonGenerator gen = jsonFactory.createGenerator(ObjectWriteContext.empty(),
+                new NopOutputStream());
+        IOContext ioContext = ((GeneratorBase) gen).ioContext();
+        gen.writeString("test");
+        gen.close();
+        gen.close();
+        ioContext.close();
+
+        assertEquals(1, pool.pooledCount());
     }
 
     @Test

--- a/src/test/java/tools/jackson/core/unittest/util/JsonBufferRecyclersTest.java
+++ b/src/test/java/tools/jackson/core/unittest/util/JsonBufferRecyclersTest.java
@@ -69,7 +69,14 @@ class JsonBufferRecyclersTest extends JacksonCoreTestBase
         assertToken(JsonToken.VALUE_STRING, p.nextToken());
         assertEquals("foobar", p.getString());
         assertToken(JsonToken.END_OBJECT, p.nextToken());
-        
+
+        p.close();
+
+        if (expSizeAfter != null) {
+            assertEquals(expSizeAfter, pool.pooledCount());
+        }
+
+        // Second close() must not release the recycler again
         p.close();
 
         if (expSizeAfter != null) {
@@ -113,12 +120,20 @@ class JsonBufferRecyclersTest extends JacksonCoreTestBase
         }
 
         StringWriter w = new StringWriter();
-        try (JsonGenerator g = jsonF.createGenerator(ObjectWriteContext.empty(), w)) {
+        JsonGenerator g = jsonF.createGenerator(ObjectWriteContext.empty(), w);
+        try (g) {
             g.writeStartObject();
             g.writeNumberProperty("a", -42);
             g.writeStringProperty("b", "barfoo");
             g.writeEndObject();
         }
+
+        if (expSizeAfter != null) {
+            assertEquals(expSizeAfter, pool.pooledCount());
+        }
+
+        // Second close() must not release the recycler again
+        g.close();
 
         if (expSizeAfter != null) {
             assertEquals(expSizeAfter, pool.pooledCount());


### PR DESCRIPTION
### Summary

Add test coverage for `BufferRecycler` pool lifecycle and bounded-pool capacity guarantees.

The existing pool tests cover basic recycler reuse. This adds coverage for a few additional lifecycle and capacity invariants:

* a bounded pool does not retain more recyclers than its configured capacity
* `clear()` removes retained recyclers from a bounded pool
* repeated `BufferRecycler.releaseToPool()` calls do not release the same recycler more than once
* repeated parser / generator close operations do not return the same recycler to the pool multiple times
* concurrent parser and generator use does not cause a bounded pool to retain more recyclers than its configured capacity

### Tests

Added coverage to `BufferRecyclerPoolTest` for:

* bounded pool capacity
* bounded pool clearing
* idempotent `BufferRecycler.releaseToPool()`
* parser and generator close lifecycle
* concurrent parser / generator use with a bounded recycler pool

No production code changes.
