### PR TITLE
Combine duplicate CREDITS entries for @Dongnyoung

### DIFF
--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -56,6 +56,9 @@ Revanth Meesala (@revanthmeesala)
   (3.1.6)
 
 Lee Dongnyoung (@DongNyoung)
+ * Reported, fixed #1646: Non-blocking ByteBuffer parser `releaseBuffered()` can write
+   already-consumed bytes
+  (3.3.0)
  * Contributed #1651: Fix object context handling for buffered `INCLUDE_NON_NULL` tokens
   (3.1.6)
 
@@ -76,9 +79,4 @@ Antonin Janec (@xtonik)
 Scott Lewis (@scottslewis)
  * Contributed #1637: Add `JsonPointer.startsWith(JsonPointer)` to check
    prefix match
-  (3.3.0)
-
-DongNyoung Lee (@Dongnyoung)
- * Reported, fixed #1646: Non-blocking ByteBuffer parser `releaseBuffered()` can write
-   already-consumed bytes
   (3.3.0)


### PR DESCRIPTION
`release-notes/CREDITS` carried two entries for the same contributor:

- `Lee Dongnyoung (@DongNyoung)` -- #1651 (3.1.6)
- `DongNyoung Lee (@Dongnyoung)` -- #1646 (3.3.0)

Folds the second into the first, bullets sorted by issue number ascending
per the convention in `CREDITS-2.x`. Docs only, no code change.

The duplicate only existed on `3.x` (the #1646 entry is 3.3.0-only), so no
backport needed.

Verified that this auto-merges cleanly with #1670, which adds a #1667 bullet
to the same entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)