### PR TITLE
Prevent stale symbol table children from replacing newer root tables

### DIFF
--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -67,6 +67,8 @@ DongNyoung Lee (@Dongnyoung)
  * Reported, fixed #1664: UTF-8 byte-backed parsers report raw byte instead of
    decoded character for invalid root-value separator
   (3.3.0)
+ * Reported #1654: Stale symbol table child can replace a newer root table
+  (3.3.0)
 
 seonwoojung (@seonwooj0810)
  * Contributed #707: Add `JsonReadFeature.ALLOW_HEXADECIMAL_NUMBERS`

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -22,6 +22,8 @@ JSON library.
 #1646: Non-blocking ByteBuffer parser `releaseBuffered()` can write
   already-consumed bytes
  (reported, fix by DongNyoung L)
+#1654: Stale symbol table child can replace a newer root table
+ (reported by DongNyoung L)
 #1664: UTF-8 byte-backed parsers report raw byte instead of decoded character
   for invalid root-value separator
  (reported, fix by DongNyoung L)

--- a/src/main/java/tools/jackson/core/sym/ByteQuadsCanonicalizer.java
+++ b/src/main/java/tools/jackson/core/sym/ByteQuadsCanonicalizer.java
@@ -76,7 +76,7 @@ public class ByteQuadsCanonicalizer
      */
     protected final AtomicReference<TableInfo> _tableInfo;
 
-    private final TableInfo _parentTableInfo;
+    private final Object _parentTableInfoId;
 
     /**
      * Seed value we use as the base to make hash codes non-static between
@@ -225,7 +225,7 @@ public class ByteQuadsCanonicalizer
     {
         // Settings to distinguish parent table: no parent
         _parent = null;
-        _parentTableInfo = null;
+        _parentTableInfoId = null;
         _count = 0;
 
         // and mark as shared just in case to prevent modifications
@@ -258,7 +258,7 @@ public class ByteQuadsCanonicalizer
             boolean intern, boolean failOnDoS)
     {
         _parent = parent;
-        _parentTableInfo = state;
+        _parentTableInfoId = state.id;
         _seed = seed;
         _interner = intern ? InternCache.instance : null;
         _failOnDoS = failOnDoS;
@@ -293,7 +293,7 @@ public class ByteQuadsCanonicalizer
     private ByteQuadsCanonicalizer(TableInfo state)
     {
         _parent = null;
-        _parentTableInfo = null;
+        _parentTableInfoId = null;
         _seed = 0;
         _interner = null;
         _failOnDoS = true;
@@ -398,17 +398,18 @@ public class ByteQuadsCanonicalizer
         // we will try to merge if child table has new entries
         // 28-Jul-2019, tatu: From [core#548]: do not share if immediate rehash needed
         if ((_parent != null) && maybeDirty()) {
-            _parent.mergeChild(_parentTableInfo, new TableInfo(this));
+            _parent.mergeChild(_parentTableInfoId, new TableInfo(this));
             // Let's also mark this instance as dirty, so that just in
             // case release was too early, there's no corruption of possibly shared data.
             _hashShared = true;
         }
     }
 
-    private void mergeChild(TableInfo parentState, TableInfo childState)
+    private void mergeChild(Object parentStateId, TableInfo childState)
     {
         final int childCount = childState.count;
         TableInfo currState = _tableInfo.get();
+        final boolean staleChild = (currState.id != parentStateId);
 
         // Should usually grow; but occasionally could also shrink if (but only if)
         // collision list overflow ends up clearing some collision lists.
@@ -421,12 +422,12 @@ public class ByteQuadsCanonicalizer
         // One way to do this is to just purge tables if they grow
         // too large, and that's what we'll do here.
         if (childCount > MAX_ENTRIES_FOR_REUSE) {
-            if (currState != parentState) {
+            if (staleChild) {
                 return;
             }
             // At any rate, need to clean up the tables
             childState = TableInfo.createInitial(DEFAULT_T_SIZE);
-        } else if ((childCount < currState.count) && (currState != parentState)) {
+        } else if ((childCount < currState.count) && staleChild) {
             // Do not let an older child replace a newer, larger table from another child.
             return;
         }
@@ -1429,6 +1430,7 @@ public class ByteQuadsCanonicalizer
      */
     private final static class TableInfo
     {
+        public final Object id = new Object();
         public final int size;
         public final int count;
         public final int tertiaryShift;

--- a/src/main/java/tools/jackson/core/sym/ByteQuadsCanonicalizer.java
+++ b/src/main/java/tools/jackson/core/sym/ByteQuadsCanonicalizer.java
@@ -76,6 +76,8 @@ public class ByteQuadsCanonicalizer
      */
     protected final AtomicReference<TableInfo> _tableInfo;
 
+    private final TableInfo _parentTableInfo;
+
     /**
      * Seed value we use as the base to make hash codes non-static between
      * different runs, but still stable for lifetime of a single symbol table
@@ -223,6 +225,7 @@ public class ByteQuadsCanonicalizer
     {
         // Settings to distinguish parent table: no parent
         _parent = null;
+        _parentTableInfo = null;
         _count = 0;
 
         // and mark as shared just in case to prevent modifications
@@ -255,6 +258,7 @@ public class ByteQuadsCanonicalizer
             boolean intern, boolean failOnDoS)
     {
         _parent = parent;
+        _parentTableInfo = state;
         _seed = seed;
         _interner = intern ? InternCache.instance : null;
         _failOnDoS = failOnDoS;
@@ -289,6 +293,7 @@ public class ByteQuadsCanonicalizer
     private ByteQuadsCanonicalizer(TableInfo state)
     {
         _parent = null;
+        _parentTableInfo = null;
         _seed = 0;
         _interner = null;
         _failOnDoS = true;
@@ -393,14 +398,14 @@ public class ByteQuadsCanonicalizer
         // we will try to merge if child table has new entries
         // 28-Jul-2019, tatu: From [core#548]: do not share if immediate rehash needed
         if ((_parent != null) && maybeDirty()) {
-            _parent.mergeChild(new TableInfo(this));
+            _parent.mergeChild(_parentTableInfo, new TableInfo(this));
             // Let's also mark this instance as dirty, so that just in
             // case release was too early, there's no corruption of possibly shared data.
             _hashShared = true;
         }
     }
 
-    private void mergeChild(TableInfo childState)
+    private void mergeChild(TableInfo parentState, TableInfo childState)
     {
         final int childCount = childState.count;
         TableInfo currState = _tableInfo.get();
@@ -416,8 +421,14 @@ public class ByteQuadsCanonicalizer
         // One way to do this is to just purge tables if they grow
         // too large, and that's what we'll do here.
         if (childCount > MAX_ENTRIES_FOR_REUSE) {
+            if (currState != parentState) {
+                return;
+            }
             // At any rate, need to clean up the tables
             childState = TableInfo.createInitial(DEFAULT_T_SIZE);
+        } else if ((childCount < currState.count) && (currState != parentState)) {
+            // Do not let an older child replace a newer, larger table from another child.
+            return;
         }
         _tableInfo.compareAndSet(currState, childState);
     }

--- a/src/main/java/tools/jackson/core/sym/ByteQuadsCanonicalizer.java
+++ b/src/main/java/tools/jackson/core/sym/ByteQuadsCanonicalizer.java
@@ -76,7 +76,7 @@ public class ByteQuadsCanonicalizer
      */
     protected final AtomicReference<TableInfo> _tableInfo;
 
-    private final Object _parentTableInfoId;
+    private final TableInfo _parentTableInfo;
 
     /**
      * Seed value we use as the base to make hash codes non-static between
@@ -225,7 +225,7 @@ public class ByteQuadsCanonicalizer
     {
         // Settings to distinguish parent table: no parent
         _parent = null;
-        _parentTableInfoId = null;
+        _parentTableInfo = null;
         _count = 0;
 
         // and mark as shared just in case to prevent modifications
@@ -258,7 +258,7 @@ public class ByteQuadsCanonicalizer
             boolean intern, boolean failOnDoS)
     {
         _parent = parent;
-        _parentTableInfoId = state.id;
+        _parentTableInfo = state;
         _seed = seed;
         _interner = intern ? InternCache.instance : null;
         _failOnDoS = failOnDoS;
@@ -293,7 +293,7 @@ public class ByteQuadsCanonicalizer
     private ByteQuadsCanonicalizer(TableInfo state)
     {
         _parent = null;
-        _parentTableInfoId = null;
+        _parentTableInfo = null;
         _seed = 0;
         _interner = null;
         _failOnDoS = true;
@@ -398,40 +398,26 @@ public class ByteQuadsCanonicalizer
         // we will try to merge if child table has new entries
         // 28-Jul-2019, tatu: From [core#548]: do not share if immediate rehash needed
         if ((_parent != null) && maybeDirty()) {
-            _parent.mergeChild(_parentTableInfoId, new TableInfo(this));
+            _parent.mergeChild(_parentTableInfo, new TableInfo(this));
             // Let's also mark this instance as dirty, so that just in
             // case release was too early, there's no corruption of possibly shared data.
             _hashShared = true;
         }
     }
 
-    private void mergeChild(Object parentStateId, TableInfo childState)
+    private void mergeChild(TableInfo parentState, TableInfo childState)
     {
-        final int childCount = childState.count;
-        TableInfo currState = _tableInfo.get();
-        final boolean staleChild = (currState.id != parentStateId);
-
-        // Should usually grow; but occasionally could also shrink if (but only if)
-        // collision list overflow ends up clearing some collision lists.
-        if (childCount == currState.count) {
-            return;
-        }
-
         // One caveat: let's try to avoid problems with degenerate cases of documents with
         // generated "random" names: for these, symbol tables would bloat indefinitely.
         // One way to do this is to just purge tables if they grow
         // too large, and that's what we'll do here.
-        if (childCount > MAX_ENTRIES_FOR_REUSE) {
-            if (staleChild) {
-                return;
-            }
-            // At any rate, need to clean up the tables
+        if (childState.count > MAX_ENTRIES_FOR_REUSE) {
             childState = TableInfo.createInitial(DEFAULT_T_SIZE);
-        } else if ((childCount < currState.count) && staleChild) {
-            // Do not let an older child replace a newer, larger table from another child.
-            return;
         }
-        _tableInfo.compareAndSet(currState, childState);
+        // Only replace the exact state this child was forked from: if another child has
+        // merged in the meantime, its table is newer and ours is simply dropped rather
+        // than clobbering it (which could lose names, or shrink the table).
+        _tableInfo.compareAndSet(parentState, childState);
     }
 
     /*
@@ -1430,7 +1416,6 @@ public class ByteQuadsCanonicalizer
      */
     private final static class TableInfo
     {
-        public final Object id = new Object();
         public final int size;
         public final int count;
         public final int tertiaryShift;

--- a/src/main/java/tools/jackson/core/sym/CharsToNameCanonicalizer.java
+++ b/src/main/java/tools/jackson/core/sym/CharsToNameCanonicalizer.java
@@ -111,7 +111,7 @@ public final class CharsToNameCanonicalizer
      */
     protected final AtomicReference<TableInfo> _tableInfo;
 
-    private final TableInfo _parentTableInfo;
+    private final Object _parentTableInfoId;
 
     /**
      * Constraints used by {@link TokenStreamFactory} that uses
@@ -238,7 +238,7 @@ public final class CharsToNameCanonicalizer
             int seed)
     {
         _parent = null;
-        _parentTableInfo = null;
+        _parentTableInfoId = null;
         _seed = seed;
         _streamReadConstraints = src;
 
@@ -262,7 +262,7 @@ public final class CharsToNameCanonicalizer
             TableInfo parentState)
     {
         _parent = parent;
-        _parentTableInfo = parentState;
+        _parentTableInfoId = parentState.id;
         _streamReadConstraints = src;
         _seed = seed;
         _tableInfo = null; // not used by child tables
@@ -358,7 +358,7 @@ public final class CharsToNameCanonicalizer
 
         // we will try to merge if child table has new entries
         if (_parent != null && _canonicalize) { // canonicalize set to false if max size was reached
-            _parent.mergeChild(_parentTableInfo, new TableInfo(this));
+            _parent.mergeChild(_parentTableInfoId, new TableInfo(this));
             // Let's also mark this instance as dirty, so that just in
             // case release was too early, there's no corruption of possibly shared data.
             _hashShared = true;
@@ -372,10 +372,11 @@ public final class CharsToNameCanonicalizer
      * Note that caller has to make sure symbol table passed in is
      * really a child or sibling of this symbol table.
      */
-    private void mergeChild(TableInfo parentState, TableInfo childState)
+    private void mergeChild(Object parentStateId, TableInfo childState)
     {
         final int childCount = childState.size;
         TableInfo currState = _tableInfo.get();
+        final boolean staleChild = (currState.id != parentStateId);
 
         // Should usually grow; but occasionally could also shrink if (but only if)
         // collision list overflow ends up clearing some collision lists.
@@ -387,12 +388,12 @@ public final class CharsToNameCanonicalizer
         // One way to do this is to just purge tables if they grow
         // too large, and that's what we'll do here.
         if (childCount > MAX_ENTRIES_FOR_REUSE) {
-            if (currState != parentState) {
+            if (staleChild) {
                 return;
             }
             // At any rate, need to clean up the tables
             childState = TableInfo.createInitial(DEFAULT_T_SIZE);
-        } else if ((childCount < currState.size) && (currState != parentState)) {
+        } else if ((childCount < currState.size) && staleChild) {
             // Do not let an older child replace a newer, larger table from another child.
             return;
         }
@@ -878,6 +879,7 @@ public final class CharsToNameCanonicalizer
      */
     private final static class TableInfo
     {
+        final Object id = new Object();
         final int size;
         final int longestCollisionList;
         final String[] symbols;

--- a/src/main/java/tools/jackson/core/sym/CharsToNameCanonicalizer.java
+++ b/src/main/java/tools/jackson/core/sym/CharsToNameCanonicalizer.java
@@ -111,7 +111,7 @@ public final class CharsToNameCanonicalizer
      */
     protected final AtomicReference<TableInfo> _tableInfo;
 
-    private final Object _parentTableInfoId;
+    private final TableInfo _parentTableInfo;
 
     /**
      * Constraints used by {@link TokenStreamFactory} that uses
@@ -238,7 +238,7 @@ public final class CharsToNameCanonicalizer
             int seed)
     {
         _parent = null;
-        _parentTableInfoId = null;
+        _parentTableInfo = null;
         _seed = seed;
         _streamReadConstraints = src;
 
@@ -262,7 +262,7 @@ public final class CharsToNameCanonicalizer
             TableInfo parentState)
     {
         _parent = parent;
-        _parentTableInfoId = parentState.id;
+        _parentTableInfo = parentState;
         _streamReadConstraints = src;
         _seed = seed;
         _tableInfo = null; // not used by child tables
@@ -358,7 +358,7 @@ public final class CharsToNameCanonicalizer
 
         // we will try to merge if child table has new entries
         if (_parent != null && _canonicalize) { // canonicalize set to false if max size was reached
-            _parent.mergeChild(_parentTableInfoId, new TableInfo(this));
+            _parent.mergeChild(_parentTableInfo, new TableInfo(this));
             // Let's also mark this instance as dirty, so that just in
             // case release was too early, there's no corruption of possibly shared data.
             _hashShared = true;
@@ -372,32 +372,19 @@ public final class CharsToNameCanonicalizer
      * Note that caller has to make sure symbol table passed in is
      * really a child or sibling of this symbol table.
      */
-    private void mergeChild(Object parentStateId, TableInfo childState)
+    private void mergeChild(TableInfo parentState, TableInfo childState)
     {
-        final int childCount = childState.size;
-        TableInfo currState = _tableInfo.get();
-        final boolean staleChild = (currState.id != parentStateId);
-
-        // Should usually grow; but occasionally could also shrink if (but only if)
-        // collision list overflow ends up clearing some collision lists.
-        if (childCount == currState.size) {
-            return;
-        }
         // One caveat: let's try to avoid problems with  degenerate cases of documents with
         // generated "random" names: for these, symbol tables would bloat indefinitely.
         // One way to do this is to just purge tables if they grow
         // too large, and that's what we'll do here.
-        if (childCount > MAX_ENTRIES_FOR_REUSE) {
-            if (staleChild) {
-                return;
-            }
-            // At any rate, need to clean up the tables
+        if (childState.size > MAX_ENTRIES_FOR_REUSE) {
             childState = TableInfo.createInitial(DEFAULT_T_SIZE);
-        } else if ((childCount < currState.size) && staleChild) {
-            // Do not let an older child replace a newer, larger table from another child.
-            return;
         }
-        _tableInfo.compareAndSet(currState, childState);
+        // Only replace the exact state this child was forked from: if another child has
+        // merged in the meantime, its table is newer and ours is simply dropped rather
+        // than clobbering it (which could lose names, or shrink the table).
+        _tableInfo.compareAndSet(parentState, childState);
     }
 
     /*
@@ -879,7 +866,6 @@ public final class CharsToNameCanonicalizer
      */
     private final static class TableInfo
     {
-        final Object id = new Object();
         final int size;
         final int longestCollisionList;
         final String[] symbols;

--- a/src/main/java/tools/jackson/core/sym/CharsToNameCanonicalizer.java
+++ b/src/main/java/tools/jackson/core/sym/CharsToNameCanonicalizer.java
@@ -111,6 +111,8 @@ public final class CharsToNameCanonicalizer
      */
     protected final AtomicReference<TableInfo> _tableInfo;
 
+    private final TableInfo _parentTableInfo;
+
     /**
      * Constraints used by {@link TokenStreamFactory} that uses
      * this canonicalizer.
@@ -236,6 +238,7 @@ public final class CharsToNameCanonicalizer
             int seed)
     {
         _parent = null;
+        _parentTableInfo = null;
         _seed = seed;
         _streamReadConstraints = src;
 
@@ -259,6 +262,7 @@ public final class CharsToNameCanonicalizer
             TableInfo parentState)
     {
         _parent = parent;
+        _parentTableInfo = parentState;
         _streamReadConstraints = src;
         _seed = seed;
         _tableInfo = null; // not used by child tables
@@ -354,7 +358,7 @@ public final class CharsToNameCanonicalizer
 
         // we will try to merge if child table has new entries
         if (_parent != null && _canonicalize) { // canonicalize set to false if max size was reached
-            _parent.mergeChild(new TableInfo(this));
+            _parent.mergeChild(_parentTableInfo, new TableInfo(this));
             // Let's also mark this instance as dirty, so that just in
             // case release was too early, there's no corruption of possibly shared data.
             _hashShared = true;
@@ -368,7 +372,7 @@ public final class CharsToNameCanonicalizer
      * Note that caller has to make sure symbol table passed in is
      * really a child or sibling of this symbol table.
      */
-    private void mergeChild(TableInfo childState)
+    private void mergeChild(TableInfo parentState, TableInfo childState)
     {
         final int childCount = childState.size;
         TableInfo currState = _tableInfo.get();
@@ -383,8 +387,14 @@ public final class CharsToNameCanonicalizer
         // One way to do this is to just purge tables if they grow
         // too large, and that's what we'll do here.
         if (childCount > MAX_ENTRIES_FOR_REUSE) {
+            if (currState != parentState) {
+                return;
+            }
             // At any rate, need to clean up the tables
             childState = TableInfo.createInitial(DEFAULT_T_SIZE);
+        } else if ((childCount < currState.size) && (currState != parentState)) {
+            // Do not let an older child replace a newer, larger table from another child.
+            return;
         }
         _tableInfo.compareAndSet(currState, childState);
     }

--- a/src/test/java/tools/jackson/core/unittest/sym/SymbolTableMergingTest.java
+++ b/src/test/java/tools/jackson/core/unittest/sym/SymbolTableMergingTest.java
@@ -88,6 +88,18 @@ class SymbolTableMergingTest
         assertEquals(3, f.charSymbolCount());
     }
 
+    @Test
+    void staleByteSymbolsWithClose() throws Exception
+    {
+        _testStaleSymbolsWithClose(true);
+    }
+
+    @Test
+    void staleCharSymbolsWithClose() throws Exception
+    {
+        _testStaleSymbolsWithClose(false);
+    }
+
     /*
     /**********************************************************
     /* Helper methods
@@ -109,6 +121,23 @@ class SymbolTableMergingTest
         p.close();
         // but should after close
         assertEquals(2, useBytes ? f.byteSymbolCount() : f.charSymbolCount());
+    }
+
+    private void _testStaleSymbolsWithClose(boolean useBytes) throws IOException
+    {
+        MyJsonFactory f = new MyJsonFactory();
+
+        JsonParser smaller = _getParser(f, "{ \"a\" : 1 }", useBytes);
+        assertToken(JsonToken.START_OBJECT, smaller.nextToken());
+        assertToken(JsonToken.PROPERTY_NAME, smaller.nextToken());
+
+        JsonParser larger = _getParser(f, "{ \"a\" : 1, \"b\" : 2, \"c\" : 3 }", useBytes);
+        while (larger.nextToken() != null) { }
+        larger.close();
+        assertEquals(3, useBytes ? f.byteSymbolCount() : f.charSymbolCount());
+
+        smaller.close();
+        assertEquals(3, useBytes ? f.byteSymbolCount() : f.charSymbolCount());
     }
 
     private JsonParser _getParser(MyJsonFactory f, String doc, boolean useBytes) throws IOException

--- a/src/test/java/tools/jackson/core/unittest/sym/SymbolTableMergingTest.java
+++ b/src/test/java/tools/jackson/core/unittest/sym/SymbolTableMergingTest.java
@@ -35,6 +35,8 @@ class SymbolTableMergingTest
     }
 
     final static String JSON = "{ \"a\" : 3, \"aaa\" : 4, \"_a\" : 0 }";
+    final static String STALE_SMALL_DOC = a2q("{'a':1}");
+    final static String STALE_LARGE_DOC = a2q("{'a':1,'b':2,'c':3}");
 
     @Test
     void byteSymbolsWithClose() throws Exception
@@ -127,11 +129,11 @@ class SymbolTableMergingTest
     {
         MyJsonFactory f = new MyJsonFactory();
 
-        JsonParser smaller = _getParser(f, "{ \"a\" : 1 }", useBytes);
+        JsonParser smaller = _getParser(f, STALE_SMALL_DOC, useBytes);
         assertToken(JsonToken.START_OBJECT, smaller.nextToken());
         assertToken(JsonToken.PROPERTY_NAME, smaller.nextToken());
 
-        JsonParser larger = _getParser(f, "{ \"a\" : 1, \"b\" : 2, \"c\" : 3 }", useBytes);
+        JsonParser larger = _getParser(f, STALE_LARGE_DOC, useBytes);
         while (larger.nextToken() != null) { }
         larger.close();
         assertEquals(3, useBytes ? f.byteSymbolCount() : f.charSymbolCount());
@@ -144,7 +146,7 @@ class SymbolTableMergingTest
     {
         JsonParser p;
         if (useBytes) {
-            p = f.createParser(ObjectReadContext.empty(), doc.getBytes("UTF-8"));
+            p = f.createParser(ObjectReadContext.empty(), utf8Bytes(doc));
             assertEquals(UTF8StreamJsonParser.class, p.getClass());
             assertEquals(0, f.byteSymbolCount());
         } else {


### PR DESCRIPTION
Fixes #1654 
### Summary

Prevent stale child symbol tables from replacing newer, larger root symbol tables when parsers are closed out of creation order.

Previously, `mergeChild()` compared the child state against the root state observed at release time. This made the update atomic, but did not detect that the child itself could have been created from an older parent state. As a result, an older, smaller child could replace a root table that had already been updated by another child.

Child symbol tables now retain the parent table state they were created from. During release, a stale child no longer replaces the root if another child has already advanced it to a newer, larger state.

This applies to both `CharsToNameCanonicalizer` and `ByteQuadsCanonicalizer`. The existing reset behavior for oversized symbol tables is preserved.

### Tests

Added coverage to `SymbolTableMergingTest` for out-of-order stale child release with:

* byte-backed parsers
* char-backed parsers

Ran:

* `.\mvnw.cmd -Dtest=SymbolTableMergingTest '-Dsurefire.useModulePath=false' test`
* `.\mvnw.cmd '-Dtest=SymbolTableMergingTest,TestSymbolTables,TestByteBasedSymbols,TestHashCollisionChars,PlaceholderSymbolTableTest,TestSymbolsWithMediaItem' '-Dsurefire.useModulePath=false' test`
