### PR TITLE
Fix `willInternPropertyNames()` when canonicalization is disabled

### DIFF
--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -58,6 +58,9 @@ Revanth Meesala (@revanthmeesala)
 Lee Dongnyoung (@DongNyoung)
  * Contributed #1651: Fix object context handling for buffered `INCLUDE_NON_NULL` tokens
   (3.1.6)
+ * Contributed #1667: `JsonParser.willInternPropertyNames()` returns `true` even when
+   `CANONICALIZE_PROPERTY_NAMES` is disabled
+  (3.2.3)
 
 seonwoojung (@seonwooj0810)
  * Contributed #707: Add `JsonReadFeature.ALLOW_HEXADECIMAL_NUMBERS`

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -15,6 +15,12 @@ JSON library.
 === Releases ===
 ------------------------------------------------------------------------
 
+3.2.3 (not yet released)
+
+#1667: `JsonParser.willInternPropertyNames()` returns `true` even when
+  `CANONICALIZE_PROPERTY_NAMES` is disabled
+ (contributed by @Dongnyoung)
+
 3.2.2 (14-Aug-2026)
 
 #1630: `UTF8StreamJsonParser.nextName()` ignores

--- a/src/main/java/tools/jackson/core/sym/CharsToNameCanonicalizer.java
+++ b/src/main/java/tools/jackson/core/sym/CharsToNameCanonicalizer.java
@@ -425,7 +425,7 @@ public final class CharsToNameCanonicalizer
      * @since 3.2
      */
     public boolean willInternStrings() {
-        return JsonFactory.Feature.INTERN_PROPERTY_NAMES.enabledIn(_factoryFeatures);
+        return _canonicalize && JsonFactory.Feature.INTERN_PROPERTY_NAMES.enabledIn(_factoryFeatures);
     }
 
     /**

--- a/src/test/java/tools/jackson/core/unittest/read/InternPropertyNamesTest.java
+++ b/src/test/java/tools/jackson/core/unittest/read/InternPropertyNamesTest.java
@@ -5,6 +5,7 @@ import java.io.*;
 import org.junit.jupiter.api.Test;
 
 import tools.jackson.core.JsonParser;
+import tools.jackson.core.JsonToken;
 import tools.jackson.core.ObjectReadContext;
 import tools.jackson.core.TokenStreamFactory;
 import tools.jackson.core.json.JsonFactory;
@@ -89,19 +90,26 @@ class InternPropertyNamesTest extends JacksonCoreTestBase
         }
     }
 
-    // When CANONICALIZE is disabled for byte-based input, the bootstrapper falls back
-    // to a ReaderBasedJsonParser. Its CharsToNameCanonicalizer still honours the
-    // INTERN_PROPERTY_NAMES flag, so interning is reported as enabled when that flag is set.
+    // INTERN_PROPERTY_NAMES only takes effect when canonicalization is enabled.
     @Test
-    void interningWhenCanonicalizationDisabled() throws Exception {
+    void interningDisabledWhenCanonicalizationDisabled() throws Exception {
         JsonFactory f = _factoryWith(true, false);
         try (JsonParser p = createParserUsingStream(f, DOC, "UTF-8")) {
-            assertTrue(p.willInternPropertyNames());
+            _verifyNonInternedName(p);
         }
-        // But when INTERN is also disabled, should be false
+        try (JsonParser p = createParserUsingReader(f, DOC)) {
+            _verifyNonInternedName(p);
+        }
+        try (JsonParser p = createParserForDataInput(f, new MockDataInput(DOC))) {
+            _verifyNonInternedName(p);
+        }
+        try (JsonParser p = f.createNonBlockingByteArrayParser(ObjectReadContext.empty())) {
+            assertFalse(p.willInternPropertyNames());
+        }
+
         JsonFactory f2 = _factoryWith(false, false);
         try (JsonParser p = createParserUsingStream(f2, DOC, "UTF-8")) {
-            assertFalse(p.willInternPropertyNames());
+            _verifyNonInternedName(p);
         }
     }
 
@@ -138,6 +146,15 @@ class InternPropertyNamesTest extends JacksonCoreTestBase
                 .configure(TokenStreamFactory.Feature.INTERN_PROPERTY_NAMES, intern)
                 .configure(TokenStreamFactory.Feature.CANONICALIZE_PROPERTY_NAMES, canonicalize)
                 .build();
+    }
+
+    private void _verifyNonInternedName(JsonParser p) throws Exception {
+        assertFalse(p.willInternPropertyNames());
+        assertToken(JsonToken.START_OBJECT, p.nextToken());
+        assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
+        String name = p.currentName();
+        assertEquals("a", name);
+        assertNotSame("a", name);
     }
 
 }


### PR DESCRIPTION
(originally by @Dongnyoung )

Rebase of #1667 onto `3.2`, plus release notes.

`CharsToNameCanonicalizer.willInternStrings()` checked only `INTERN_PROPERTY_NAMES`.
When `INTERN_PROPERTY_NAMES` is enabled but `CANONICALIZE_PROPERTY_NAMES` is disabled,
`findSymbol()` bypasses `_addSymbol()` and returns `new String(buffer, start, len)`
directly -- so names are not actually interned, even though
`JsonParser.willInternPropertyNames()` reported `true`. This also matches the feature
docs: `INTERN_PROPERTY_NAMES` only has effect when `CANONICALIZE_PROPERTY_NAMES` is on.

Fix includes `_canonicalize` in `willInternStrings()`, and extends
`InternPropertyNamesTest` to cover the `intern=true, canonicalize=false` case.

Targets `3.2` rather than `3.1`: `willInternPropertyNames()` / `willInternStrings()`
were added in 3.2.0 (#1211) and do not exist on the `3.1` branch.

Original commit and authorship by @Dongnyoung preserved.

Closes #1667

🤖 Generated with [Claude Code](https://claude.com/claude-code)