### PR TITLE
Add failing `ReaderBasedJsonParser` reproduction for #1677

### DIFF
--- a/src/test/java/tools/jackson/core/unittest/read/SimpleParserTest.java
+++ b/src/test/java/tools/jackson/core/unittest/read/SimpleParserTest.java
@@ -745,6 +745,27 @@ class SimpleParserTest extends JacksonCoreTestBase
     }
 
     @Test
+    void readerBasedStringLengthEnforcesMaxStringLengthAtInputBoundary() throws Exception
+    {
+        final int maxLen = 500;
+        final String longText = "x".repeat(2_000);
+
+        JsonFactory factory = JsonFactory.builder()
+                .streamReadConstraints(StreamReadConstraints.builder().maxStringLength(maxLen).build())
+                .build();
+
+        // Keep the closing quote in the second read so _finishString() must
+        // copy the over-limit prefix into TextBuffer before loading more input.
+        try (JsonParser parser = factory.createParser(ObjectReadContext.empty(),
+                new ChunkedReader("[\"" + longText, "\"]"))) {
+            assertToken(JsonToken.START_ARRAY, parser.nextToken());
+            assertToken(JsonToken.VALUE_STRING, parser.nextToken());
+
+            assertThrows(StreamConstraintsException.class, parser::getStringLength);
+        }
+    }
+
+    @Test
     void readStringWithIncreasedLimit() throws Exception
     {
         for (int mode : ALL_MODES) {
@@ -870,6 +891,41 @@ class SimpleParserTest extends JacksonCoreTestBase
     /* Helper methods
     /**********************************************************
      */
+
+    private static class ChunkedReader extends Reader
+    {
+        private final String[] _chunks;
+
+        private int _chunkIndex;
+        private int _chunkOffset;
+
+        ChunkedReader(String... chunks) {
+            _chunks = chunks;
+        }
+
+        @Override
+        public int read(char[] cbuf, int off, int len) throws IOException {
+            if (len == 0) {
+                return 0;
+            }
+            while (_chunkIndex < _chunks.length) {
+                String chunk = _chunks[_chunkIndex];
+                int remaining = chunk.length() - _chunkOffset;
+                if (remaining > 0) {
+                    int amount = Math.min(len, remaining);
+                    chunk.getChars(_chunkOffset, _chunkOffset + amount, cbuf, off);
+                    _chunkOffset += amount;
+                    return amount;
+                }
+                ++_chunkIndex;
+                _chunkOffset = 0;
+            }
+            return -1;
+        }
+
+        @Override
+        public void close() { }
+    }
 
     private void _doTestSpec(boolean verify)
     {


### PR DESCRIPTION
### Problem

This PR adds a parser-level failing reproduction for #1677, as discussed in the issue.

The reproduction uses the normal `JsonFactory.createParser(..., Reader)` API rather than calling `TextBuffer` directly. The custom `Reader` only controls read boundaries: it returns an over-limit string prefix in one read and the closing quote in the next read, which is a normal condition for streaming `Reader` input.

When the first read ends before the closing quote, `ReaderBasedJsonParser._finishString()` reaches:

`TextBuffer.resetWithCopy(char[], int, int)`

with the known prefix length already exceeding `maxStringLength`.

With `maxStringLength = 500` and a 2,000-character prefix, the current implementation does not throw `StreamConstraintsException`; `getStringLength()` completes normally. Therefore the added test intentionally fails.

### Reproduction path

`JsonFactory.createParser(..., Reader)` → `ReaderBasedJsonParser` → `getStringLength()` → `_finishString()` → `TextBuffer.resetWithCopy(...)`

This PR intentionally contains only the failing parser-level reproduction and does not include a production fix yet.