### PR TITLE
Allocate `ByteArrayBuilder` past-block list lazily

### DIFF
--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -17,6 +17,8 @@ JSON library.
 
 3.3.0 (not yet released)
 
+#1675: Allocate ByteArrayBuilder past-block list lazily
+ (contributed by @pjfanning, w/ Claude code)
 #1637: Add `JsonPointer.startsWith(JsonPointer)` to check prefix match
  (contributed by @scottslewis)
 #1646: Non-blocking ByteBuffer parser `releaseBuffered()` can write

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -17,8 +17,6 @@ JSON library.
 
 3.3.0 (not yet released)
 
-#1675: Allocate ByteArrayBuilder past-block list lazily
- (contributed by @pjfanning, w/ Claude code)
 #1637: Add `JsonPointer.startsWith(JsonPointer)` to check prefix match
  (contributed by @scottslewis)
 #1646: Non-blocking ByteBuffer parser `releaseBuffered()` can write
@@ -27,6 +25,8 @@ JSON library.
 #1664: UTF-8 byte-backed parsers report raw byte instead of decoded character
   for invalid root-value separator
  (reported, fix by DongNyoung L)
+#1675: Allocate ByteArrayBuilder past-block list lazily
+ (contributed by @pjfanning, w/ Claude code)
 
 3.2.3 (not yet released)
 

--- a/src/main/java/tools/jackson/core/util/ByteArrayBuilder.java
+++ b/src/main/java/tools/jackson/core/util/ByteArrayBuilder.java
@@ -43,7 +43,9 @@ public final class ByteArrayBuilder
 
     // Optional buffer recycler instance that we can use for allocating the first block.
     private final BufferRecycler _bufferRecycler;
-    private final List<byte[]> _pastBlocks = new ArrayList<>();
+    // 24-Aug-2026, pjfanning: Allocated lazily on first block overflow: most
+    //   instances fit within the first block and never need this at all.
+    private List<byte[]> _pastBlocks;
 
     // Number of bytes within byte arrays in {@link _pastBlocks}.
     private int _pastLen;
@@ -78,7 +80,9 @@ public final class ByteArrayBuilder
         _pastLen = 0;
         _currBlockPtr = 0;
 
-        _pastBlocks.clear();
+        if (_pastBlocks != null) {
+            _pastBlocks.clear();
+        }
     }
 
     /**
@@ -163,10 +167,12 @@ public final class ByteArrayBuilder
         byte[] result = new byte[totalLen];
         int offset = 0;
 
-        for (byte[] block : _pastBlocks) {
-            int len = block.length;
-            System.arraycopy(block, 0, result, offset, len);
-            offset += len;
+        if (_pastBlocks != null) {
+            for (byte[] block : _pastBlocks) {
+                int len = block.length;
+                System.arraycopy(block, 0, result, offset, len);
+                offset += len;
+            }
         }
         System.arraycopy(_currBlock, 0, result, offset, _currBlockPtr);
         offset += _currBlockPtr;
@@ -174,7 +180,7 @@ public final class ByteArrayBuilder
             throw new RuntimeException("Internal error: total len assumed to be "+totalLen+", copied "+offset+" bytes");
         }
         // Let's only reset if there's sizable use, otherwise will get reset later on
-        if (!_pastBlocks.isEmpty()) {
+        if (_pastBlocks != null && !_pastBlocks.isEmpty()) {
             reset();
         }
         return result;
@@ -327,6 +333,9 @@ public final class ByteArrayBuilder
         // plus not to exceed max we define...
         if (newSize > MAX_BLOCK_SIZE) {
             newSize = MAX_BLOCK_SIZE;
+        }
+        if (_pastBlocks == null) {
+            _pastBlocks = new ArrayList<>();
         }
         _pastBlocks.add(_currBlock);
         _currBlock = new byte[newSize];

--- a/src/test/java/tools/jackson/core/unittest/util/ByteArrayBuilderTest.java
+++ b/src/test/java/tools/jackson/core/unittest/util/ByteArrayBuilderTest.java
@@ -86,6 +86,36 @@ public class ByteArrayBuilderTest extends JacksonCoreTestBase
         byteArrayBuilder.close();
     }
 
+    // Content spanning multiple blocks, then reuse of the same builder: exercises
+    // the lazily-created past-block list, including reset() before it exists
+    @Test
+    void testMultipleBlocksAndReuse() throws Exception
+    {
+        ByteArrayBuilder b = new ByteArrayBuilder(null, 10);
+
+        // First round: single block only, no overflow
+        b.write(new byte[] { 1, 2, 3 });
+        assertArrayEquals(new byte[] { 1, 2, 3 }, b.toByteArray());
+
+        // Second round: enough to overflow into several blocks
+        b.reset();
+        byte[] input = new byte[5000];
+        for (int i = 0; i < input.length; ++i) {
+            input[i] = (byte) i;
+        }
+        b.write(input);
+        assertEquals(input.length, b.size());
+        assertArrayEquals(input, b.toByteArray());
+
+        // Third round: back to a single block; past blocks must not linger
+        b.reset();
+        b.append(42);
+        assertArrayEquals(new byte[] { 42 }, b.toByteArray());
+
+        b.release();
+        b.close();
+    }
+
     // [core#1195]: Try to verify that BufferRecycler instance is indeed reused
     @Test
     void testBufferRecyclerReuse() throws Exception


### PR DESCRIPTION
`ByteArrayBuilder` allocated `_pastBlocks = new ArrayList<>()` in its field
initializer, for every instance. The list is only needed once content overflows
the first block — which for most instances never happens (`ParserBase`'s binary
decoding buffer, `JsonStringEncoder`'s `fromInitial(...)` slow path,
`Base64Variant.decode(String)`), since the first block is 500 bytes or a
recycled `BYTE_WRITE_CONCAT_BUFFER`.

Now created on first `_allocMore()`. `reset()`, `toByteArray()` and the
`isEmpty()` check are null-guarded; once created, the list survives `reset()` so
a reused builder does not re-allocate it.

### Size of the win — deliberately modest

Worth stating plainly: `new ArrayList<>()` does **not** eagerly allocate a
backing array — it uses the shared `DEFAULTCAPACITY_EMPTY_ELEMENTDATA` sentinel
until the first `add()`. So what is saved per instance is the `ArrayList` object
header itself, ~24 bytes, not a 40-element array. This is an allocation-count /
young-gen-pressure change, not something a throughput benchmark will show
clearly. I have not benchmarked it and am not claiming a measurable speedup.

The case for it is that it is free: no API change, no behaviour change, and the
null checks are on paths that are either cold (`toByteArray()`, `reset()`) or
already doing an allocation (`_allocMore()`).

### Test

New test `testMultipleBlocksAndReuse()` covers the paths this change alters:
single block (list never created), overflow across several blocks, and reuse of
the same builder afterwards.

Full suite green (1837 tests).

No release-notes entry, as there is no issue number for this yet.