### PR TITLE
UTF8JsonGenerator: writeNumber fast path that avoids extra String allocation

### DIFF
--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -28,6 +28,8 @@ JSON library.
  (fix by @tinyb0y)
 #1649: Optimize `NumberInput.looksLikeValidNumber`
  (fix by @cowtowncoder, w/ Claude code)
+#1657: UTF8JsonGenerator: writeNumber fast path that avoids extra String allocation
+ (implemented by @pjfanning)
 
 3.2.1 (10-Jul-2026)
 

--- a/src/main/java/tools/jackson/core/io/NumberOutput.java
+++ b/src/main/java/tools/jackson/core/io/NumberOutput.java
@@ -286,6 +286,40 @@ public final class NumberOutput
         return useFastWriter ? FloatToDecimal.toString(v) : Float.toString(v);
     }
 
+    /**
+     * Direct-to-buffer write for {@code float} values, bypassing String allocation.
+     * Writes UTF-8 bytes directly into the provided buffer.
+     * Only intended for use when FAST_FLOAT_WRITER is enabled, as it uses the Schubfach
+     * algorithm for writing floating point numbers.
+     *
+     * @param v float value to write
+     * @param buf target byte buffer (caller must ensure at least 16 bytes available from {@code off})
+     * @param off offset within buffer to start writing
+     *
+     * @return offset within buffer after the last byte written
+     * @since 3.3
+     */
+    public static int writeFloat(float v, byte[] buf, int off) {
+        return FloatToDecimal.writeFloat(v, buf, off);
+    }
+
+    /**
+     * Direct-to-buffer write for {@code double} values, bypassing String allocation.
+     * Writes UTF-8 bytes directly into the provided buffer.
+     * Only intended for use when FAST_FLOAT_WRITER is enabled, as it uses the Schubfach
+     * algorithm for writing floating point numbers.
+     *
+     * @param v double value to write
+     * @param buf target byte buffer (caller must ensure at least 25 bytes available from {@code off})
+     * @param off offset within buffer to start writing
+     *
+     * @return offset within buffer after the last byte written
+     * @since 3.3
+     */
+    public static int writeDouble(double v, byte[] buf, int off) {
+        return DoubleToDecimal.writeDouble(v, buf, off);
+    }
+
     /*
     /**********************************************************************
     /* Other convenience methods

--- a/src/main/java/tools/jackson/core/io/NumberOutput.java
+++ b/src/main/java/tools/jackson/core/io/NumberOutput.java
@@ -293,7 +293,7 @@ public final class NumberOutput
      * the Schubfach algorithm for writing floating point numbers.
      *
      * @param v float value to write
-     * @param buf target byte buffer (caller must ensure at least 16 bytes available from {@code off})
+     * @param buf target byte buffer (caller must ensure at least 15 bytes available from {@code off})
      * @param off offset within buffer to start writing
      *
      * @return offset within buffer after the last byte written
@@ -310,7 +310,7 @@ public final class NumberOutput
      * the Schubfach algorithm for writing floating point numbers.
      *
      * @param v double value to write
-     * @param buf target byte buffer (caller must ensure at least 25 bytes available from {@code off})
+     * @param buf target byte buffer (caller must ensure at least 24 bytes available from {@code off})
      * @param off offset within buffer to start writing
      *
      * @return offset within buffer after the last byte written

--- a/src/main/java/tools/jackson/core/io/NumberOutput.java
+++ b/src/main/java/tools/jackson/core/io/NumberOutput.java
@@ -18,14 +18,14 @@ public final class NumberOutput
     /**
      * Maximum number of bytes the Schubfach algorithm may produce for a {@code float}.
      * Equals {@code H + 6} where {@code H = 9} (digit count).
-     * @since 3.3
+     * @since 3.2.2
      */
     public static final int MAX_FLOAT_BYTES = 15;
 
     /**
      * Maximum number of bytes the Schubfach algorithm may produce for a {@code double}.
      * Equals {@code H + 7} where {@code H = 17} (digit count).
-     * @since 3.3
+     * @since 3.2.2
      */
     public static final int MAX_DOUBLE_BYTES = 24;
 
@@ -337,7 +337,7 @@ public final class NumberOutput
      * @param off offset within buffer to start writing
      *
      * @return offset within buffer after the last byte written
-     * @since 3.3
+     * @since 3.2.2
      */
     public static int outputFloat(float v, byte[] b, int off) {
         return FloatToDecimal.writeFloat(v, b, off);
@@ -354,7 +354,7 @@ public final class NumberOutput
      * @param off offset within buffer to start writing
      *
      * @return offset within buffer after the last byte written
-     * @since 3.3
+     * @since 3.2.2
      */
     public static int outputDouble(double v, byte[] b, int off) {
         return DoubleToDecimal.writeDouble(v, b, off);

--- a/src/main/java/tools/jackson/core/io/NumberOutput.java
+++ b/src/main/java/tools/jackson/core/io/NumberOutput.java
@@ -59,7 +59,7 @@ public final class NumberOutput
 
     /**
      * Method for appending value of given {@code int} value into
-     * specified {@code char[]}.
+     * specified {@code char[]} buffer.
      *<p>
      * NOTE: caller must guarantee that the output buffer has enough room
      * for String representation of the value.
@@ -123,6 +123,19 @@ public final class NumberOutput
         return _full3(ones, b, off);
     }
 
+    /**
+     * Method for appending value of given {@code int} value into
+     * specified {@code byte[]} buffer.
+     *<p>
+     * NOTE: caller must guarantee that the output buffer has enough room
+     * for String representation of the value.
+     *
+     * @param v Value to append to buffer
+     * @param b Buffer to append value to: caller must guarantee there is enough room
+     * @param off Offset within output buffer ({@code b}) to append number at
+     *
+     * @return Offset within buffer after outputting {@code int}
+     */
     public static int outputInt(int v, byte[] b, int off)
     {
         if (v < 0) {
@@ -170,7 +183,7 @@ public final class NumberOutput
 
     /**
      * Method for appending value of given {@code long} value into
-     * specified {@code char[]}.
+     * specified {@code char[]} buffer.
      *<p>
      * NOTE: caller must guarantee that the output buffer has enough room
      * for String representation of the value.
@@ -216,6 +229,19 @@ public final class NumberOutput
         return _outputFullBillion((int) v, b, off);
     }
 
+    /**
+     * Method for appending value of given {@code long} value into
+     * specified {@code byte[]} buffer.
+     *<p>
+     * NOTE: caller must guarantee that the output buffer has enough room
+     * for String representation of the value.
+     *
+     * @param v Value to append to buffer
+     * @param b Buffer to append value to: caller must guarantee there is enough room
+     * @param off Offset within output buffer ({@code b}) to append number at
+     *
+     * @return Offset within buffer after outputting {@code long}
+     */
     public static int outputLong(long v, byte[] b, int off)
     {
         if (v < 0L) {

--- a/src/main/java/tools/jackson/core/io/NumberOutput.java
+++ b/src/main/java/tools/jackson/core/io/NumberOutput.java
@@ -289,8 +289,8 @@ public final class NumberOutput
     /**
      * Direct-to-buffer write for {@code float} values, bypassing String allocation.
      * Writes UTF-8 bytes directly into the provided buffer.
-     * Only intended for use when FAST_FLOAT_WRITER is enabled, as it uses the Schubfach
-     * algorithm for writing floating point numbers.
+     * Only intended for use when <code>USE_FAST_DOUBLE_WRITER</code> is enabled, as it uses
+     * the Schubfach algorithm for writing floating point numbers.
      *
      * @param v float value to write
      * @param buf target byte buffer (caller must ensure at least 16 bytes available from {@code off})
@@ -306,8 +306,8 @@ public final class NumberOutput
     /**
      * Direct-to-buffer write for {@code double} values, bypassing String allocation.
      * Writes UTF-8 bytes directly into the provided buffer.
-     * Only intended for use when FAST_FLOAT_WRITER is enabled, as it uses the Schubfach
-     * algorithm for writing floating point numbers.
+     * Only intended for use when <code>USE_FAST_DOUBLE_WRITER</code> is enabled, as it uses
+     * the Schubfach algorithm for writing floating point numbers.
      *
      * @param v double value to write
      * @param buf target byte buffer (caller must ensure at least 25 bytes available from {@code off})

--- a/src/main/java/tools/jackson/core/io/NumberOutput.java
+++ b/src/main/java/tools/jackson/core/io/NumberOutput.java
@@ -16,6 +16,20 @@ public final class NumberOutput
     final static String SMALLEST_LONG = String.valueOf(Long.MIN_VALUE);
 
     /**
+     * Maximum number of bytes the Schubfach algorithm may produce for a {@code float}.
+     * Equals {@code H + 6} where {@code H = 9} (digit count).
+     * @since 3.3
+     */
+    public static final int MAX_FLOAT_BYTES = 15;
+
+    /**
+     * Maximum number of bytes the Schubfach algorithm may produce for a {@code double}.
+     * Equals {@code H + 7} where {@code H = 17} (digit count).
+     * @since 3.3
+     */
+    public static final int MAX_DOUBLE_BYTES = 24;
+
+    /**
      * Encoded representations of 3-decimal-digit indexed values, where
      * 3 LSB are ascii characters
      */

--- a/src/main/java/tools/jackson/core/io/NumberOutput.java
+++ b/src/main/java/tools/jackson/core/io/NumberOutput.java
@@ -302,36 +302,36 @@ public final class NumberOutput
 
     /**
      * Direct-to-buffer write for {@code float} values, bypassing String allocation.
-     * Writes UTF-8 bytes directly into the provided buffer.
-     * Only intended for use when <code>USE_FAST_DOUBLE_WRITER</code> is enabled, as it uses
+     * Writes UTF-8 bytes directly into the provided byte buffer.
+     * Only intended for use when {@code USE_FAST_DOUBLE_WRITER} is enabled, as it uses
      * the Schubfach algorithm for writing floating point numbers.
      *
      * @param v float value to write
-     * @param buf target byte buffer (caller must ensure at least 15 bytes available from {@code off})
+     * @param b target byte buffer (caller must ensure at least {@link #MAX_FLOAT_BYTES} bytes available from {@code off})
      * @param off offset within buffer to start writing
      *
      * @return offset within buffer after the last byte written
      * @since 3.3
      */
-    public static int writeFloat(float v, byte[] buf, int off) {
-        return FloatToDecimal.writeFloat(v, buf, off);
+    public static int outputFloat(float v, byte[] b, int off) {
+        return FloatToDecimal.writeFloat(v, b, off);
     }
 
     /**
      * Direct-to-buffer write for {@code double} values, bypassing String allocation.
-     * Writes UTF-8 bytes directly into the provided buffer.
-     * Only intended for use when <code>USE_FAST_DOUBLE_WRITER</code> is enabled, as it uses
+     * Writes UTF-8 bytes directly into the provided byte buffer.
+     * Only intended for use when {@code USE_FAST_DOUBLE_WRITER} is enabled, as it uses
      * the Schubfach algorithm for writing floating point numbers.
      *
      * @param v double value to write
-     * @param buf target byte buffer (caller must ensure at least 24 bytes available from {@code off})
+     * @param b target byte buffer (caller must ensure at least {@link #MAX_DOUBLE_BYTES} bytes available from {@code off})
      * @param off offset within buffer to start writing
      *
      * @return offset within buffer after the last byte written
      * @since 3.3
      */
-    public static int writeDouble(double v, byte[] buf, int off) {
-        return DoubleToDecimal.writeDouble(v, buf, off);
+    public static int outputDouble(double v, byte[] b, int off) {
+        return DoubleToDecimal.writeDouble(v, b, off);
     }
 
     /*

--- a/src/main/java/tools/jackson/core/io/schubfach/DoubleToDecimal.java
+++ b/src/main/java/tools/jackson/core/io/schubfach/DoubleToDecimal.java
@@ -602,7 +602,7 @@ final public class DoubleToDecimal {
      * @param buf the target byte buffer
      * @param off the offset within {@code buf} to start writing
      * @return the offset within {@code buf} after the last byte written
-     * @since 3.3
+     * @since 3.2.2
      */
     public static int writeDouble(double v, byte[] buf, int off) {
         return new DoubleToDecimal().toBuffer(v, buf, off);

--- a/src/main/java/tools/jackson/core/io/schubfach/DoubleToDecimal.java
+++ b/src/main/java/tools/jackson/core/io/schubfach/DoubleToDecimal.java
@@ -594,4 +594,63 @@ final public class DoubleToDecimal {
         return new String(bytes, 0, 0, index + 1);
     }
 
+    /**
+     * Writes the decimal representation of the given {@code double} directly into
+     * the provided byte buffer as ASCII/UTF-8, avoiding any String allocation.
+     *
+     * @param v   the {@code double} to be rendered
+     * @param buf the target byte buffer
+     * @param off the offset within {@code buf} to start writing
+     * @return the offset within {@code buf} after the last byte written
+     * @since 3.3
+     */
+    public static int writeDouble(double v, byte[] buf, int off) {
+        return new DoubleToDecimal().toBuffer(v, buf, off);
+    }
+
+    private int toBuffer(double v, byte[] buf, int off) {
+        switch (toDecimal(v)) {
+        case NON_SPECIAL:
+            System.arraycopy(bytes, 0, buf, off, index + 1);
+            return off + index + 1;
+        case PLUS_ZERO:
+            buf[off]     = '0';
+            buf[off + 1] = '.';
+            buf[off + 2] = '0';
+            return off + 3;
+        case MINUS_ZERO:
+            buf[off]     = '-';
+            buf[off + 1] = '0';
+            buf[off + 2] = '.';
+            buf[off + 3] = '0';
+            return off + 4;
+        case PLUS_INF:
+            buf[off]     = 'I';
+            buf[off + 1] = 'n';
+            buf[off + 2] = 'f';
+            buf[off + 3] = 'i';
+            buf[off + 4] = 'n';
+            buf[off + 5] = 'i';
+            buf[off + 6] = 't';
+            buf[off + 7] = 'y';
+            return off + 8;
+        case MINUS_INF:
+            buf[off]     = '-';
+            buf[off + 1] = 'I';
+            buf[off + 2] = 'n';
+            buf[off + 3] = 'f';
+            buf[off + 4] = 'i';
+            buf[off + 5] = 'n';
+            buf[off + 6] = 'i';
+            buf[off + 7] = 't';
+            buf[off + 8] = 'y';
+            return off + 9;
+        default: // NAN
+            buf[off]     = 'N';
+            buf[off + 1] = 'a';
+            buf[off + 2] = 'N';
+            return off + 3;
+        }
+    }
+
 }

--- a/src/main/java/tools/jackson/core/io/schubfach/FloatToDecimal.java
+++ b/src/main/java/tools/jackson/core/io/schubfach/FloatToDecimal.java
@@ -566,5 +566,64 @@ final public class FloatToDecimal {
         return new String(bytes, 0, 0, index + 1);
     }
 
+    /**
+     * Writes the decimal representation of the given {@code float} directly into
+     * the provided byte buffer as ASCII/UTF-8, avoiding any String allocation.
+     *
+     * @param v   the {@code float} to be rendered
+     * @param buf the target byte buffer
+     * @param off the offset within {@code buf} to start writing
+     * @return the offset within {@code buf} after the last byte written
+     * @since 3.3
+     */
+    public static int writeFloat(float v, byte[] buf, int off) {
+        return new FloatToDecimal().toBuffer(v, buf, off);
+    }
+
+    private int toBuffer(float v, byte[] buf, int off) {
+        switch (toDecimal(v)) {
+        case NON_SPECIAL:
+            System.arraycopy(bytes, 0, buf, off, index + 1);
+            return off + index + 1;
+        case PLUS_ZERO:
+            buf[off]     = '0';
+            buf[off + 1] = '.';
+            buf[off + 2] = '0';
+            return off + 3;
+        case MINUS_ZERO:
+            buf[off]     = '-';
+            buf[off + 1] = '0';
+            buf[off + 2] = '.';
+            buf[off + 3] = '0';
+            return off + 4;
+        case PLUS_INF:
+            buf[off]     = 'I';
+            buf[off + 1] = 'n';
+            buf[off + 2] = 'f';
+            buf[off + 3] = 'i';
+            buf[off + 4] = 'n';
+            buf[off + 5] = 'i';
+            buf[off + 6] = 't';
+            buf[off + 7] = 'y';
+            return off + 8;
+        case MINUS_INF:
+            buf[off]     = '-';
+            buf[off + 1] = 'I';
+            buf[off + 2] = 'n';
+            buf[off + 3] = 'f';
+            buf[off + 4] = 'i';
+            buf[off + 5] = 'n';
+            buf[off + 6] = 'i';
+            buf[off + 7] = 't';
+            buf[off + 8] = 'y';
+            return off + 9;
+        default: // NAN
+            buf[off]     = 'N';
+            buf[off + 1] = 'a';
+            buf[off + 2] = 'N';
+            return off + 3;
+        }
+    }
+
 }
 

--- a/src/main/java/tools/jackson/core/io/schubfach/FloatToDecimal.java
+++ b/src/main/java/tools/jackson/core/io/schubfach/FloatToDecimal.java
@@ -574,7 +574,7 @@ final public class FloatToDecimal {
      * @param buf the target byte buffer
      * @param off the offset within {@code buf} to start writing
      * @return the offset within {@code buf} after the last byte written
-     * @since 3.3
+     * @since 3.2.2
      */
     public static int writeFloat(float v, byte[] buf, int off) {
         return new FloatToDecimal().toBuffer(v, buf, off);

--- a/src/main/java/tools/jackson/core/json/UTF8JsonGenerator.java
+++ b/src/main/java/tools/jackson/core/json/UTF8JsonGenerator.java
@@ -1077,8 +1077,7 @@ public class UTF8JsonGenerator
         }
         _verifyValueWrite(WRITE_NUMBER);
         if (useFast) {
-            // Direct-to-buffer write: schubfach outputs at most 24 bytes for doubles (H+7, H=17)
-            if ((_outputTail + 24) > _outputEnd) {
+            if ((_outputTail + NumberOutput.MAX_DOUBLE_BYTES) > _outputEnd) {
                 _flushBuffer();
             }
             _outputTail = NumberOutput.writeDouble(d, _outputBuffer, _outputTail);
@@ -1099,8 +1098,7 @@ public class UTF8JsonGenerator
         }
         _verifyValueWrite(WRITE_NUMBER);
         if (useFast) {
-            // Direct-to-buffer write: schubfach outputs at most 15 bytes for floats (H+6, H=9)
-            if ((_outputTail + 15) > _outputEnd) {
+            if ((_outputTail + NumberOutput.MAX_FLOAT_BYTES) > _outputEnd) {
                 _flushBuffer();
             }
             _outputTail = NumberOutput.writeFloat(f, _outputBuffer, _outputTail);

--- a/src/main/java/tools/jackson/core/json/UTF8JsonGenerator.java
+++ b/src/main/java/tools/jackson/core/json/UTF8JsonGenerator.java
@@ -1080,7 +1080,7 @@ public class UTF8JsonGenerator
             if ((_outputTail + NumberOutput.MAX_DOUBLE_BYTES) > _outputEnd) {
                 _flushBuffer();
             }
-            _outputTail = NumberOutput.writeDouble(d, _outputBuffer, _outputTail);
+            _outputTail = NumberOutput.outputDouble(d, _outputBuffer, _outputTail);
             return this;
         }
         return writeRaw(NumberOutput.toString(d, false));
@@ -1101,7 +1101,7 @@ public class UTF8JsonGenerator
             if ((_outputTail + NumberOutput.MAX_FLOAT_BYTES) > _outputEnd) {
                 _flushBuffer();
             }
-            _outputTail = NumberOutput.writeFloat(f, _outputBuffer, _outputTail);
+            _outputTail = NumberOutput.outputFloat(f, _outputBuffer, _outputTail);
             return this;
         }
         return writeRaw(NumberOutput.toString(f, false));

--- a/src/main/java/tools/jackson/core/json/UTF8JsonGenerator.java
+++ b/src/main/java/tools/jackson/core/json/UTF8JsonGenerator.java
@@ -2192,12 +2192,12 @@ public class UTF8JsonGenerator
             int maxRead) throws JacksonException
     {
         // anything to shift to front?
-        int i = 0;
-        while (inputPtr < inputEnd) {
-            readBuffer[i++]  = readBuffer[inputPtr++];
+        int available = inputEnd - inputPtr;
+        if (inputPtr > 0 && available > 0) {
+            System.arraycopy(readBuffer, inputPtr, readBuffer, 0, available);
         }
         inputPtr = 0;
-        inputEnd = i;
+        inputEnd = available;
         maxRead = Math.min(maxRead, readBuffer.length);
 
         do {

--- a/src/main/java/tools/jackson/core/json/UTF8JsonGenerator.java
+++ b/src/main/java/tools/jackson/core/json/UTF8JsonGenerator.java
@@ -1075,9 +1075,16 @@ public class UTF8JsonGenerator
             writeString(NumberOutput.toString(d, useFast));
             return this;
         }
-        // What is the max length for doubles? 40 chars?
         _verifyValueWrite(WRITE_NUMBER);
-        return writeRaw(NumberOutput.toString(d, useFast));
+        if (useFast) {
+            // Direct-to-buffer write: schubfach outputs at most 25 bytes for doubles
+            if ((_outputTail + 25) > _outputEnd) {
+                _flushBuffer();
+            }
+            _outputTail = NumberOutput.writeDouble(d, _outputBuffer, _outputTail);
+            return this;
+        }
+        return writeRaw(NumberOutput.toString(d, false));
     }
 
     @Override
@@ -1090,9 +1097,16 @@ public class UTF8JsonGenerator
             writeString(NumberOutput.toString(f, useFast));
             return this;
         }
-        // What is the max length for floats?
         _verifyValueWrite(WRITE_NUMBER);
-        return writeRaw(NumberOutput.toString(f, useFast));
+        if (useFast) {
+            // Direct-to-buffer write: schubfach outputs at most 16 bytes for floats
+            if ((_outputTail + 16) > _outputEnd) {
+                _flushBuffer();
+            }
+            _outputTail = NumberOutput.writeFloat(f, _outputBuffer, _outputTail);
+            return this;
+        }
+        return writeRaw(NumberOutput.toString(f, false));
     }
 
     @Override

--- a/src/main/java/tools/jackson/core/json/UTF8JsonGenerator.java
+++ b/src/main/java/tools/jackson/core/json/UTF8JsonGenerator.java
@@ -1077,8 +1077,8 @@ public class UTF8JsonGenerator
         }
         _verifyValueWrite(WRITE_NUMBER);
         if (useFast) {
-            // Direct-to-buffer write: schubfach outputs at most 25 bytes for doubles
-            if ((_outputTail + 25) > _outputEnd) {
+            // Direct-to-buffer write: schubfach outputs at most 24 bytes for doubles (H+7, H=17)
+            if ((_outputTail + 24) > _outputEnd) {
                 _flushBuffer();
             }
             _outputTail = NumberOutput.writeDouble(d, _outputBuffer, _outputTail);
@@ -1099,8 +1099,8 @@ public class UTF8JsonGenerator
         }
         _verifyValueWrite(WRITE_NUMBER);
         if (useFast) {
-            // Direct-to-buffer write: schubfach outputs at most 16 bytes for floats
-            if ((_outputTail + 16) > _outputEnd) {
+            // Direct-to-buffer write: schubfach outputs at most 15 bytes for floats (H+6, H=9)
+            if ((_outputTail + 15) > _outputEnd) {
                 _flushBuffer();
             }
             _outputTail = NumberOutput.writeFloat(f, _outputBuffer, _outputTail);

--- a/src/main/java/tools/jackson/core/json/WriterBasedJsonGenerator.java
+++ b/src/main/java/tools/jackson/core/json/WriterBasedJsonGenerator.java
@@ -1840,12 +1840,12 @@ public class WriterBasedJsonGenerator
             int maxRead) throws JacksonException
     {
         // anything to shift to front?
-        int i = 0;
-        while (inputPtr < inputEnd) {
-            readBuffer[i++]  = readBuffer[inputPtr++];
+        int available = inputEnd - inputPtr;
+        if (inputPtr > 0 && available > 0) {
+            System.arraycopy(readBuffer, inputPtr, readBuffer, 0, available);
         }
         inputPtr = 0;
-        inputEnd = i;
+        inputEnd = available;
         maxRead = Math.min(maxRead, readBuffer.length);
 
         do {

--- a/src/test/java/tools/jackson/core/unittest/io/schubfach/SchubfachWriteBufferTest.java
+++ b/src/test/java/tools/jackson/core/unittest/io/schubfach/SchubfachWriteBufferTest.java
@@ -1,0 +1,72 @@
+package tools.jackson.core.unittest.io.schubfach;
+
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.Test;
+
+import tools.jackson.core.io.NumberOutput;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for {@link NumberOutput#writeFloat} and {@link NumberOutput#writeDouble}
+ * which write directly to a byte buffer, avoiding String allocation.
+ */
+public class SchubfachWriteBufferTest
+{
+    @Test
+    public void testWriteFloatBasic()
+    {
+        float[] values = {
+            0.0f, -0.0f, 1.0f, -1.0f, 1.5f, -1.5f,
+            123.456f, -123.456f, 1.0E10f, 1.0E-10f,
+            Float.MAX_VALUE, Float.MIN_VALUE, Float.MIN_NORMAL,
+            Float.NaN, Float.POSITIVE_INFINITY, Float.NEGATIVE_INFINITY
+        };
+        for (float v : values) {
+            String expected = NumberOutput.toString(v, true);
+            byte[] buf = new byte[32];
+            int end = NumberOutput.writeFloat(v, buf, 0);
+            String actual = new String(buf, 0, end, StandardCharsets.ISO_8859_1);
+            assertEquals(expected, actual, "mismatch for float " + v);
+        }
+    }
+
+    @Test
+    public void testWriteDoubleBasic()
+    {
+        double[] values = {
+            0.0, -0.0, 1.0, -1.0, 1.5, -1.5,
+            123.456789, -123.456789, 1.0E10, 1.0E-10,
+            Double.MAX_VALUE, Double.MIN_VALUE, Double.MIN_NORMAL,
+            Double.NaN, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY
+        };
+        for (double v : values) {
+            String expected = NumberOutput.toString(v, true);
+            byte[] buf = new byte[48];
+            int end = NumberOutput.writeDouble(v, buf, 0);
+            String actual = new String(buf, 0, end, StandardCharsets.ISO_8859_1);
+            assertEquals(expected, actual, "mismatch for double " + v);
+        }
+    }
+
+    @Test
+    public void testWriteFloatAtOffset()
+    {
+        byte[] buf = new byte[32];
+        buf[0] = (byte) ',';
+        int end = NumberOutput.writeFloat(1.5f, buf, 1);
+        String result = new String(buf, 1, end - 1, StandardCharsets.ISO_8859_1);
+        assertEquals("1.5", result);
+    }
+
+    @Test
+    public void testWriteDoubleAtOffset()
+    {
+        byte[] buf = new byte[48];
+        buf[0] = (byte) ',';
+        int end = NumberOutput.writeDouble(1.5, buf, 1);
+        String result = new String(buf, 1, end - 1, StandardCharsets.ISO_8859_1);
+        assertEquals("1.5", result);
+    }
+}

--- a/src/test/java/tools/jackson/core/unittest/io/schubfach/SchubfachWriteBufferTest.java
+++ b/src/test/java/tools/jackson/core/unittest/io/schubfach/SchubfachWriteBufferTest.java
@@ -9,7 +9,7 @@ import tools.jackson.core.io.NumberOutput;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * Tests for {@link NumberOutput#writeFloat} and {@link NumberOutput#writeDouble}
+ * Tests for {@link NumberOutput#outputFloat} and {@link NumberOutput#outputDouble}
  * which write directly to a byte buffer, avoiding String allocation.
  */
 public class SchubfachWriteBufferTest
@@ -26,7 +26,7 @@ public class SchubfachWriteBufferTest
         for (float v : values) {
             String expected = NumberOutput.toString(v, true);
             byte[] buf = new byte[32];
-            int end = NumberOutput.writeFloat(v, buf, 0);
+            int end = NumberOutput.outputFloat(v, buf, 0);
             String actual = new String(buf, 0, end, StandardCharsets.ISO_8859_1);
             assertEquals(expected, actual, "mismatch for float " + v);
         }
@@ -44,7 +44,7 @@ public class SchubfachWriteBufferTest
         for (double v : values) {
             String expected = NumberOutput.toString(v, true);
             byte[] buf = new byte[48];
-            int end = NumberOutput.writeDouble(v, buf, 0);
+            int end = NumberOutput.outputDouble(v, buf, 0);
             String actual = new String(buf, 0, end, StandardCharsets.ISO_8859_1);
             assertEquals(expected, actual, "mismatch for double " + v);
         }
@@ -55,7 +55,7 @@ public class SchubfachWriteBufferTest
     {
         byte[] buf = new byte[32];
         buf[0] = (byte) ',';
-        int end = NumberOutput.writeFloat(1.5f, buf, 1);
+        int end = NumberOutput.outputFloat(1.5f, buf, 1);
         String result = new String(buf, 1, end - 1, StandardCharsets.ISO_8859_1);
         assertEquals("1.5", result);
     }
@@ -65,7 +65,7 @@ public class SchubfachWriteBufferTest
     {
         byte[] buf = new byte[48];
         buf[0] = (byte) ',';
-        int end = NumberOutput.writeDouble(1.5, buf, 1);
+        int end = NumberOutput.outputDouble(1.5, buf, 1);
         String result = new String(buf, 1, end - 1, StandardCharsets.ISO_8859_1);
         assertEquals("1.5", result);
     }

--- a/src/test/java/tools/jackson/core/unittest/write/FastDoubleWriteNumberTest.java
+++ b/src/test/java/tools/jackson/core/unittest/write/FastDoubleWriteNumberTest.java
@@ -1,0 +1,213 @@
+package tools.jackson.core.unittest.write;
+
+import java.io.*;
+
+import org.junit.jupiter.api.Test;
+
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.core.ObjectWriteContext;
+import tools.jackson.core.StreamWriteFeature;
+import tools.jackson.core.json.JsonFactory;
+import tools.jackson.core.unittest.JacksonCoreTestBase;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for {@link JsonGenerator#writeNumber(double)} and
+ * {@link JsonGenerator#writeNumber(float)} with
+ * {@link StreamWriteFeature#USE_FAST_DOUBLE_WRITER} enabled.
+ */
+public class FastDoubleWriteNumberTest extends JacksonCoreTestBase
+{
+    private final JsonFactory FAST_FACTORY = JsonFactory.builder()
+            .enable(StreamWriteFeature.USE_FAST_DOUBLE_WRITER)
+            .build();
+
+    @Test
+    void testDoubleValues() throws Exception
+    {
+        double[] values = {
+            0.0, -0.0, 1.0, -1.0, 1.5, -1.5,
+            0.25, -0.25, 123.456, -123.456,
+            1.0E10, 1.0E-10, -1.0E10, -1.0E-10,
+            Double.MAX_VALUE, Double.MIN_VALUE, Double.MIN_NORMAL
+        };
+        for (double v : values) {
+            _verifyDoubleWrite(v);
+        }
+    }
+
+    @Test
+    void testFloatValues() throws Exception
+    {
+        float[] values = {
+            0.0f, -0.0f, 1.0f, -1.0f, 1.5f, -1.5f,
+            0.25f, -0.25f, 123.456f, -123.456f,
+            1.0E10f, 1.0E-10f, -1.0E10f, -1.0E-10f,
+            Float.MAX_VALUE, Float.MIN_VALUE, Float.MIN_NORMAL
+        };
+        for (float v : values) {
+            _verifyFloatWrite(v);
+        }
+    }
+
+    @Test
+    void testDoubleSpecialValues() throws Exception
+    {
+        // NaN and Infinity go through writeString path, not direct buffer write
+        _verifyDoubleSpecial(Double.NaN, "NaN");
+        _verifyDoubleSpecial(Double.POSITIVE_INFINITY, "Infinity");
+        _verifyDoubleSpecial(Double.NEGATIVE_INFINITY, "-Infinity");
+    }
+
+    @Test
+    void testFloatSpecialValues() throws Exception
+    {
+        _verifyFloatSpecial(Float.NaN, "NaN");
+        _verifyFloatSpecial(Float.POSITIVE_INFINITY, "Infinity");
+        _verifyFloatSpecial(Float.NEGATIVE_INFINITY, "-Infinity");
+    }
+
+    @Test
+    void testDoubleWriteInObject() throws Exception
+    {
+        // Test writeNumber(double) inside an object context
+        StringWriter sw = new StringWriter();
+        try (JsonGenerator gen = FAST_FACTORY.createGenerator(ObjectWriteContext.empty(), sw)) {
+            gen.writeStartObject();
+            gen.writeName("value");
+            gen.writeNumber(1.5);
+            gen.writeEndObject();
+        }
+        assertEquals("{\"value\":1.5}", sw.toString());
+    }
+
+    @Test
+    void testFloatWriteInObject() throws Exception
+    {
+        StringWriter sw = new StringWriter();
+        try (JsonGenerator gen = FAST_FACTORY.createGenerator(ObjectWriteContext.empty(), sw)) {
+            gen.writeStartObject();
+            gen.writeName("value");
+            gen.writeNumber(1.5f);
+            gen.writeEndObject();
+        }
+        assertEquals("{\"value\":1.5}", sw.toString());
+    }
+
+    @Test
+    void testDoubleWriteInArray() throws Exception
+    {
+        StringWriter sw = new StringWriter();
+        try (JsonGenerator gen = FAST_FACTORY.createGenerator(ObjectWriteContext.empty(), sw)) {
+            gen.writeStartArray();
+            gen.writeNumber(0.25);
+            gen.writeNumber(-0.25);
+            gen.writeNumber(17.07);
+            gen.writeEndArray();
+        }
+        assertEquals("[0.25,-0.25,17.07]", sw.toString());
+    }
+
+    @Test
+    void testFloatWriteInArray() throws Exception
+    {
+        StringWriter sw = new StringWriter();
+        try (JsonGenerator gen = FAST_FACTORY.createGenerator(ObjectWriteContext.empty(), sw)) {
+            gen.writeStartArray();
+            gen.writeNumber(0.25f);
+            gen.writeNumber(-0.25f);
+            gen.writeNumber(17.07f);
+            gen.writeEndArray();
+        }
+        assertEquals("[0.25,-0.25,17.07]", sw.toString());
+    }
+
+    @Test
+    void testDoubleWriteToOutputStream() throws Exception
+    {
+        // Test the byte-buffer path (UTF8JsonGenerator)
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        try (JsonGenerator gen = FAST_FACTORY.createGenerator(ObjectWriteContext.empty(), bytes)) {
+            gen.writeStartArray();
+            gen.writeNumber(0.25);
+            gen.writeNumber(-0.25);
+            gen.writeNumber(1.5);
+            gen.writeEndArray();
+        }
+        assertEquals("[0.25,-0.25,1.5]", bytes.toString("UTF-8"));
+    }
+
+    @Test
+    void testFloatWriteToOutputStream() throws Exception
+    {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        try (JsonGenerator gen = FAST_FACTORY.createGenerator(ObjectWriteContext.empty(), bytes)) {
+            gen.writeStartArray();
+            gen.writeNumber(0.25f);
+            gen.writeNumber(-0.25f);
+            gen.writeNumber(1.5f);
+            gen.writeEndArray();
+        }
+        assertEquals("[0.25,-0.25,1.5]", bytes.toString("UTF-8"));
+    }
+
+    @Test
+    void testDoubleWithNumbersAsStrings() throws Exception
+    {
+        // When cfgNumbersAsStrings is true, should still quote numbers
+        JsonFactory factory = JsonFactory.builder()
+                .enable(StreamWriteFeature.USE_FAST_DOUBLE_WRITER)
+                .build();
+        StringWriter sw = new StringWriter();
+        // Note: cfgNumbersAsStrings is set via WRITE_NUMBERS_AS_STRINGS feature
+        // For now just verify basic fast mode works
+        try (JsonGenerator gen = factory.createGenerator(ObjectWriteContext.empty(), sw)) {
+            gen.writeNumber(1.5);
+        }
+        assertEquals("1.5", sw.toString());
+    }
+
+    private void _verifyDoubleWrite(double v) throws Exception
+    {
+        // Verify fast mode produces output that round-trips to the same value
+        StringWriter sw = new StringWriter();
+        try (JsonGenerator gen = FAST_FACTORY.createGenerator(ObjectWriteContext.empty(), sw)) {
+            gen.writeNumber(v);
+        }
+        String output = sw.toString();
+        // Verify the output can be parsed back to the same double
+        double parsed = Double.parseDouble(output);
+        assertEquals(v, parsed, "round-trip failure for double " + v);
+    }
+
+    private void _verifyFloatWrite(float v) throws Exception
+    {
+        StringWriter sw = new StringWriter();
+        try (JsonGenerator gen = FAST_FACTORY.createGenerator(ObjectWriteContext.empty(), sw)) {
+            gen.writeNumber(v);
+        }
+        String output = sw.toString();
+        float parsed = Float.parseFloat(output);
+        assertEquals(v, parsed, "round-trip failure for float " + v);
+    }
+
+    private void _verifyDoubleSpecial(double v, String expected) throws Exception
+    {
+        StringWriter sw = new StringWriter();
+        try (JsonGenerator gen = FAST_FACTORY.createGenerator(ObjectWriteContext.empty(), sw)) {
+            gen.writeNumber(v);
+        }
+        // Special values are written as strings (quoted)
+        assertEquals("\"" + expected + "\"", sw.toString());
+    }
+
+    private void _verifyFloatSpecial(float v, String expected) throws Exception
+    {
+        StringWriter sw = new StringWriter();
+        try (JsonGenerator gen = FAST_FACTORY.createGenerator(ObjectWriteContext.empty(), sw)) {
+            gen.writeNumber(v);
+        }
+        assertEquals("\"" + expected + "\"", sw.toString());
+    }
+}

--- a/src/test/java/tools/jackson/core/unittest/write/FastDoubleWriteNumberTest.java
+++ b/src/test/java/tools/jackson/core/unittest/write/FastDoubleWriteNumberTest.java
@@ -79,7 +79,7 @@ public class FastDoubleWriteNumberTest extends JacksonCoreTestBase
             gen.writeNumber(1.5);
             gen.writeEndObject();
         }
-        assertEquals("{\"value\":1.5}", sw.toString());
+        assertEquals(a2q("{'value':1.5}"), sw.toString());
     }
 
     @Test
@@ -92,7 +92,7 @@ public class FastDoubleWriteNumberTest extends JacksonCoreTestBase
             gen.writeNumber(1.5f);
             gen.writeEndObject();
         }
-        assertEquals("{\"value\":1.5}", sw.toString());
+        assertEquals(a2q("{'value':1.5}"), sw.toString());
     }
 
     @Test
@@ -199,7 +199,7 @@ public class FastDoubleWriteNumberTest extends JacksonCoreTestBase
             gen.writeNumber(v);
         }
         // Special values are written as strings (quoted)
-        assertEquals("\"" + expected + "\"", sw.toString());
+        assertEquals(q(expected), sw.toString());
     }
 
     private void _verifyFloatSpecial(float v, String expected) throws Exception
@@ -208,6 +208,6 @@ public class FastDoubleWriteNumberTest extends JacksonCoreTestBase
         try (JsonGenerator gen = FAST_FACTORY.createGenerator(ObjectWriteContext.empty(), sw)) {
             gen.writeNumber(v);
         }
-        assertEquals("\"" + expected + "\"", sw.toString());
+        assertEquals(q(expected), sw.toString());
     }
 }


### PR DESCRIPTION
Partially related to #1656 
The new XJBWriter has support for writing the number to a pre-existing byte array and avoid String allocations.
It's possible that 1656 will get nowhere but I thought that it might be worth considering this change as a completely separate change.
I modified the existing Schubfach code to allow String allocation to be skipped when writing numbers in UTF8JsonGenerator.
And if we do switch to XJB, the NumberOutput class can be modified to use XJB instead of Schubfach but this PR tests UTF8JsonGenerator in isolation.

This change only kicks in if you enable StreamWriteFeature.USE_FAST_DOUBLE_WRITER