### PR TITLE
use arraycopy for performance

### DIFF
--- a/src/main/java/tools/jackson/core/json/UTF8JsonGenerator.java
+++ b/src/main/java/tools/jackson/core/json/UTF8JsonGenerator.java
@@ -2180,12 +2180,12 @@ public class UTF8JsonGenerator
             int maxRead) throws JacksonException
     {
         // anything to shift to front?
-        int i = 0;
-        while (inputPtr < inputEnd) {
-            readBuffer[i++]  = readBuffer[inputPtr++];
+        int available = inputEnd - inputPtr;
+        if (inputPtr > 0 && available > 0) {
+            System.arraycopy(readBuffer, inputPtr, readBuffer, 0, available);
         }
         inputPtr = 0;
-        inputEnd = i;
+        inputEnd = available;
         maxRead = Math.min(maxRead, readBuffer.length);
 
         do {

--- a/src/main/java/tools/jackson/core/json/WriterBasedJsonGenerator.java
+++ b/src/main/java/tools/jackson/core/json/WriterBasedJsonGenerator.java
@@ -1840,12 +1840,12 @@ public class WriterBasedJsonGenerator
             int maxRead) throws JacksonException
     {
         // anything to shift to front?
-        int i = 0;
-        while (inputPtr < inputEnd) {
-            readBuffer[i++]  = readBuffer[inputPtr++];
+        int available = inputEnd - inputPtr;
+        if (inputPtr > 0 && available > 0) {
+            System.arraycopy(readBuffer, inputPtr, readBuffer, 0, available);
         }
         inputPtr = 0;
-        inputEnd = i;
+        inputEnd = available;
         maxRead = Math.min(maxRead, readBuffer.length);
 
         do {


### PR DESCRIPTION
Claude Assisted.

Use System.arraycopy for buffer shifts in JSON generators

Body:

Replace manual while-loop byte shifting with System.arraycopy in _readMore() methods of UTF8JsonGenerator and WriterBasedJsonGenerator.

Both generators had identical code that shifted remaining bytes to the front of a read buffer using element-by-element assignment:

```
while (inputPtr < inputEnd) {
    readBuffer[i++] = readBuffer[inputPtr++];
}
```

This is replaced with System.arraycopy, which is a JVM intrinsic optimised for overlapping memory copies. The guard if (inputPtr > 0 && available > 0) avoids unnecessary copying when the buffer is already at position 0 or empty.

Files changed:
- src/main/java/tools/jackson/core/json/UTF8JsonGenerator.java
- src/main/java/tools/jackson/core/json/WriterBasedJsonGenerator.java