### PR TITLE
Fix WriterBasedJsonGenerator AIOOBE for zero-length custom escape

### DIFF
--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -82,3 +82,13 @@ DongNyoung Lee (@Dongnyoung)
  * Reported, fixed #1646: Non-blocking ByteBuffer parser `releaseBuffered()` can write
    already-consumed bytes
   (3.3.0)
+
+@hdimitrieski
+ * Reported #1668: WriterBasedJsonGenerator AIOOBE when a zero-length custom
+   escape lands at the output buffer boundary
+  (3.3.0)
+
+Burak KALAYCI (@kalayciburak)
+ * Contributed #1668: WriterBasedJsonGenerator AIOOBE when a zero-length custom
+   escape lands at the output buffer boundary
+  (3.3.0)

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -22,6 +22,10 @@ JSON library.
 #1646: Non-blocking ByteBuffer parser `releaseBuffered()` can write
   already-consumed bytes
  (reported, fix by DongNyoung L)
+#1668: WriterBasedJsonGenerator AIOOBE when a zero-length custom escape
+  lands at the output buffer boundary
+ (reported by @hdimitrieski)
+ (fix by @kalayciburak)
 
 3.2.2 (14-Aug-2026)
 

--- a/src/main/java/tools/jackson/core/json/WriterBasedJsonGenerator.java
+++ b/src/main/java/tools/jackson/core/json/WriterBasedJsonGenerator.java
@@ -1552,6 +1552,11 @@ public class WriterBasedJsonGenerator
             ++_outputTail;
             _prependOrWriteCharacterEscape(c, escCode);
         }
+        // [core#1668] empty custom escape can leave head==tail at the buffer
+        // end. Recycle after the scan so the next write does not call flush.
+        if (_outputHead == _outputTail && _outputTail >= _outputEnd) {
+            _outputHead = _outputTail = 0;
+        }
     }
 
     private void _writeSegmentCustom(int end)
@@ -1980,6 +1985,13 @@ public class WriterBasedJsonGenerator
             _currentEscape = null;
         }
         int len = escape.length();
+        // 18-Aug-2026, [core#1668]: empty custom escape appends nothing.
+        // Prefix is already flushed; drop the source char. Do not recycle
+        // the buffer here: callers still walk toward a precomputed end.
+        if (len == 0) {
+            _outputHead = _outputTail;
+            return;
+        }
         if (_outputTail >= len) { // fits in, prepend
             int ptr = _outputTail - len;
             _outputHead = ptr;
@@ -2079,6 +2091,9 @@ public class WriterBasedJsonGenerator
             _currentEscape = null;
         }
         int len = escape.length();
+        if (len == 0) { // [core#1668] empty custom escape: append nothing
+            return ptr;
+        }
         if (ptr >= len && ptr < end) { // fits in, prepend
             ptr -= len;
             escape.getChars(0, len, buffer, ptr);
@@ -2139,6 +2154,9 @@ public class WriterBasedJsonGenerator
             _currentEscape = null;
         }
         int len = escape.length();
+        if (len == 0) { // [core#1668] empty custom escape: append nothing
+            return;
+        }
         if ((_outputTail + len) > _outputEnd) {
             _flushBuffer();
             if (len > _outputEnd) { // very very long escape; unlikely but theoretically possible

--- a/src/test/java/tools/jackson/core/unittest/json/ZeroLengthCustomEscape1668Test.java
+++ b/src/test/java/tools/jackson/core/unittest/json/ZeroLengthCustomEscape1668Test.java
@@ -1,0 +1,120 @@
+package tools.jackson.core.unittest.json;
+
+import java.io.ByteArrayOutputStream;
+import java.io.StringWriter;
+
+import org.junit.jupiter.api.Test;
+
+import tools.jackson.core.JsonEncoding;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.core.ObjectWriteContext;
+import tools.jackson.core.SerializableString;
+import tools.jackson.core.io.CharacterEscapes;
+import tools.jackson.core.io.SerializedString;
+import tools.jackson.core.json.JsonFactory;
+import tools.jackson.core.unittest.JacksonCoreTestBase;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+// [core#1668]: a zero-length custom escape at the last character of a string
+// must not throw ArrayIndexOutOfBoundsException when that character lands
+// exactly at the Writer-backed output buffer boundary.
+class ZeroLengthCustomEscape1668Test
+    extends JacksonCoreTestBase
+{
+    @SuppressWarnings("serial")
+    static class ZeroLengthNulEscape extends CharacterEscapes
+    {
+        private static final SerializableString EMPTY = new SerializedString("");
+        private final int[] escapes;
+
+        ZeroLengthNulEscape() {
+            escapes = standardAsciiEscapesForJSON();
+            escapes[0] = ESCAPE_CUSTOM;
+        }
+
+        @Override
+        public int[] getEscapeCodesForAscii() {
+            return escapes;
+        }
+
+        @Override
+        public SerializableString getEscapeSequence(int ch) {
+            return ch == 0 ? EMPTY : null;
+        }
+    }
+
+    @Test
+    void writerStringAtBufferBoundary() throws Exception {
+        _testAtBufferBoundary(false, false);
+    }
+
+    @Test
+    void writerCharsAtBufferBoundary() throws Exception {
+        _testAtBufferBoundary(false, true);
+    }
+
+    @Test
+    void utf8StringAtBufferBoundary() throws Exception {
+        _testAtBufferBoundary(true, false);
+    }
+
+    @Test
+    void utf8CharsAtBufferBoundary() throws Exception {
+        _testAtBufferBoundary(true, true);
+    }
+
+    private void _testAtBufferBoundary(boolean useStream, boolean stringAsChars)
+        throws Exception
+    {
+        JsonFactory factory = JsonFactory.builder()
+                .characterEscapes(new ZeroLengthNulEscape())
+                .build();
+        final String value = "Istio LFS144" + '\0';
+        final String expectedValue = "Istio LFS144";
+
+        // Default concat buffer is 4000 chars; sweep alignments around that edge.
+        for (int pad = 3900; pad <= 4100; pad++) {
+            String json;
+            if (useStream) {
+                ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+                try (JsonGenerator gen = factory.createGenerator(
+                        ObjectWriteContext.empty(), bytes, JsonEncoding.UTF8)) {
+                    _writeDoc(gen, pad, value, stringAsChars);
+                }
+                json = bytes.toString("UTF-8");
+            } else {
+                StringWriter w = new StringWriter();
+                try (JsonGenerator gen = factory.createGenerator(
+                        ObjectWriteContext.empty(), w)) {
+                    _writeDoc(gen, pad, value, stringAsChars);
+                }
+                json = w.toString();
+            }
+            String expected = "[\"" + "x".repeat(pad) + "\"," + q(expectedValue) + "]";
+            assertEquals(expected, json, "pad=" + pad);
+            assertFalse(json.contains("\0"), "NUL should be omitted, pad=" + pad);
+        }
+    }
+
+    private void _writeDoc(JsonGenerator gen, int pad, String value, boolean stringAsChars)
+        throws Exception
+    {
+        gen.writeStartArray();
+        _writeString(gen, "x".repeat(pad), stringAsChars);
+        _writeString(gen, value, stringAsChars);
+        gen.writeEndArray();
+    }
+
+    private void _writeString(JsonGenerator gen, String str, boolean stringAsChars)
+        throws Exception
+    {
+        if (stringAsChars) {
+            char[] ch = str.toCharArray();
+            gen.writeString(ch, 0, ch.length);
+        } else {
+            gen.writeString(str);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #1668.

`WriterBasedJsonGenerator.writeString(String)` throws
`ArrayIndexOutOfBoundsException` when a `CharacterEscapes` implementation
returns a zero-length sequence and that escaped character is the last
character of the string, aligned with the output buffer end.

`_writeStringCustom` plus `_prependOrWriteCharacterEscape` left
`_outputHead == _outputTail` at the buffer end. The closing quote then
wrote at index 4000 of a 4000-char buffer.

## Changes

- Empty custom escape now appends nothing (skip the write) instead of
  changing `_flushBuffer`.
- After the custom-escape scan, recycle the buffer if it is empty at
  the end so the next write does not need a no-op flush.
- Add `ZeroLengthCustomEscape1668Test` covering Writer and UTF-8
  generators, plus `writeString(String)` and `writeString(char[])`.

## Testing

```
./mvnw -B -ff -ntp test -Dtest=ZeroLengthCustomEscape1668Test,TestCustomEscaping -Dsurefire.useModulePath=false
```

Result: 9/9 GREEN.

```
./mvnw -B -ff -ntp test -Dsurefire.useModulePath=false
```

Result: 1836 tests, 0 failures, 2 skipped.

The same empty-escape case exists on 2.21 if a backport is wanted.