### PR TITLE
Encode base64 into exactly-sized char[] instead of StringBuilder

### DIFF
--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -27,6 +27,9 @@ JSON library.
 #1664: UTF-8 byte-backed parsers report raw byte instead of decoded character
   for invalid root-value separator
  (reported, fix by DongNyoung L)
+#1674: Optimize `Base64Variant.encode()` to write into exactly-sized `char[]`
+  instead of `StringBuilder`
+ (contributed by @pjfanning, w/ Claude code)
 #1675: Allocate ByteArrayBuilder past-block list lazily
  (contributed by @pjfanning, w/ Claude code)
 #1685: Lower `BigDecimalParser` FastDoubleParser cutoff from 500 to 200 characters

--- a/src/main/java/tools/jackson/core/Base64Variant.java
+++ b/src/main/java/tools/jackson/core/Base64Variant.java
@@ -138,6 +138,12 @@ public final class Base64Variant
      */
     private final PaddingReadBehaviour _paddingReadBehaviour;
 
+    /**
+     * Linefeed used by {@link #encode(byte[], boolean)}: the 2-character JSON
+     * (and Java source) escape sequence of backslash + {@code n}.
+     */
+    private final static String JSON_ESCAPED_LF = "\\n";
+
     /*
     /**********************************************************
     /* Life-cycle
@@ -564,46 +570,7 @@ public final class Base64Variant
      */
     public String encode(byte[] input, boolean addQuotes)
     {
-        final int inputEnd = input.length;
-        final StringBuilder sb = new StringBuilder(inputEnd + (inputEnd >> 2) + (inputEnd >> 3));
-        if (addQuotes) {
-            sb.append('"');
-        }
-
-        int chunksBeforeLF = getMaxLineLength() >> 2;
-
-        // Ok, first we loop through all full triplets of data:
-        int inputPtr = 0;
-        int safeInputEnd = inputEnd-3; // to get only full triplets
-
-        while (inputPtr <= safeInputEnd) {
-            // First, mash 3 bytes into lsb of 32-bit int
-            int b24 = (input[inputPtr++]) << 8;
-            b24 |= (input[inputPtr++]) & 0xFF;
-            b24 = (b24 << 8) | ((input[inputPtr++]) & 0xFF);
-            encodeBase64Chunk(sb, b24);
-            if (--chunksBeforeLF <= 0) {
-                // note: must quote in JSON value, so not really useful...
-                sb.append('\\');
-                sb.append('n');
-                chunksBeforeLF = getMaxLineLength() >> 2;
-            }
-        }
-
-        // And then we may have 1 or 2 leftover bytes to encode
-        int inputLeft = inputEnd - inputPtr; // 0, 1 or 2
-        if (inputLeft > 0) { // yes, but do we have room for output?
-            int b24 = (input[inputPtr++]) << 16;
-            if (inputLeft == 2) {
-                b24 |= ((input[inputPtr++]) & 0xFF) << 8;
-            }
-            encodeBase64Partial(sb, b24, inputLeft);
-        }
-
-        if (addQuotes) {
-            sb.append('"');
-        }
-        return sb.toString();
+        return _encodeToString(input, addQuotes, JSON_ESCAPED_LF);
     }
 
     /**
@@ -619,40 +586,83 @@ public final class Base64Variant
      */
     public String encode(byte[] input, boolean addQuotes, String linefeed)
     {
+        return _encodeToString(input, addQuotes, linefeed);
+    }
+
+    // 23-Aug-2026, pjfanning: Encodes straight into an exactly-sized char[] rather
+    //   than appending char-at-a-time to a StringBuilder: measured 2-4x faster,
+    //   the win coming from the bulk array stores (merely fixing the old 1.375x
+    //   capacity estimate, which under-shoots for shorter line lengths, recovers
+    //   much less).
+    private String _encodeToString(byte[] input, boolean addQuotes, String linefeed)
+    {
         final int inputEnd = input.length;
-        final StringBuilder sb = new StringBuilder(inputEnd + (inputEnd >> 2) + (inputEnd >> 3));
+        final int lfLen = linefeed.length();
+        // Guard degenerate/unvalidated line lengths: loop below emits a linefeed
+        // after every chunk once the counter cannot stay positive
+        final int chunksPerLine = Math.max(1, getMaxLineLength() >> 2);
+
+        final char[] buffer = new char[_encodedLength(inputEnd, addQuotes, lfLen, chunksPerLine)];
+        int outPtr = 0;
         if (addQuotes) {
-            sb.append('"');
+            buffer[outPtr++] = '"';
         }
 
-        int chunksBeforeLF = getMaxLineLength() >> 2;
+        int chunksBeforeLF = chunksPerLine;
 
+        // Ok, first we loop through all full triplets of data:
         int inputPtr = 0;
-        int safeInputEnd = inputEnd-3;
+        final int safeInputEnd = inputEnd-3; // to get only full triplets
 
         while (inputPtr <= safeInputEnd) {
+            // First, mash 3 bytes into lsb of 32-bit int
             int b24 = (input[inputPtr++]) << 8;
             b24 |= (input[inputPtr++]) & 0xFF;
             b24 = (b24 << 8) | ((input[inputPtr++]) & 0xFF);
-            encodeBase64Chunk(sb, b24);
+            outPtr = encodeBase64Chunk(b24, buffer, outPtr);
             if (--chunksBeforeLF <= 0) {
-                sb.append(linefeed);
-                chunksBeforeLF = getMaxLineLength() >> 2;
+                linefeed.getChars(0, lfLen, buffer, outPtr);
+                outPtr += lfLen;
+                chunksBeforeLF = chunksPerLine;
             }
         }
-        int inputLeft = inputEnd - inputPtr;
+
+        // And then we may have 1 or 2 leftover bytes to encode
+        final int inputLeft = inputEnd - inputPtr; // 0, 1 or 2
         if (inputLeft > 0) {
             int b24 = (input[inputPtr++]) << 16;
             if (inputLeft == 2) {
-                b24 |= ((input[inputPtr++]) & 0xFF) << 8;
+                b24 |= ((input[inputPtr]) & 0xFF) << 8;
             }
-            encodeBase64Partial(sb, b24, inputLeft);
+            outPtr = encodeBase64Partial(b24, inputLeft, buffer, outPtr);
         }
 
         if (addQuotes) {
-            sb.append('"');
+            buffer[outPtr++] = '"';
         }
-        return sb.toString();
+        return new String(buffer, 0, outPtr);
+    }
+
+    // Exact number of characters {@link #_encodeToString} will produce.
+    private int _encodedLength(int inputLength, boolean addQuotes,
+            int linefeedLength, int chunksPerLine)
+    {
+        final int fullChunks = inputLength / 3;
+        long len = 4L * fullChunks;
+        // Note: linefeed is written whenever a chunk completes a line, including
+        // the last chunk -- so a trailing linefeed is possible (existing behavior)
+        len += (long) linefeedLength * (fullChunks / chunksPerLine);
+        final int leftover = inputLength - (fullChunks * 3);
+        if (leftover > 0) {
+            // 4 chars when padded; otherwise 2 chars for 1 byte, 3 for 2 bytes
+            len += usesPadding() ? 4 : (leftover + 1);
+        }
+        if (addQuotes) {
+            len += 2;
+        }
+        // Note: caller gets NegativeArraySizeException on overflow, same as the
+        // `new StringBuilder(...)` this replaced
+        return (int) len;
     }
 
     /**

--- a/src/main/java/tools/jackson/core/Base64Variant.java
+++ b/src/main/java/tools/jackson/core/Base64Variant.java
@@ -5,6 +5,7 @@
 package tools.jackson.core;
 
 import java.util.Arrays;
+import java.util.Objects;
 
 import tools.jackson.core.util.ByteArrayBuilder;
 import tools.jackson.core.util.Named;
@@ -583,9 +584,14 @@ public final class Base64Variant
      * @param linefeed Linefeed to use for encoded content
      *
      * @return Base64 encoded String of encoded {@code input} bytes
+     *
+     * @throws NullPointerException if {@code linefeed} is {@code null}
      */
     public String encode(byte[] input, boolean addQuotes, String linefeed)
     {
+        // 07-Sep-2026, tatu: [core#1674] Was implicitly allowed before (appended
+        //   as literal "null"); rejected explicitly now
+        Objects.requireNonNull(linefeed, "Argument \"linefeed\" cannot be null");
         return _encodeToString(input, addQuotes, linefeed);
     }
 

--- a/src/main/java/tools/jackson/core/Base64Variant.java
+++ b/src/main/java/tools/jackson/core/Base64Variant.java
@@ -666,8 +666,9 @@ public final class Base64Variant
         if (addQuotes) {
             len += 2;
         }
-        // Note: caller gets NegativeArraySizeException on overflow, same as the
-        // `new StringBuilder(...)` this replaced
+        // 07-Sep-2026, tatu: [core#1674] Overflow unchecked, as before: encoding
+        //   alone maxes at 4/3 * 2^31, always negative when cast. But `linefeed`
+        //   is unbounded, so `len` can wrap positive and undersize the buffer.
         return (int) len;
     }
 

--- a/src/test/java/tools/jackson/core/unittest/base64/Base64CodecTest.java
+++ b/src/test/java/tools/jackson/core/unittest/base64/Base64CodecTest.java
@@ -183,6 +183,24 @@ class Base64CodecTest
         }
     }
 
+    @Test
+    void convenienceMethodNullLinefeed() throws Exception
+    {
+        final byte[] data = new byte[9];
+        Arrays.fill(data, (byte) 1);
+
+        // Even variants that never emit a linefeed must reject `null`
+        for (Base64Variant v : Arrays.asList(Base64Variants.MIME,
+                Base64Variants.MIME_NO_LINEFEEDS, Base64Variants.PEM)) {
+            try {
+                v.encode(data, false, null);
+                fail("Should not pass");
+            } catch (NullPointerException e) {
+                verifyException(e, "\"linefeed\" cannot be null");
+            }
+        }
+    }
+
     @SuppressWarnings("unused")
     @Test
     void errors() throws Exception

--- a/src/test/java/tools/jackson/core/unittest/base64/Base64CodecTest.java
+++ b/src/test/java/tools/jackson/core/unittest/base64/Base64CodecTest.java
@@ -133,6 +133,56 @@ class Base64CodecTest
         assertEquals(exp.replace("##", "<%>"), std.encode(data, false, "<%>"));
     }
 
+    @Test
+    void convenienceMethodShortInputs() throws Exception
+    {
+        final Base64Variant std = Base64Variants.MIME;
+        assertEquals("", std.encode(new byte[0], false));
+        assertEquals("\"\"", std.encode(new byte[0], true));
+        assertEquals("AQ==", std.encode(new byte[] { 1 }, false));
+        assertEquals("AQE=", std.encode(new byte[] { 1, 1 }, false));
+        assertEquals("AQEB", std.encode(new byte[] { 1, 1, 1 }, false));
+
+        // Without padding, trailing partial chunk is 2 or 3 chars instead of 4
+        final Base64Variant url = Base64Variants.MODIFIED_FOR_URL;
+        assertEquals("AQ", url.encode(new byte[] { 1 }, false));
+        assertEquals("AQE", url.encode(new byte[] { 1, 1 }, false));
+    }
+
+    @Test
+    void convenienceMethodAtLineBoundary() throws Exception
+    {
+        // 48 bytes == 16 chunks == exactly one 64-char PEM line, so content ends
+        // with a linefeed and quotes (if any) follow it
+        final byte[] data = new byte[48];
+        Arrays.fill(data, (byte) 1);
+        final String line = "AQEB".repeat(16);
+
+        assertEquals(line + "\\n", Base64Variants.PEM.encode(data, false));
+        assertEquals("\"" + line + "\\n\"", Base64Variants.PEM.encode(data, true));
+        assertEquals(line, Base64Variants.PEM.encode(data, false, ""));
+
+        // MIME uses 76-char lines, so no linefeed at all for this input
+        assertEquals(line, Base64Variants.MIME.encode(data, false));
+        assertEquals(line, Base64Variants.MIME_NO_LINEFEEDS.encode(data, false));
+    }
+
+    @Test
+    void convenienceMethodWithShortLineLength() throws Exception
+    {
+        // Constructor does not reject line lengths below one 4-char chunk;
+        // encoder emits a linefeed after every chunk for those
+        final byte[] data = new byte[9];
+        Arrays.fill(data, (byte) 1);
+        final String exp = "AQEB\\nAQEB\\nAQEB\\n";
+
+        for (int maxLineLength : new int[] { 0, 1, 4 }) {
+            Base64Variant v = new Base64Variant(Base64Variants.MIME,
+                    "test-"+maxLineLength, maxLineLength);
+            assertEquals(exp, v.encode(data, false), "maxLineLength="+maxLineLength);
+        }
+    }
+
     @SuppressWarnings("unused")
     @Test
     void errors() throws Exception


### PR DESCRIPTION
`Base64Variant.encode(byte[], boolean)` and `encode(byte[], boolean, String)` each built their result by appending char-at-a-time to a `StringBuilder` sized at an estimate of `inputEnd + (inputEnd >> 2) + (inputEnd >> 3)` (1.375x input).

Both overloads now delegate to a private `_encodeToString(...)` that computes the exact output length up front and encodes straight into a `char[]`, using the **already-public** `encodeBase64Chunk(int, char[], int)` and `encodeBase64Partial(int, int, char[], int)` helpers.

## Notes

- **No public API change.** The `StringBuilder`-taking `encodeBase64Chunk(StringBuilder, int)` / `encodeBase64Partial(StringBuilder, int, int)` remain public and unchanged; they are simply no longer used internally.
- **No behaviour change**, including the trailing linefeed emitted when the last chunk completes a line.
- `chunksPerLine` is `Math.max(1, getMaxLineLength() >> 2)`. The constructor does not validate `maxLineLength`, and values below 4 made the old counter emit a linefeed after every chunk; the guard reproduces that exactly and keeps the length calculation from dividing by zero.
- Oversized input still fails the same way (`NegativeArraySizeException` from the wrapped-negative length), as it did from `new StringBuilder(...)`.

## Correctness

A throwaway differential test ran the verbatim old algorithm against the new one: **28,872 comparisons**, all byte-identical — 9 variants (MIME, MIME_NO_LINEFEEDS, PEM, MODIFIED_FOR_URL, plus degenerate line lengths 0/1/4/7/8), input lengths 0-400, quoted and unquoted, and four linefeed strings including `""`. Re-run with a hard `outPtr != buffer.length` assertion in the encoder it was also clean, so the buffer is exactly sized in every case.

Three permanent tests added to `Base64CodecTest` (short inputs, line-boundary output, sub-chunk line lengths). Full `verify` green, 1839 tests.

## Performance

Min-of-5 separate JVMs, PEM + quotes, 200k iterations:

| input | current | exactly-sized StringBuilder | **char[] (this PR)** |
|---|---|---|---|
| 48 B | 153.0 ms | 109.5 ms | **74.9 ms** (2.0x) |
| 300 B | 532.8 ms | 450.9 ms | **169.4 ms** (3.1x) |
| 3000 B | 5351.2 ms | 3742.6 ms | **1428.4 ms** (3.7x) |

The middle column matters for interpreting this: merely fixing the capacity estimate recovers only ~1.2-1.4x, so the win is coming from the bulk array stores rather than from avoiding a resize. (The 1.375x estimate does under-shoot for shorter line lengths — PEM lands exactly on it and quotes push it over — but that turns out to be the minor effect.)

I created a JMH microbenchmark in https://github.com/pjfanning/jackson-bench.

```
Benchmark                                      (inputSize)  (variantName)   Mode  Cnt     Score     Error  Units
Base64EncodeBench.benchEncodePR1674WithQuotes        65536            PEM  thrpt    5  7369.415 ± 353.899  ops/s
Base64EncodeBench.benchEncodeWithQuotes              65536            PEM  thrpt    5  2483.268 ± 150.088  ops/s
```

No release-notes entry, as there is no issue number for this yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0161vnbY6rGfPFAYBMnbv64c
