### PR TITLE
Improve JsonFactory test coverage

### DIFF
--- a/src/test/java/tools/jackson/core/unittest/json/JsonFactoryTest.java
+++ b/src/test/java/tools/jackson/core/unittest/json/JsonFactoryTest.java
@@ -135,8 +135,8 @@ public class JsonFactoryTest
 
         JsonFactory jf2 = f.copy();
         assertTrue(jf2.isEnabled(JsonFactory.Feature.INTERN_PROPERTY_NAMES));
-        assertTrue(f.isEnabled(JsonReadFeature.ALLOW_JAVA_COMMENTS));
-        assertTrue(f.isEnabled(JsonWriteFeature.ESCAPE_NON_ASCII));
+        assertTrue(jf2.isEnabled(JsonReadFeature.ALLOW_JAVA_COMMENTS));
+        assertTrue(jf2.isEnabled(JsonWriteFeature.ESCAPE_NON_ASCII));
     }
 
     @Test

--- a/src/test/java/tools/jackson/core/unittest/json/JsonFactoryTest.java
+++ b/src/test/java/tools/jackson/core/unittest/json/JsonFactoryTest.java
@@ -319,7 +319,7 @@ public class JsonFactoryTest
 
     @Test
     public void testCanonicalizationEnabled() throws Exception {
-        doCanonicalizationTest(false);
+        doCanonicalizationTest(true);
     }
 
     @Test

--- a/src/test/java/tools/jackson/core/unittest/json/JsonFactoryTest.java
+++ b/src/test/java/tools/jackson/core/unittest/json/JsonFactoryTest.java
@@ -157,6 +157,21 @@ public class JsonFactoryTest
         g.writeNumber(3);
         g.close();
         assertEquals("1/2/3", w.toString());
+
+        b = JsonFactory.builder()
+                .rootValueSeparator((String)null);
+        assertNull(b.rootValueSeparator());
+
+        f = b.build();
+        assertNull(f.getRootValueSeparator());
+
+        w = new StringWriter();
+        g = f.createGenerator(ObjectWriteContext.empty(), w);
+        g.writeNumber(1);
+        g.writeNumber(2);
+        g.writeNumber(3);
+        g.close();
+        assertEquals("123",w.toString());
     }
 
     @Test


### PR DESCRIPTION
### Changes

Improve `JsonFactoryTest` coverage for a few existing behaviors:

- Fix `testCanonicalizationEnabled()` to actually test canonicalization with the feature enabled.
- Verify that `JsonFactory.copy()` preserves `JsonReadFeature` and `JsonWriteFeature` settings on the copied factory.
- Add coverage for disabling the root value separator with `null`, including the generated output.

### Tests

```powershell
.\mvnw.cmd test "-Dtest=JsonFactoryTest" "-Dsurefire.useModulePath=false"