### PR TITLE
Fix #1680: drop the per-character escape-table load in the ASCII copy loop

### DIFF
--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -68,3 +68,8 @@ Burak KALAYCI (@kalayciburak)
  * Contributed #1668: `WriterBasedJsonGenerator` AIOOBE when a zero-length custom
    escape lands at the output buffer boundary
   (3.1.7)
+
+Francesco Nigro (@franz1981)
+ * Reported, contributed fix for #1680: Avoid per-character escape-table load in
+   `_writeStringSegment` ASCII loop
+  (3.1.7)

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -24,6 +24,9 @@ JSON library.
 #1673: `readString(Writer)` AIOOBE when an escape or multi-byte character
   lands at the output buffer boundary
  (fix by @pjfanning)
+#1680: Avoid per-character escape-table load in `_writeStringSegment` ASCII loop
+ (reported by @franz1981)
+ (fix by @franz1981)
 
 3.1.6 (14-Aug-2026)
 

--- a/src/main/java/tools/jackson/core/json/UTF8JsonGenerator.java
+++ b/src/main/java/tools/jackson/core/json/UTF8JsonGenerator.java
@@ -1470,11 +1470,17 @@ public class UTF8JsonGenerator
         int outputPtr = _outputTail;
         final byte[] outputBuffer = _outputBuffer;
         final int[] escCodes = _outputEscapes;
+        // 01-Sep-2026, franz1981: [core#1680] For the standard table the test is expressible
+        //   with constants; C2 unswitches on this flag so that clone has no per-character
+        //   table load. A custom quote char, escaped slashes or CharacterEscapes give a
+        //   different array and fall back to the lookup below.
+        final boolean stdEsc = (escCodes == CharTypes.get7BitOutputEscapes());
 
         while (offset < len) {
             int ch = cbuf[offset];
             // note: here we know that (ch > 0x7F) will cover case of escaping non-ASCII too:
-            if (ch > 0x7F || escCodes[ch] != 0) {
+            if (stdEsc ? (ch < 0x20 || ch > 0x7F || ch == '"' || ch == '\\')
+                    : (ch > 0x7F || escCodes[ch] != 0)) {
                 break;
             }
             outputBuffer[outputPtr++] = (byte) ch;
@@ -1502,11 +1508,17 @@ public class UTF8JsonGenerator
         int outputPtr = _outputTail;
         final byte[] outputBuffer = _outputBuffer;
         final int[] escCodes = _outputEscapes;
+        // 01-Sep-2026, franz1981: [core#1680] For the standard table the test is expressible
+        //   with constants; C2 unswitches on this flag so that clone has no per-character
+        //   table load. A custom quote char, escaped slashes or CharacterEscapes give a
+        //   different array and fall back to the lookup below.
+        final boolean stdEsc = (escCodes == CharTypes.get7BitOutputEscapes());
 
         while (offset < len) {
             int ch = text.charAt(offset);
             // note: here we know that (ch > 0x7F) will cover case of escaping non-ASCII too:
-            if (ch > 0x7F || escCodes[ch] != 0) {
+            if (stdEsc ? (ch < 0x20 || ch > 0x7F || ch == '"' || ch == '\\')
+                    : (ch > 0x7F || escCodes[ch] != 0)) {
                 break;
             }
             outputBuffer[outputPtr++] = (byte) ch;


### PR DESCRIPTION
_writeStringSegment() reads _outputEscapes[ch] per character. For the standard table the same test is constant-expressible, so the loop now branches on a loop-invariant flag that C2 unswitches and constant-folds; the standard clone has no table load. Custom quote char, escaped slashes and CharacterEscapes are unaffected -- different array, flag false, original lookup.

Shorter body lets C2 unroll 4 characters per iteration instead of 2: 15.5 ->
13.8 instructions and 2 -> 1 stack operands per character on JDK 25/x86_64. Writing one String property per object: 356.5 -> 347.5 ns/op (3.1.5).

Measure after databind#6182: with that present the loop is not unrolled at all and this change appears to be worth ~23%, which is mostly that issue and not the removed load.

Output verified byte-identical over chars 0x00-0x100, quotes, backslashes, control chars and strings crossing the segment boundary.