### PR TITLE
Fix #1680: overridable escape-scan fast path for JSON generators

### DIFF
--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -112,3 +112,8 @@ Steven Schlansker (@stevenschlansker)
  * Contributed #1688: Add `JsonParser.nextNameMatchAndToken()`, fused property
    name match plus value token advance
   (3.3.0)
+
+Francesco Nigro (@franz1981)
+ * Suggested #1680: Avoid per-character escape-table load in JSON String value
+   serialization fast path
+  (3.3.0)

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -32,6 +32,9 @@ JSON library.
  (contributed by @pjfanning, w/ Claude code)
 #1675: Allocate ByteArrayBuilder past-block list lazily
  (contributed by @pjfanning, w/ Claude code)
+#1680: Avoid per-character escape-table load in JSON String value
+  serialization fast path
+ (suggested by Francesco N)
 #1685: Lower `BigDecimalParser` FastDoubleParser cutoff from 500 to 200 characters
  (reported, fix by DongNyoung L)
 #1686: Synchronous decimal number parsing buffers oversized values before

--- a/src/main/java/tools/jackson/core/json/UTF8JsonGenerator.java
+++ b/src/main/java/tools/jackson/core/json/UTF8JsonGenerator.java
@@ -1516,20 +1516,9 @@ public class UTF8JsonGenerator
         // Fast+tight loop for ASCII-only, no-escaping-needed output
         len += offset; // becomes end marker, then
 
-        int outputPtr = _outputTail;
-        final byte[] outputBuffer = _outputBuffer;
-        final int[] escCodes = _outputEscapes;
-
-        while (offset < len) {
-            int ch = cbuf[offset];
-            // note: here we know that (ch > 0x7F) will cover case of escaping non-ASCII too:
-            if (ch > 0x7F || escCodes[ch] != 0) {
-                break;
-            }
-            outputBuffer[outputPtr++] = (byte) ch;
-            ++offset;
-        }
-        _outputTail = outputPtr;
+        final int start = offset;
+        offset = _writeUnescapedAscii(cbuf, offset, len, _outputBuffer, _outputTail);
+        _outputTail += (offset - start);
         if (offset < len) {
             if (_characterEscapes != null) {
                 _writeCustomStringSegment2(cbuf, offset, len);
@@ -1548,20 +1537,9 @@ public class UTF8JsonGenerator
         // Fast+tight loop for ASCII-only, no-escaping-needed output
         len += offset; // becomes end marker, then
 
-        int outputPtr = _outputTail;
-        final byte[] outputBuffer = _outputBuffer;
-        final int[] escCodes = _outputEscapes;
-
-        while (offset < len) {
-            int ch = text.charAt(offset);
-            // note: here we know that (ch > 0x7F) will cover case of escaping non-ASCII too:
-            if (ch > 0x7F || escCodes[ch] != 0) {
-                break;
-            }
-            outputBuffer[outputPtr++] = (byte) ch;
-            ++offset;
-        }
-        _outputTail = outputPtr;
+        final int start = offset;
+        offset = _writeUnescapedAscii(text, offset, len, _outputBuffer, _outputTail);
+        _outputTail += (offset - start);
         if (offset < len) {
             if (_characterEscapes != null) {
                 _writeCustomStringSegment2(text, offset, len);
@@ -1571,6 +1549,92 @@ public class UTF8JsonGenerator
                 _writeStringSegmentASCII2(text, offset, len);
             }
         }
+    }
+
+    /**
+     * Method that copies as many characters as possible from given text segment
+     * into output buffer (one byte per character), stopping at the first character
+     * that is either non-ASCII (code above 0x7F) or needs escaping as per
+     * {@link #_outputEscapes}.
+     *<p>
+     * Default implementation checks characters against {@link #_outputEscapes},
+     * with a specialization for the standard JSON escape settings; sub-classes
+     * with statically known escaping rules may override this method to use a
+     * simple comparison-based check instead of a per-character table lookup.
+     *
+     * @param cbuf Buffer that contains characters to copy
+     * @param offset Offset of the first character to copy
+     * @param end Offset after the last character that may be copied
+     * @param outputBuffer Output buffer to copy characters into
+     * @param outputPtr Offset in {@code outputBuffer} to start copying at
+     *
+     * @return Offset of the first character NOT copied ({@code end} if all were):
+     *   the output pointer will have advanced by same amount as the offset
+     *
+     * @since 3.3
+     */
+    protected int _writeUnescapedAscii(final char[] cbuf, int offset, final int end,
+            final byte[] outputBuffer, int outputPtr)
+    {
+        final int[] escCodes = _outputEscapes;
+        // [core#1680]: With standard escape settings can check the (few) escapable
+        // characters directly, avoiding per-character escape table load
+        if (escCodes == CharTypes.get7BitOutputEscapes()) {
+            while (offset < end) {
+                final int ch = cbuf[offset];
+                if (ch < 0x20 || ch > 0x7F || ch == '"' || ch == '\\') {
+                    break;
+                }
+                outputBuffer[outputPtr++] = (byte) ch;
+                ++offset;
+            }
+            return offset;
+        }
+        while (offset < end) {
+            final int ch = cbuf[offset];
+            // note: here we know that (ch > 0x7F) will cover case of escaping non-ASCII too:
+            if (ch > 0x7F || escCodes[ch] != 0) {
+                break;
+            }
+            outputBuffer[outputPtr++] = (byte) ch;
+            ++offset;
+        }
+        return offset;
+    }
+
+    /**
+     * Alternative to {@link #_writeUnescapedAscii(char[], int, int, byte[], int)}
+     * used when content to copy comes as a {@link String}.
+     *
+     * @since 3.3
+     */
+    protected int _writeUnescapedAscii(final String text, int offset, final int end,
+            final byte[] outputBuffer, int outputPtr)
+    {
+        final int[] escCodes = _outputEscapes;
+        // [core#1680]: With standard escape settings can check the (few) escapable
+        // characters directly, avoiding per-character escape table load
+        if (escCodes == CharTypes.get7BitOutputEscapes()) {
+            while (offset < end) {
+                final int ch = text.charAt(offset);
+                if (ch < 0x20 || ch > 0x7F || ch == '"' || ch == '\\') {
+                    break;
+                }
+                outputBuffer[outputPtr++] = (byte) ch;
+                ++offset;
+            }
+            return offset;
+        }
+        while (offset < end) {
+            final int ch = text.charAt(offset);
+            // note: here we know that (ch > 0x7F) will cover case of escaping non-ASCII too:
+            if (ch > 0x7F || escCodes[ch] != 0) {
+                break;
+            }
+            outputBuffer[outputPtr++] = (byte) ch;
+            ++offset;
+        }
+        return offset;
     }
 
     /**

--- a/src/main/java/tools/jackson/core/json/WriterBasedJsonGenerator.java
+++ b/src/main/java/tools/jackson/core/json/WriterBasedJsonGenerator.java
@@ -1198,25 +1198,54 @@ public class WriterBasedJsonGenerator
         }
     }
 
+    /**
+     * Helper method that finds offset of the first character in given range
+     * (from {@code ptr}, inclusive, to {@code end}, exclusive) that needs
+     * escaping as per {@link #_outputEscapes}; returning {@code end} if none does.
+     *<p>
+     * Default implementation checks characters against {@link #_outputEscapes},
+     * with a specialization for the standard JSON escape settings; sub-classes
+     * with statically known escaping rules may override this method to use a
+     * simple comparison-based check instead of a per-character table lookup.
+     *
+     * @since 3.3
+     */
+    protected int _findFirstToEscape(final char[] cbuf, int ptr, final int end)
+    {
+        final int[] escCodes = _outputEscapes;
+        // [core#1680]: With standard escape settings can check the (few) escapable
+        // characters directly, avoiding per-character escape table load
+        if (escCodes == CharTypes.get7BitOutputEscapes()) {
+            while (ptr < end) {
+                final char c = cbuf[ptr];
+                if (c < 0x20 || c == '"' || c == '\\') {
+                    break;
+                }
+                ++ptr;
+            }
+            return ptr;
+        }
+        final int escLen = escCodes.length;
+        while (ptr < end) {
+            final char c = cbuf[ptr];
+            if (c < escLen && escCodes[c] != 0) {
+                break;
+            }
+            ++ptr;
+        }
+        return ptr;
+    }
+
     private void _writeString2(final int len) throws JacksonException
     {
         // And then we'll need to verify need for escaping etc:
         final int end = _outputTail + len;
-        final int[] escCodes = _outputEscapes;
-        final int escLen = escCodes.length;
 
-        output_loop:
         while (_outputTail < end) {
-            // Fast loop for chars not needing escaping
-            escape_loop:
-            while (true) {
-                char c = _outputBuffer[_outputTail];
-                if (c < escLen && escCodes[c] != 0) {
-                    break escape_loop;
-                }
-                if (++_outputTail >= end) {
-                    break output_loop;
-                }
+            // Fast scan for chars not needing escaping:
+            _outputTail = _findFirstToEscape(_outputBuffer, _outputTail, end);
+            if (_outputTail >= end) {
+                break;
             }
 
             // Ok, bumped into something that needs escaping.
@@ -1235,7 +1264,7 @@ public class WriterBasedJsonGenerator
              * we have room now.
              */
             char c = _outputBuffer[_outputTail++];
-            _prependOrWriteCharacterEscape(c, escCodes[c]);
+            _prependOrWriteCharacterEscape(c, _outputEscapes[c]);
         }
     }
 
@@ -1279,26 +1308,15 @@ public class WriterBasedJsonGenerator
     private void _writeSegment(int end) throws JacksonException
     {
         final int[] escCodes = _outputEscapes;
-        final int escLen = escCodes.length;
 
         int ptr = 0;
         int start = ptr;
 
-        output_loop:
         while (ptr < end) {
-            // Fast loop for chars not needing escaping
-            char c;
-            while (true) {
-                c = _outputBuffer[ptr];
-                if (c < escLen && escCodes[c] != 0) {
-                    break;
-                }
-                if (++ptr >= end) {
-                    break;
-                }
-            }
+            // Fast scan for chars not needing escaping:
+            ptr = _findFirstToEscape(_outputBuffer, ptr, end);
 
-            // Ok, bumped into something that needs escaping.
+            // Ok, bumped into something that needs escaping, or hit the end.
             /* First things first: need to flush the buffer.
              * Inlined, as we don't want to lose tail pointer
              */
@@ -1310,10 +1328,10 @@ public class WriterBasedJsonGenerator
                     throw _wrapIOFailure(e);
                 }
                 if (ptr >= end) {
-                    break output_loop;
+                    break;
                 }
             }
-            ++ptr;
+            char c = _outputBuffer[ptr++];
             // So; either try to prepend (most likely), or write directly:
             start = _prependOrWriteCharacterEscape(_outputBuffer, ptr, end, c, escCodes[c]);
         }
@@ -1339,19 +1357,10 @@ public class WriterBasedJsonGenerator
 
         len += offset; // -> len marks the end from now on
         final int[] escCodes = _outputEscapes;
-        final int escLen = escCodes.length;
         while (offset < len) {
             int start = offset;
-
-            while (true) {
-                char c = text[offset];
-                if (c < escLen && escCodes[c] != 0) {
-                    break;
-                }
-                if (++offset >= len) {
-                    break;
-                }
-            }
+            // Fast scan for chars not needing escaping:
+            offset = _findFirstToEscape(text, offset, len);
 
             // Short span? Better just copy it to buffer first:
             int newAmount = offset - start;


### PR DESCRIPTION
Alternative/extension to #1681 (by @franz1981), targeting `3.x` since it adds new `protected` API.

Extracts the ASCII fast-scan loops into overridable `protected` methods, one virtual call per segment (per-character hooks would defeat the optimization once any override is loaded):

- `UTF8JsonGenerator._writeUnescapedAscii(char[]/String, ...)` — scan+copy, used by both `_writeStringSegment` fast loops
- `WriterBasedJsonGenerator._findFirstToEscape(char[], int, int)` — scan only, used by `_writeString2`, `_writeSegment`, `_writeString(char[],...)`

Default implementations include #1681's loop-invariant specialization: when `_outputEscapes == CharTypes.get7BitOutputEscapes()` the loop tests `ch < 0x20 || ch > 0x7F || ch == '"' || ch == '\\'` directly (no table load; C2 unswitches on the invariant). Custom `CharacterEscapes`, `ESCAPE_FORWARD_SLASHES` and alternate quote chars keep the original table lookup, so output is unchanged everywhere. Sub-classes with statically known escaping rules can override with a simple `||` check of their own.

Relative to #1681: also covers `WriterBasedJsonGenerator`, and exposes the extension point; happy to rebase on top of #1681 if that lands in `3.1` first.

Fixes #1680

🤖 Generated with [Claude Code](https://claude.com/claude-code)