### PR TITLE
tests NaN writing support when USE_FAST_DOUBLE_WRITER is enabled

### DIFF
--- a/src/test/java/tools/jackson/core/unittest/json/StreamWriteFeaturesTest.java
+++ b/src/test/java/tools/jackson/core/unittest/json/StreamWriteFeaturesTest.java
@@ -59,19 +59,7 @@ class GeneratorFeaturesTest
     @Test
     void nonNumericQuoting() throws IOException
     {
-        JsonFactory f = new JsonFactory();
-        // by default, quoting should be enabled
-        assertTrue(f.isEnabled(JsonWriteFeature.WRITE_NAN_AS_STRINGS));
-        _testNonNumericQuoting(f, true);
-        // can disable it
-        f = f.rebuild().disable(JsonWriteFeature.WRITE_NAN_AS_STRINGS)
-                .build();
-        _testNonNumericQuoting(f, false);
-        // and (re)enable:
-        f = f.rebuild()
-                .enable(JsonWriteFeature.WRITE_NAN_AS_STRINGS)
-                .build();
-        _testNonNumericQuoting(f, true);
+        _testNonNumericQuoting(new JsonFactory());
     }
 
     @Test
@@ -80,18 +68,7 @@ class GeneratorFeaturesTest
         JsonFactory f = JsonFactory.builder()
                 .enable(StreamWriteFeature.USE_FAST_DOUBLE_WRITER)
                 .build();
-        // by default, quoting should be enabled
-        assertTrue(f.isEnabled(JsonWriteFeature.WRITE_NAN_AS_STRINGS));
-        _testNonNumericQuoting(f, true);
-        // can disable it
-        f = f.rebuild().disable(JsonWriteFeature.WRITE_NAN_AS_STRINGS)
-                .build();
-        _testNonNumericQuoting(f, false);
-        // and (re)enable:
-        f = f.rebuild()
-                .enable(JsonWriteFeature.WRITE_NAN_AS_STRINGS)
-                .build();
-        _testNonNumericQuoting(f, true);
+        _testNonNumericQuoting(f);
     }
 
     /**
@@ -316,6 +293,22 @@ class GeneratorFeaturesTest
         } else {
             assertEquals("{foo:1}", result);
         }
+    }
+
+    private void _testNonNumericQuoting(JsonFactory f)
+    {
+        // by default, quoting should be enabled
+        assertTrue(f.isEnabled(JsonWriteFeature.WRITE_NAN_AS_STRINGS));
+        _testNonNumericQuoting(f, true);
+        // can disable it
+        f = f.rebuild().disable(JsonWriteFeature.WRITE_NAN_AS_STRINGS)
+                .build();
+        _testNonNumericQuoting(f, false);
+        // and (re)enable:
+        f = f.rebuild()
+                .enable(JsonWriteFeature.WRITE_NAN_AS_STRINGS)
+                .build();
+        _testNonNumericQuoting(f, true);
     }
 
     private void _testNonNumericQuoting(JsonFactory f, boolean quoted)

--- a/src/test/java/tools/jackson/core/unittest/json/StreamWriteFeaturesTest.java
+++ b/src/test/java/tools/jackson/core/unittest/json/StreamWriteFeaturesTest.java
@@ -74,6 +74,26 @@ class GeneratorFeaturesTest
         _testNonNumericQuoting(f, true);
     }
 
+    @Test
+    void nonNumericQuotingFastWriter() throws IOException
+    {
+        JsonFactory f = JsonFactory.builder()
+                .enable(StreamWriteFeature.USE_FAST_DOUBLE_WRITER)
+                .build();
+        // by default, quoting should be enabled
+        assertTrue(f.isEnabled(JsonWriteFeature.WRITE_NAN_AS_STRINGS));
+        _testNonNumericQuoting(f, true);
+        // can disable it
+        f = f.rebuild().disable(JsonWriteFeature.WRITE_NAN_AS_STRINGS)
+                .build();
+        _testNonNumericQuoting(f, false);
+        // and (re)enable:
+        f = f.rebuild()
+                .enable(JsonWriteFeature.WRITE_NAN_AS_STRINGS)
+                .build();
+        _testNonNumericQuoting(f, true);
+    }
+
     /**
      * Testing for [JACKSON-176], ability to force serializing numbers
      * as JSON Strings.
@@ -297,6 +317,7 @@ class GeneratorFeaturesTest
             assertEquals("{foo:1}", result);
         }
     }
+
     private void _testNonNumericQuoting(JsonFactory f, boolean quoted)
     {
         StringWriter sw = new StringWriter();

--- a/src/test/java/tools/jackson/core/unittest/json/StreamWriteFeaturesTest.java
+++ b/src/test/java/tools/jackson/core/unittest/json/StreamWriteFeaturesTest.java
@@ -59,7 +59,10 @@ class GeneratorFeaturesTest
     @Test
     void nonNumericQuoting() throws IOException
     {
-        _testNonNumericQuoting(new JsonFactory());
+        JsonFactory f = JsonFactory.builder()
+                .disable(StreamWriteFeature.USE_FAST_DOUBLE_WRITER)
+                .build();
+        _testNonNumericQuoting(f);
     }
 
     @Test


### PR DESCRIPTION
Copies a test used with default setup but I think it is important to see if USE_FAST_DOUBLE_WRITER has an effect.