### PR TITLE
Fix #1683: reject JSON-escaped lone surrogates in ReaderBasedJsonParser

### DIFF
--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -554,3 +554,9 @@ Burak KALAYCI (@kalayciburak)
  * Contributed #1668: `WriterBasedJsonGenerator` AIOOBE when a zero-length custom
    escape lands at the output buffer boundary
   (2.21.7)
+
+Elankumaran Srinivasan (@elang2)
+ * Contributed #1683: `ReaderBasedJsonParser` should reject JSON-escaped lone
+   surrogates in field names and string values (mirror of #1541 fix in
+   `UTF8StreamJsonParser`)
+  (2.23.0)

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -20,6 +20,10 @@ a pure JSON library.
   based on supplied length
  (requested by @kilink)
  (contributed by @seonwooj0810)
+#1683: `ReaderBasedJsonParser` should reject JSON-escaped lone
+  surrogates in field names and string values (mirror of #1541
+  fix in `UTF8StreamJsonParser`)
+ (contributed by @elang2)
 
 2.22.3 (not yet released)
 

--- a/src/main/java/com/fasterxml/jackson/core/json/ReaderBasedJsonParser.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/ReaderBasedJsonParser.java
@@ -1866,6 +1866,46 @@ public class ReaderBasedJsonParser
                      * For now let's assume it does not.
                      */
                     c = _decodeEscaped();
+                    // [jackson-core#1683]: Validate JSON-escaped surrogates in
+                    //   field name. Mirror of [jackson-core#1541] fix in
+                    //   UTF8StreamJsonParser.
+                    if (c >= 0xD800 && c <= 0xDFFF) {
+                        if (c < 0xDC00) { // high surrogate: must be followed by low surrogate escape
+                            char hi = c;
+                            if (_inputPtr >= _inputEnd) {
+                                if (!_loadMore()) {
+                                    _reportInvalidEOF(" in field name", JsonToken.FIELD_NAME);
+                                }
+                            }
+                            if (_inputBuffer[_inputPtr] != INT_BACKSLASH) {
+                                _reportUnexpectedCharAfterHighSurrogate(_inputBuffer[_inputPtr] & 0xFFFF, "field name");
+                            }
+                            ++_inputPtr;
+                            char lo = _decodeEscaped();
+                            if (lo < 0xDC00 || lo > 0xDFFF) {
+                                _reportBrokenSurrogatePair(lo, "field name");
+                            }
+                            // Store as two UTF-16 code units. Hash includes the low
+                            // surrogate below; add high surrogate here.
+                            hash = (hash * CharsToNameCanonicalizer.HASH_MULT) + hi;
+                            if (outPtr >= outBuf.length) {
+                                totalLen += outBuf.length;
+                                _streamReadConstraints.validateNameLength(totalLen);
+                                outBuf = _textBuffer.finishCurrentSegment();
+                                outPtr = 0;
+                            }
+                            outBuf[outPtr++] = hi;
+                            if (outPtr >= outBuf.length) {
+                                totalLen += outBuf.length;
+                                _streamReadConstraints.validateNameLength(totalLen);
+                                outBuf = _textBuffer.finishCurrentSegment();
+                                outPtr = 0;
+                            }
+                            c = lo;
+                        } else { // lone low surrogate
+                            _reportUnexpectedLowSurrogate(c, "field name");
+                        }
+                    }
                 } else if (i <= endChar) {
                     if (i == endChar) {
                         break;
@@ -2086,6 +2126,36 @@ public class ReaderBasedJsonParser
                     // an UTF-16 surrogate pair, does that affect decoding?
                     // For now let's assume it does not.
                     c = _decodeEscaped();
+                    // [jackson-core#1683]: Validate JSON-escaped surrogates in
+                    //   apostrophe-quoted string value.
+                    if (c >= 0xD800 && c <= 0xDFFF) {
+                        if (c < 0xDC00) { // high surrogate
+                            char hi = c;
+                            if (_inputPtr >= _inputEnd) {
+                                if (!_loadMore()) {
+                                    _reportInvalidEOF(
+                                            ": was expecting closing quote for a string value",
+                                            JsonToken.VALUE_STRING);
+                                }
+                            }
+                            if (_inputBuffer[_inputPtr] != INT_BACKSLASH) {
+                                _reportUnexpectedCharAfterHighSurrogate(_inputBuffer[_inputPtr] & 0xFFFF, "string value");
+                            }
+                            ++_inputPtr;
+                            char lo = _decodeEscaped();
+                            if (lo < 0xDC00 || lo > 0xDFFF) {
+                                _reportBrokenSurrogatePair(lo, "string value");
+                            }
+                            if (outPtr >= outBuf.length) {
+                                outBuf = _textBuffer.finishCurrentSegment();
+                                outPtr = 0;
+                            }
+                            outBuf[outPtr++] = hi;
+                            c = lo;
+                        } else { // lone low surrogate
+                            _reportUnexpectedLowSurrogate(c, "string value");
+                        }
+                    }
                 } else if (i <= '\'') {
                     if (i == '\'') {
                         break;
@@ -2214,6 +2284,39 @@ public class ReaderBasedJsonParser
                      * For now let's assume it does not.
                      */
                     c = _decodeEscaped();
+                    // [jackson-core#1683]: Validate JSON-escaped surrogates in
+                    //   string value. Mirror of [jackson-core#1541] fix in
+                    //   UTF8StreamJsonParser, applied to the Reader-based path.
+                    if (c >= 0xD800 && c <= 0xDFFF) {
+                        if (c < 0xDC00) { // high surrogate: must be followed by low surrogate escape
+                            char hi = c;
+                            if (_inputPtr >= _inputEnd) {
+                                if (!_loadMore()) {
+                                    _reportInvalidEOF(
+                                            ": was expecting closing quote for a string value",
+                                            JsonToken.VALUE_STRING);
+                                }
+                            }
+                            if (_inputBuffer[_inputPtr] != INT_BACKSLASH) {
+                                _reportUnexpectedCharAfterHighSurrogate(_inputBuffer[_inputPtr] & 0xFFFF, "string value");
+                            }
+                            ++_inputPtr;
+                            char lo = _decodeEscaped();
+                            if (lo < 0xDC00 || lo > 0xDFFF) {
+                                _reportBrokenSurrogatePair(lo, "string value");
+                            }
+                            // Emit high surrogate first, then fall through so the
+                            // low surrogate is appended by the normal path below.
+                            if (outPtr >= outBuf.length) {
+                                outBuf = _textBuffer.finishCurrentSegment();
+                                outPtr = 0;
+                            }
+                            outBuf[outPtr++] = hi;
+                            c = lo;
+                        } else { // lone low surrogate
+                            _reportUnexpectedLowSurrogate(c, "string value");
+                        }
+                    }
                 } else if (i < INT_SPACE) {
                     _throwUnquotedSpace(i, "string value");
                 } // anything else?
@@ -2262,7 +2365,33 @@ public class ReaderBasedJsonParser
                     // Although chars outside of BMP are to be escaped as an UTF-16 surrogate pair,
                     // does that affect decoding? For now let's assume it does not.
                     _inputPtr = inPtr;
-                    /*c = */ _decodeEscaped();
+                    char decoded = _decodeEscaped();
+                    // [jackson-core#1683]: Validate JSON-escaped surrogates even when
+                    //   the string content is being skipped, so callers that stream
+                    //   over content with `skipChildren()` still see malformed input.
+                    if (decoded >= 0xD800 && decoded <= 0xDFFF) {
+                        if (decoded < 0xDC00) { // high surrogate: must be followed by low surrogate escape
+                            char hi = decoded;
+                            if (_inputPtr >= _inputEnd) {
+                                if (!_loadMore()) {
+                                    _reportInvalidEOF(
+                                            ": was expecting closing quote for a string value",
+                                            JsonToken.VALUE_STRING);
+                                }
+                            }
+                            if (_inputBuffer[_inputPtr] != INT_BACKSLASH) {
+                                _reportUnexpectedCharAfterHighSurrogate(_inputBuffer[_inputPtr] & 0xFFFF, "string value");
+                            }
+                            ++_inputPtr;
+                            char lo = _decodeEscaped();
+                            if (lo < 0xDC00 || lo > 0xDFFF) {
+                                _reportBrokenSurrogatePair(lo, "string value");
+                            }
+                        } else { // lone low surrogate
+                            _reportUnexpectedLowSurrogate(decoded, "string value");
+                        }
+                    }
+                    inBuf = _inputBuffer;
                     inPtr = _inputPtr;
                     inLen = _inputEnd;
                 } else if (i <= INT_QUOTE) {
@@ -3039,6 +3168,24 @@ public class ReaderBasedJsonParser
         }
         final String fullMsg = String.format("Unrecognized token '%s': was expecting %s", sb, msg);
         throw _constructReadException(fullMsg, loc);
+    }
+
+    // [jackson-core#1683]: helpers for reporting malformed JSON-escaped surrogate
+    //   sequences. Wording mirrors the messages introduced for UTF8StreamJsonParser
+    //   by the [jackson-core#1541] fix, extended to name the offending context.
+    private void _reportUnexpectedLowSurrogate(int lo, String ctx) throws IOException {
+        _reportError("Unexpected low surrogate in " + ctx + ": 0x" + Integer.toHexString(lo));
+    }
+
+    private void _reportUnexpectedCharAfterHighSurrogate(int next, String ctx)
+            throws IOException {
+        _reportError("Broken surrogate pair in " + ctx
+                + ": expected '\\' to start low surrogate, got 0x" + Integer.toHexString(next));
+    }
+
+    private void _reportBrokenSurrogatePair(int lo, String ctx) throws IOException {
+        _reportError(String.format(
+                "Broken surrogate pair in %s: expected low surrogate, got 0x%04X", ctx, lo));
     }
 
     /*

--- a/src/test/java/com/fasterxml/jackson/core/read/EscapedSurrogateInStringValue1683Test.java
+++ b/src/test/java/com/fasterxml/jackson/core/read/EscapedSurrogateInStringValue1683Test.java
@@ -1,0 +1,411 @@
+package com.fasterxml.jackson.core.read;
+
+import java.io.StringReader;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.core.JUnit5TestBase;
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.core.json.JsonReadFeature;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Tests for [jackson-core#1683]: JSON-escaped lone surrogates in string values
+ * (and field names) must be rejected by the Reader-based parser, matching the
+ * fix applied for the UTF-8 stream parser in [jackson-core#1541].
+ *
+ * <p>Only exercises {@link com.fasterxml.jackson.core.json.ReaderBasedJsonParser}
+ * paths; UTF-8 / async parsers are covered separately.
+ */
+class EscapedSurrogateInStringValue1683Test extends JUnit5TestBase
+{
+    private final JsonFactory FACTORY = new JsonFactory();
+
+    // JSON documents. Each backslash-u escape is written using an explicit
+    // '\\' + 'u' + hex prefix so the Java pre-lexer doesn't fold it into a
+    // single UTF-16 code unit before it reaches the parser.
+    private static final String LONE_LEADING_VALUE   = "{\"k\":\"\\uD800\"}";
+    private static final String LONE_TRAILING_VALUE  = "{\"k\":\"\\uDC00\"}";
+    private static final String REVERSED_PAIR_VALUE  = "{\"k\":\"\\uDC00\\uD800\"}";
+    private static final String VALID_PAIR_VALUE     = "{\"k\":\"\\uD800\\uDC00\"}";
+    private static final String LONE_TRAILING_NAME   = "{\"\\uDC00\":1}";
+    private static final String LONE_LEADING_NAME    = "{\"\\uD800\":1}";
+    private static final String REVERSED_PAIR_NAME   = "{\"\\uDC00\\uD800\":1}";
+
+    // ---- string-value coverage --------------------------------------------
+
+    @Test
+    void loneLeadingSurrogateInStringValue_stringInput() throws Exception {
+        assertRejects(LONE_LEADING_VALUE, /*fromString=*/true);
+    }
+
+    @Test
+    void loneLeadingSurrogateInStringValue_readerInput() throws Exception {
+        assertRejects(LONE_LEADING_VALUE, /*fromString=*/false);
+    }
+
+    @Test
+    void loneTrailingSurrogateInStringValue_stringInput() throws Exception {
+        assertRejects(LONE_TRAILING_VALUE, /*fromString=*/true);
+    }
+
+    @Test
+    void loneTrailingSurrogateInStringValue_readerInput() throws Exception {
+        assertRejects(LONE_TRAILING_VALUE, /*fromString=*/false);
+    }
+
+    @Test
+    void reversedSurrogatePairInStringValue_stringInput() throws Exception {
+        assertRejects(REVERSED_PAIR_VALUE, /*fromString=*/true);
+    }
+
+    @Test
+    void reversedSurrogatePairInStringValue_readerInput() throws Exception {
+        assertRejects(REVERSED_PAIR_VALUE, /*fromString=*/false);
+    }
+
+    @Test
+    void validSurrogatePairInStringValue_stringInput() throws Exception {
+        assertAcceptsValidPair(VALID_PAIR_VALUE, /*fromString=*/true);
+    }
+
+    @Test
+    void validSurrogatePairInStringValue_readerInput() throws Exception {
+        assertAcceptsValidPair(VALID_PAIR_VALUE, /*fromString=*/false);
+    }
+
+    // ---- field-name coverage ----------------------------------------------
+
+    @Test
+    void loneTrailingSurrogateInFieldName_stringInput() throws Exception {
+        assertRejects(LONE_TRAILING_NAME, /*fromString=*/true);
+    }
+
+    @Test
+    void loneTrailingSurrogateInFieldName_readerInput() throws Exception {
+        assertRejects(LONE_TRAILING_NAME, /*fromString=*/false);
+    }
+
+    @Test
+    void loneLeadingSurrogateInFieldName_stringInput() throws Exception {
+        assertRejects(LONE_LEADING_NAME, /*fromString=*/true);
+    }
+
+    @Test
+    void loneLeadingSurrogateInFieldName_readerInput() throws Exception {
+        assertRejects(LONE_LEADING_NAME, /*fromString=*/false);
+    }
+
+    @Test
+    void reversedSurrogatePairInFieldName_stringInput() throws Exception {
+        assertRejects(REVERSED_PAIR_NAME, /*fromString=*/true);
+    }
+
+    @Test
+    void reversedSurrogatePairInFieldName_readerInput() throws Exception {
+        assertRejects(REVERSED_PAIR_NAME, /*fromString=*/false);
+    }
+
+    // ---- single-quoted string coverage (exercises _handleApos) ------------
+
+    private static final String APOS_LONE_LEADING   = "{'k':'\\uD800'}";
+    private static final String APOS_LONE_TRAILING  = "{'k':'\\uDC00'}";
+    private static final String APOS_REVERSED_PAIR  = "{'k':'\\uDC00\\uD800'}";
+    private static final String APOS_VALID_PAIR     = "{'k':'\\uD800\\uDC00'}";
+
+    private JsonFactory factoryWithSingleQuotes() {
+        return JsonFactory.builder()
+                .enable(JsonReadFeature.ALLOW_SINGLE_QUOTES)
+                .build();
+    }
+
+    @Test
+    void singleQuotedStringWithLoneLeadingSurrogate_stringInput() throws Exception {
+        assertRejects(factoryWithSingleQuotes(), APOS_LONE_LEADING, /*fromString=*/true);
+    }
+
+    @Test
+    void singleQuotedStringWithLoneLeadingSurrogate_readerInput() throws Exception {
+        assertRejects(factoryWithSingleQuotes(), APOS_LONE_LEADING, /*fromString=*/false);
+    }
+
+    @Test
+    void singleQuotedStringWithLoneTrailingSurrogate_stringInput() throws Exception {
+        assertRejects(factoryWithSingleQuotes(), APOS_LONE_TRAILING, /*fromString=*/true);
+    }
+
+    @Test
+    void singleQuotedStringWithLoneTrailingSurrogate_readerInput() throws Exception {
+        assertRejects(factoryWithSingleQuotes(), APOS_LONE_TRAILING, /*fromString=*/false);
+    }
+
+    @Test
+    void singleQuotedStringWithReversedSurrogatePair_stringInput() throws Exception {
+        assertRejects(factoryWithSingleQuotes(), APOS_REVERSED_PAIR, /*fromString=*/true);
+    }
+
+    @Test
+    void singleQuotedStringWithReversedSurrogatePair_readerInput() throws Exception {
+        assertRejects(factoryWithSingleQuotes(), APOS_REVERSED_PAIR, /*fromString=*/false);
+    }
+
+    @Test
+    void singleQuotedStringWithValidSurrogatePair_stringInput() throws Exception {
+        assertAcceptsValidPair(factoryWithSingleQuotes(), APOS_VALID_PAIR, /*fromString=*/true);
+    }
+
+    @Test
+    void singleQuotedStringWithValidSurrogatePair_readerInput() throws Exception {
+        assertAcceptsValidPair(factoryWithSingleQuotes(), APOS_VALID_PAIR, /*fromString=*/false);
+    }
+
+    // ---- skipChildren coverage (exercises _skipString) --------------------
+
+    @Test
+    void skipChildrenPastMalformedString_fromString() throws Exception {
+        String doc = "{\"outer\":{\"k\":\"\\uDC00\"}}";
+        try (JsonParser p = FACTORY.createParser(doc)) {
+            assertToken(JsonToken.START_OBJECT, p.nextToken());
+            assertToken(JsonToken.FIELD_NAME, p.nextToken());
+            assertToken(JsonToken.START_OBJECT, p.nextToken());
+            try {
+                p.skipChildren();
+                fail("expected JsonParseException");
+            } catch (JsonParseException e) {
+                String msg = e.getMessage() == null ? "" : e.getMessage().toLowerCase();
+                assertTrue(msg.contains("surrogate"),
+                        "expected surrogate error, got: " + e.getMessage());
+            }
+        }
+    }
+
+    @Test
+    void skipChildrenPastMalformedString_fromReader() throws Exception {
+        String doc = "{\"outer\":{\"k\":\"\\uDC00\"}}";
+        try (JsonParser p = FACTORY.createParser(new StringReader(doc))) {
+            assertToken(JsonToken.START_OBJECT, p.nextToken());
+            assertToken(JsonToken.FIELD_NAME, p.nextToken());
+            assertToken(JsonToken.START_OBJECT, p.nextToken());
+            try {
+                p.skipChildren();
+                fail("expected JsonParseException");
+            } catch (JsonParseException e) {
+                String msg = e.getMessage() == null ? "" : e.getMessage().toLowerCase();
+                assertTrue(msg.contains("surrogate"),
+                        "expected surrogate error, got: " + e.getMessage());
+            }
+        }
+    }
+
+    @Test
+    void skipChildrenPastMalformedString_highSurrogateFollowedByNonEscape() throws Exception {
+        // High surrogate followed by a plain character rather than another escape
+        String doc = "{\"outer\":{\"k\":\"\\uD800x\"}}";
+        try (JsonParser p = FACTORY.createParser(new StringReader(doc))) {
+            assertToken(JsonToken.START_OBJECT, p.nextToken());
+            assertToken(JsonToken.FIELD_NAME, p.nextToken());
+            assertToken(JsonToken.START_OBJECT, p.nextToken());
+            try {
+                p.skipChildren();
+                fail("expected JsonParseException");
+            } catch (JsonParseException e) {
+                String msg = e.getMessage() == null ? "" : e.getMessage().toLowerCase();
+                assertTrue(msg.contains("surrogate"),
+                        "expected surrogate error, got: " + e.getMessage());
+            }
+        }
+    }
+
+    // ---- segment-boundary coverage (exercises _parseName2 bounds check) ---
+
+    /**
+     * Regression test for the buffer overflow that would occur if the high
+     * surrogate write in {@code _parseName2} landed on the last slot of the
+     * current text-buffer segment. Without the bounds check between the hi
+     * and lo writes, the fall-through path would then write the low
+     * surrogate at index {@code outBuf.length}, throwing
+     * {@link ArrayIndexOutOfBoundsException} instead of returning a valid
+     * astral field name.
+     *
+     * <p>The default first-segment size in {@code TextBuffer} is 200 UTF-16
+     * code units; we sweep several padding sizes so at least one lands the
+     * high-surrogate write on {@code outBuf.length - 1}.
+     */
+    @Test
+    void longFieldNameWithSurrogatePairAtSegmentBoundary_readerInput() throws Exception {
+        // Sweep sizes so that at least one lands the hi write on the segment boundary
+        int[] padSizes = { 199, 200, 201, 399, 400, 401, 4000 };
+        for (int pad : padSizes) {
+            StringBuilder sb = new StringBuilder("{\"");
+            for (int i = 0; i < pad; i++) sb.append('a');
+            sb.append("\\uD83D\\uDE00\":1}");
+            String doc = sb.toString();
+            try (JsonParser p = FACTORY.createParser(new StringReader(doc))) {
+                assertToken(JsonToken.START_OBJECT, p.nextToken());
+                assertToken(JsonToken.FIELD_NAME, p.nextToken());
+                String name = p.currentName();
+                int expectedCodePoints = pad + 1;
+                assertEquals(expectedCodePoints, name.codePointCount(0, name.length()),
+                        "codepoint count for pad=" + pad);
+                assertEquals(0x1F600, name.codePointAt(pad),
+                        "astral cp at index " + pad + " for pad=" + pad);
+                assertToken(JsonToken.VALUE_NUMBER_INT, p.nextToken());
+                assertToken(JsonToken.END_OBJECT, p.nextToken());
+            }
+        }
+    }
+
+    @Test
+    void longFieldNameWithLoneTrailingSurrogateAtSegmentBoundary_readerInput() throws Exception {
+        // Same padding sweep, but lone-trailing-surrogate escape — must still
+        // reject cleanly at the boundary rather than overflowing.
+        int[] padSizes = { 199, 200, 201, 399, 400, 401, 4000 };
+        for (int pad : padSizes) {
+            StringBuilder sb = new StringBuilder("{\"");
+            for (int i = 0; i < pad; i++) sb.append('a');
+            sb.append("\\uDC00\":1}");
+            String doc = sb.toString();
+            try (JsonParser p = FACTORY.createParser(new StringReader(doc))) {
+                try {
+                    while (p.nextToken() != null) {
+                        if (p.currentToken() == JsonToken.FIELD_NAME) {
+                            p.getText();
+                        }
+                    }
+                    fail("expected JsonParseException for lone trailing surrogate at pad=" + pad);
+                } catch (JsonParseException e) {
+                    String msg = e.getMessage() == null ? "" : e.getMessage().toLowerCase();
+                    assertTrue(msg.contains("surrogate"),
+                            "expected surrogate error at pad=" + pad + ", got: " + e.getMessage());
+                }
+            }
+        }
+    }
+
+    // ---- mixed escape / literal-surrogate coverage (locks §5.6 behavior) --
+
+    /**
+     * The Reader path can accept a Java {@code String} input that contains a
+     * literal (unescaped) surrogate {@code char}. Verify the deliberate
+     * strict-rejection behavior when an escape surrogate is followed by, or
+     * preceded by, a literal surrogate char: both cases MUST reject with
+     * {@code JsonParseException}, even though a lenient reader might treat
+     * the escape+literal combination as a valid UTF-16 pair.
+     */
+    @Test
+    void escapedHighFollowedByLiteralLowSurrogate_isRejected() throws Exception {
+        String doc = "{\"k\":\"\\uD800" + '\uDC00' + "\"}";
+        for (boolean fromString : new boolean[]{true, false}) {
+            try (JsonParser p = open(doc, fromString)) {
+                try {
+                    while (p.nextToken() != null) { p.getText(); }
+                    fail("expected JsonParseException (fromString=" + fromString + ")");
+                } catch (JsonParseException e) {
+                    String msg = e.getMessage() == null ? "" : e.getMessage().toLowerCase();
+                    assertTrue(msg.contains("surrogate"),
+                            "expected surrogate error, got: " + e.getMessage());
+                }
+            }
+        }
+    }
+
+    @Test
+    void literalHighFollowedByEscapedLowSurrogate_isRejected() throws Exception {
+        String doc = "{\"k\":\"" + '\uD800' + "\\uDC00\"}";
+        for (boolean fromString : new boolean[]{true, false}) {
+            try (JsonParser p = open(doc, fromString)) {
+                try {
+                    while (p.nextToken() != null) { p.getText(); }
+                    fail("expected JsonParseException (fromString=" + fromString + ")");
+                } catch (JsonParseException e) {
+                    String msg = e.getMessage() == null ? "" : e.getMessage().toLowerCase();
+                    assertTrue(msg.contains("surrogate"),
+                            "expected surrogate error, got: " + e.getMessage());
+                }
+            }
+        }
+    }
+
+    @Test
+    void bothLiteralSurrogatesFormingValidPair_isAccepted() throws Exception {
+        // Literal char pair — parser does not decode escapes, so no surrogate
+        // guard fires. This exercises the pre-existing accept path for
+        // literal chars in the input stream and locks that we do not
+        // regress it while validating the escape paths.
+        String doc = "{\"k\":\"" + '\uD800' + '\uDC00' + "\"}";
+        for (boolean fromString : new boolean[]{true, false}) {
+            try (JsonParser p = open(doc, fromString)) {
+                assertToken(JsonToken.START_OBJECT, p.nextToken());
+                assertToken(JsonToken.FIELD_NAME, p.nextToken());
+                assertToken(JsonToken.VALUE_STRING, p.nextToken());
+                String v = p.getText();
+                assertEquals(0x10000, v.codePointAt(0),
+                        "expected U+10000 from literal surrogate pair (fromString=" + fromString + ")");
+                assertToken(JsonToken.END_OBJECT, p.nextToken());
+            }
+        }
+    }
+
+    // ---- helpers ----------------------------------------------------------
+
+    private JsonParser open(String doc, boolean fromString) throws Exception {
+        return open(FACTORY, doc, fromString);
+    }
+
+    private JsonParser open(JsonFactory factory, String doc, boolean fromString) throws Exception {
+        return fromString
+                ? factory.createParser(doc)
+                : factory.createParser(new StringReader(doc));
+    }
+
+    private void assertRejects(String doc, boolean fromString) throws Exception {
+        assertRejects(FACTORY, doc, fromString);
+    }
+
+    private void assertRejects(JsonFactory factory, String doc, boolean fromString) throws Exception {
+        try (JsonParser p = open(factory, doc, fromString)) {
+            try {
+                // Drive tokens until either the parser throws or the doc ends.
+                while (p.nextToken() != null) {
+                    if (p.currentToken() == JsonToken.VALUE_STRING
+                            || p.currentToken() == JsonToken.FIELD_NAME) {
+                        // Force decode; some paths defer surrogate work until
+                        // the caller pulls the text.
+                        p.getText();
+                    }
+                }
+                fail("Expected JsonParseException for malformed surrogate escape in: " + doc);
+            } catch (JsonParseException e) {
+                String msg = e.getMessage() == null ? "" : e.getMessage().toLowerCase();
+                assertTrue(msg.contains("surrogate"),
+                        "Expected surrogate error message, got: " + e.getMessage());
+            }
+        }
+    }
+
+    private void assertAcceptsValidPair(String doc, boolean fromString) throws Exception {
+        assertAcceptsValidPair(FACTORY, doc, fromString);
+    }
+
+    private void assertAcceptsValidPair(JsonFactory factory, String doc, boolean fromString) throws Exception {
+        try (JsonParser p = open(factory, doc, fromString)) {
+            assertToken(JsonToken.START_OBJECT, p.nextToken());
+            assertToken(JsonToken.FIELD_NAME, p.nextToken());
+            assertEquals("k", p.currentName());
+            assertToken(JsonToken.VALUE_STRING, p.nextToken());
+            String text = p.getText();
+            // U+10000 encodes as the surrogate pair D800 DC00 in Java strings.
+            assertEquals(2, text.length(), "expected two UTF-16 code units");
+            int cp = text.codePointAt(0);
+            assertEquals(0x10000, cp,
+                    "expected code point U+10000, got U+" + Integer.toHexString(cp));
+            assertToken(JsonToken.END_OBJECT, p.nextToken());
+        }
+    }
+}


### PR DESCRIPTION
Fixes #1683.

Mirror of #1541 for `ReaderBasedJsonParser`. The `\uXXXX` escape decoder now rejects lone / reversed surrogates in field-name and string-value positions, plus `_skipString` for consistency with `skipChildren()` callers. Error messages match #1541's wording; helpers are private and per-parser to keep duplication low across the four sites.

Not gated behind a `JsonReadFeature` — matches #1542/#1583. If your #1494 note about wanting this class of validation feature-gated has become the preferred shape since, happy to rebase behind a new `StreamReadFeature`.

Scope: PR 1 of a series covering `ReaderBasedJsonParser` alone. `UTF8StreamJsonParser` (string-value), `UTF8DataInputJsonParser` (never received #1541), and the async parser (string-value) will follow as separate PRs matching the #1541 → #1567 → #1583 progression.
