### PR TITLE
Add `JsonParser.nextNameMatchAndToken()`: fused name match plus value-token advance

### DIFF
--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -98,3 +98,8 @@ Burak KALAYCI (@kalayciburak)
  * Contributed #1668: `WriterBasedJsonGenerator` AIOOBE when a zero-length custom
    escape lands at the output buffer boundary
   (3.1.7)
+
+Steven Schlansker (@stevenschlansker)
+ * Contributed #1688: Add `JsonParser.nextNameMatchAndToken()`, fused property
+   name match plus value token advance
+  (3.3.0)

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -27,6 +27,9 @@ JSON library.
 #1664: UTF-8 byte-backed parsers report raw byte instead of decoded character
   for invalid root-value separator
  (reported, fix by DongNyoung L)
+#1688: Add `JsonParser.nextNameMatchAndToken()`, fused property name match
+  plus value token advance
+ (contributed by @stevenschlansker)
 
 3.2.3 (not yet released)
 

--- a/src/main/java/tools/jackson/core/JsonParser.java
+++ b/src/main/java/tools/jackson/core/JsonParser.java
@@ -574,6 +574,11 @@ public abstract class JsonParser
      * after more input is fed and {@link #nextToken()} called again.
      * Callers of such parsers must check {@link #currentToken()} instead of
      * assuming a non-negative result means the value is ready.
+     *<p>
+     * NOTE to subclass implementors: the default implementation is defined in terms
+     * of {@link #nextNameMatch(PropertyNameMatcher)} and {@link #nextToken()}, so
+     * subclasses that override either (especially delegating or filtering ones) should
+     * override this method as well, to keep the two paths consistent.
      *
      * @param matcher Matcher that will handle actual matching
      *

--- a/src/main/java/tools/jackson/core/JsonParser.java
+++ b/src/main/java/tools/jackson/core/JsonParser.java
@@ -567,6 +567,13 @@ public abstract class JsonParser
      * Callers that dispatch on the returned index and then read the value can
      * use this instead of the two-call sequence: format backends may implement
      * it as a single fused scan.
+     *<p>
+     * NOTE: with non-blocking (async) parsers the value token may not be
+     * available even when the name matched: the current token will then be
+     * {@link JsonToken#NOT_AVAILABLE}, and the value only becomes readable
+     * after more input is fed and {@link #nextToken()} called again.
+     * Callers of such parsers must check {@link #currentToken()} instead of
+     * assuming a non-negative result means the value is ready.
      *
      * @param matcher Matcher that will handle actual matching
      *

--- a/src/main/java/tools/jackson/core/JsonParser.java
+++ b/src/main/java/tools/jackson/core/JsonParser.java
@@ -557,6 +557,36 @@ public abstract class JsonParser
     public abstract int nextNameMatch(PropertyNameMatcher matcher) throws JacksonException;
 
     /**
+     * Combined form of {@link #nextNameMatch(PropertyNameMatcher)} and
+     * {@link #nextToken()}: matches the next Object property name against the
+     * given matcher and, when the match succeeds (non-negative index), also
+     * advances the stream so that the current token is the property's value
+     * token. On a negative result the stream is left exactly as
+     * {@link #nextNameMatch(PropertyNameMatcher)} leaves it.
+     *<p>
+     * Callers that dispatch on the returned index and then read the value can
+     * use this instead of the two-call sequence: format backends may implement
+     * it as a single fused scan.
+     *
+     * @param matcher Matcher that will handle actual matching
+     *
+     * @return Index of the matched property name, if non-negative, or a negative error
+     *   code otherwise (see {@link PropertyNameMatcher} for details)
+     *
+     * @throws JacksonIOException for low-level read issues
+     * @throws tools.jackson.core.exc.StreamReadException for decoding problems
+     *
+     * @since 3.3
+     */
+    public int nextNameMatchAndToken(PropertyNameMatcher matcher) throws JacksonException {
+        int match = nextNameMatch(matcher);
+        if (match >= 0) {
+            nextToken();
+        }
+        return match;
+    }
+
+    /**
      * Method that verifies that the current token (see {@link #currentToken}) is
      * {@link JsonToken#PROPERTY_NAME} and if so, further match that associated name
      * (see {@link #currentName}) to one of pre-specified (property) names.

--- a/src/main/java/tools/jackson/core/filter/FilteringParserDelegate.java
+++ b/src/main/java/tools/jackson/core/filter/FilteringParserDelegate.java
@@ -1052,6 +1052,17 @@ public class FilteringParserDelegate extends JsonParserDelegate
         return PropertyNameMatcher.MATCH_ODD_TOKEN;
     }
 
+    @Override
+    public int nextNameMatchAndToken(PropertyNameMatcher matcher) throws JacksonException {
+        // NOTE: cannot delegate (unlike `JsonParserDelegate`), must call local
+        // `nextNameMatch()`/`nextToken()` to handle delegation
+        int match = nextNameMatch(matcher);
+        if (match >= 0) {
+            nextToken();
+        }
+        return match;
+    }
+
     /*
     /**********************************************************************
     /* Internal helper methods

--- a/src/main/java/tools/jackson/core/json/ReaderBasedJsonParser.java
+++ b/src/main/java/tools/jackson/core/json/ReaderBasedJsonParser.java
@@ -8,6 +8,7 @@ import tools.jackson.core.exc.StreamReadException;
 import tools.jackson.core.io.CharTypes;
 import tools.jackson.core.io.IOContext;
 import tools.jackson.core.sym.CharsToNameCanonicalizer;
+import tools.jackson.core.sym.PropertyNameMatcher;
 import tools.jackson.core.util.*;
 
 import static tools.jackson.core.JsonTokenId.*;
@@ -1035,6 +1036,26 @@ public class ReaderBasedJsonParser
         }
         _nextToken = t;
         return name;
+    }
+
+    // 07-Sep-2026, tatu: [core#1688] On a match, commit the value token that
+    //    `nextName()` already classified into `_nextToken`, instead of paying
+    //    for a separate `nextToken()` call
+    @Override
+    public int nextNameMatchAndToken(PropertyNameMatcher matcher) throws JacksonException
+    {
+        String name = nextName();
+        if (name != null) {
+            int match = matcher.matchName(name);
+            if (match >= 0) {
+                _nextAfterName();
+            }
+            return match;
+        }
+        if (_currToken == JsonToken.END_OBJECT) {
+            return PropertyNameMatcher.MATCH_END_OBJECT;
+        }
+        return PropertyNameMatcher.MATCH_ODD_TOKEN;
     }
 
     private final void _isNextTokenNameYes(int i) throws JacksonException

--- a/src/main/java/tools/jackson/core/json/UTF8StreamJsonParser.java
+++ b/src/main/java/tools/jackson/core/json/UTF8StreamJsonParser.java
@@ -1119,6 +1119,20 @@ public class UTF8StreamJsonParser
     @Override
     public int nextNameMatch(PropertyNameMatcher matcher) throws JacksonException
     {
+        return _nextNameMatch(matcher, false);
+    }
+
+    @Override
+    public int nextNameMatchAndToken(PropertyNameMatcher matcher) throws JacksonException
+    {
+        return _nextNameMatch(matcher, true);
+    }
+
+    // On a non-negative match with `fused`, commits the value token directly
+    // (the work _nextAfterName() would otherwise do on the following
+    // nextToken() call); everything else is nextNameMatch() unchanged.
+    private int _nextNameMatch(PropertyNameMatcher matcher, boolean fused) throws JacksonException
+    {
         // // // Note: this is almost a verbatim copy of nextToken()
         _numTypesValid = NR_UNKNOWN;
         if (_currToken == JsonToken.PROPERTY_NAME) {
@@ -1196,7 +1210,12 @@ public class UTF8StreamJsonParser
         _updateLocation();
         if (i == INT_QUOTE) { // optimize commonest case, String value
             _tokenIncomplete = true;
-            _nextToken = JsonToken.VALUE_STRING;
+            if (fused && match >= 0) {
+                _nameCopied = false;
+                _updateToken(JsonToken.VALUE_STRING);
+            } else {
+                _nextToken = JsonToken.VALUE_STRING;
+            }
             return match;
         }
         JsonToken t;
@@ -1248,7 +1267,17 @@ public class UTF8StreamJsonParser
         default:
             t = _handleUnexpectedValue(i);
         }
-        _nextToken = t;
+        if (fused && match >= 0) {
+            _nameCopied = false;
+            if (t == JsonToken.START_ARRAY) {
+                createChildArrayContext(_tokenInputRow, _tokenInputCol);
+            } else if (t == JsonToken.START_OBJECT) {
+                createChildObjectContext(_tokenInputRow, _tokenInputCol);
+            }
+            _updateToken(t);
+        } else {
+            _nextToken = t;
+        }
         return match;
     }
 

--- a/src/main/java/tools/jackson/core/util/JsonParserDelegate.java
+++ b/src/main/java/tools/jackson/core/util/JsonParserDelegate.java
@@ -164,6 +164,7 @@ public class JsonParserDelegate extends JsonParser
     @Override public String nextName(){ return delegate.nextName(); }
     @Override public boolean nextName(SerializableString str) { return delegate.nextName(str); }
     @Override public int nextNameMatch(PropertyNameMatcher matcher) { return delegate.nextNameMatch(matcher); }
+    @Override public int nextNameMatchAndToken(PropertyNameMatcher matcher) { return delegate.nextNameMatchAndToken(matcher); }
 
     // NOTE: fine without overrides since it does NOT change state
     @Override public int currentNameMatch(PropertyNameMatcher matcher) { return delegate.currentNameMatch(matcher); }

--- a/src/main/java/tools/jackson/core/util/JsonParserDelegate.java
+++ b/src/main/java/tools/jackson/core/util/JsonParserDelegate.java
@@ -164,6 +164,8 @@ public class JsonParserDelegate extends JsonParser
     @Override public String nextName(){ return delegate.nextName(); }
     @Override public boolean nextName(SerializableString str) { return delegate.nextName(str); }
     @Override public int nextNameMatch(PropertyNameMatcher matcher) { return delegate.nextNameMatch(matcher); }
+    // Must override, and not rely on default impl in `JsonParser`:
+    // otherwise `nextToken()` half would be dispatched on this delegate, not `delegate`
     @Override public int nextNameMatchAndToken(PropertyNameMatcher matcher) { return delegate.nextNameMatchAndToken(matcher); }
 
     // NOTE: fine without overrides since it does NOT change state

--- a/src/main/java/tools/jackson/core/util/JsonParserSequence.java
+++ b/src/main/java/tools/jackson/core/util/JsonParserSequence.java
@@ -206,6 +206,17 @@ public class JsonParserSequence extends JsonParserDelegate
         return PropertyNameMatcher.MATCH_ODD_TOKEN;
     }
 
+    @Override
+    public int nextNameMatchAndToken(PropertyNameMatcher matcher) throws JacksonException {
+        // NOTE: cannot delegate (unlike `JsonParserDelegate`), must call local
+        // `nextNameMatch()`/`nextToken()` to handle delegation
+        int match = nextNameMatch(matcher);
+        if (match >= 0) {
+            nextToken();
+        }
+        return match;
+    }
+
     /*
     /**********************************************************************
     /* Additional extended API

--- a/src/test/java/perf/ManualNameMatchPerfTest.java
+++ b/src/test/java/perf/ManualNameMatchPerfTest.java
@@ -1,0 +1,146 @@
+package perf;
+
+import java.util.*;
+
+import tools.jackson.core.*;
+import tools.jackson.core.json.JsonFactory;
+import tools.jackson.core.sym.PropertyNameMatcher;
+import tools.jackson.core.util.Named;
+
+/**
+ * Manually run micro-benchmark comparing the two-call
+ * {@code nextNameMatch()} + {@code nextToken()} sequence against the fused
+ * {@code nextNameMatchAndToken()}, over both byte- and char-backed parsers.
+ * Approximates what generated per-bean deserializers do: dispatch on the
+ * match index, then read the value.
+ *
+ * @since 3.3
+ */
+public class ManualNameMatchPerfTest
+{
+    private final static String[] NAMES = new String[] {
+        "id", "name", "type", "size", "enabled", "score", "label", "flag"
+    };
+
+    private final JsonFactory _factory = new JsonFactory();
+    private final byte[] _docBytes;
+    private final String _docString;
+
+    private ManualNameMatchPerfTest(int entries) {
+        StringBuilder sb = new StringBuilder(entries * 100);
+        sb.append('[');
+        for (int i = 0; i < entries; ++i) {
+            if (i > 0) sb.append(',');
+            sb.append("{\"id\":").append(i)
+                .append(",\"name\":\"value").append(i & 0xFF).append('"')
+                .append(",\"type\":\"t").append(i & 7).append('"')
+                .append(",\"size\":").append(i * 3)
+                .append(",\"enabled\":").append((i & 1) == 0)
+                .append(",\"score\":").append(i % 97)
+                .append(",\"label\":\"L").append(i & 15).append('"')
+                .append(",\"flag\":").append((i & 3) == 0)
+                .append('}');
+        }
+        sb.append(']');
+        _docString = sb.toString();
+        _docBytes = _docString.getBytes(java.nio.charset.StandardCharsets.UTF_8);
+    }
+
+    private PropertyNameMatcher matcher() {
+        List<Named> names = new ArrayList<>();
+        for (String n : NAMES) {
+            names.add(Named.fromString(n));
+        }
+        return _factory.constructNameMatcher(names, true);
+    }
+
+    private JsonParser parser(boolean bytes) {
+        return bytes ? _factory.createParser(ObjectReadContext.empty(), _docBytes)
+                : _factory.createParser(ObjectReadContext.empty(), _docString);
+    }
+
+    // Two-call sequence: nextNameMatch() then nextToken()
+    private long readTwoCall(boolean bytes, PropertyNameMatcher m) {
+        long sum = 0;
+        try (JsonParser p = parser(bytes)) {
+            p.nextToken();
+            while (p.nextToken() == JsonToken.START_OBJECT) {
+                while (true) {
+                    int ix = p.nextNameMatch(m);
+                    if (ix < 0) {
+                        break;
+                    }
+                    p.nextToken();
+                    sum += _value(p, ix);
+                }
+            }
+        }
+        return sum;
+    }
+
+    // Fused: nextNameMatchAndToken()
+    private long readFused(boolean bytes, PropertyNameMatcher m) {
+        long sum = 0;
+        try (JsonParser p = parser(bytes)) {
+            p.nextToken();
+            while (p.nextToken() == JsonToken.START_OBJECT) {
+                while (true) {
+                    int ix = p.nextNameMatchAndToken(m);
+                    if (ix < 0) {
+                        break;
+                    }
+                    sum += _value(p, ix);
+                }
+            }
+        }
+        return sum;
+    }
+
+    // Stand-in for what a generated deserializer does with the match index
+    private static long _value(JsonParser p, int ix) {
+        switch (ix) {
+        case 0: case 3: case 5:
+            return p.getIntValue();
+        case 1: case 2: case 6:
+            return p.getString().length();
+        default:
+            return p.getBooleanValue() ? 1 : 0;
+        }
+    }
+
+    private void run(int rounds, int repsPerRound) throws Exception
+    {
+        final PropertyNameMatcher m = matcher();
+        System.out.printf("Document: %d bytes, %d properties/round%n",
+                _docBytes.length, repsPerRound);
+
+        for (boolean bytes : new boolean[] { true, false }) {
+            final String desc = bytes ? "UTF8StreamJsonParser (byte[])"
+                    : "ReaderBasedJsonParser (String)";
+            // warmup, both paths, to get C2 to steady state
+            long h = 0;
+            for (int i = 0; i < 20; ++i) {
+                h += readTwoCall(bytes, m) + readFused(bytes, m);
+            }
+            long bestTwo = Long.MAX_VALUE, bestFused = Long.MAX_VALUE;
+            for (int i = 0; i < rounds; ++i) {
+                long start = System.nanoTime();
+                for (int j = 0; j < repsPerRound; ++j) { h += readTwoCall(bytes, m); }
+                bestTwo = Math.min(bestTwo, System.nanoTime() - start);
+
+                start = System.nanoTime();
+                for (int j = 0; j < repsPerRound; ++j) { h += readFused(bytes, m); }
+                bestFused = Math.min(bestFused, System.nanoTime() - start);
+            }
+            System.out.printf("%n%s [hash 0x%x]%n", desc, h);
+            System.out.printf("  two-call : %6.2f msecs%n", bestTwo / 1000000.0);
+            System.out.printf("  fused    : %6.2f msecs (%+.1f%%)%n",
+                    bestFused / 1000000.0,
+                    100.0 * (bestFused - bestTwo) / bestTwo);
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        new ManualNameMatchPerfTest(2000).run(12, 20);
+    }
+}

--- a/src/test/java/tools/jackson/core/unittest/read/NextNameMatchAndTokenTest.java
+++ b/src/test/java/tools/jackson/core/unittest/read/NextNameMatchAndTokenTest.java
@@ -95,7 +95,9 @@ class NextNameMatchAndTokenTest extends JacksonCoreTestBase
                     JsonParser twoCall = createParser(JSON_F, mode, DOC)) {
                 fused.nextToken();
                 twoCall.nextToken();
-                while (true) {
+                // bound iteration so a regression fails instead of looping forever
+                for (int i = 0, end = 20; ; ++i) {
+                    assertTrue(i < end, "Failed to reach END_OBJECT in "+end+" rounds");
                     int ixF = fused.nextNameMatchAndToken(m1);
                     int ixT = twoCall.nextNameMatch(m2);
                     if (ixT >= 0) {

--- a/src/test/java/tools/jackson/core/unittest/read/NextNameMatchAndTokenTest.java
+++ b/src/test/java/tools/jackson/core/unittest/read/NextNameMatchAndTokenTest.java
@@ -7,8 +7,14 @@ import org.junit.jupiter.api.Test;
 
 import tools.jackson.core.JsonParser;
 import tools.jackson.core.JsonToken;
+import tools.jackson.core.ObjectReadContext;
+import tools.jackson.core.filter.FilteringParserDelegate;
+import tools.jackson.core.filter.JsonPointerBasedFilter;
+import tools.jackson.core.filter.TokenFilter;
 import tools.jackson.core.json.JsonFactory;
 import tools.jackson.core.sym.PropertyNameMatcher;
+import tools.jackson.core.util.JsonParserDelegate;
+import tools.jackson.core.util.JsonParserSequence;
 import tools.jackson.core.util.Named;
 import tools.jackson.core.unittest.JacksonCoreTestBase;
 
@@ -108,6 +114,79 @@ class NextNameMatchAndTokenTest extends JacksonCoreTestBase
                     twoCall.skipChildren();
                 }
             }
+        }
+    }
+
+    // [core#1688]: delegating parsers must not lose state via default delegation
+
+    @Test
+    void fusedMatchViaParserDelegate() throws Exception
+    {
+        for (int mode : ALL_MODES) {
+            PropertyNameMatcher m = matcher();
+            try (JsonParser p = new JsonParserDelegate(createParser(JSON_F, mode, DOC))) {
+                assertToken(JsonToken.START_OBJECT, p.nextToken());
+
+                assertEquals(0, p.nextNameMatchAndToken(m));
+                assertToken(JsonToken.VALUE_STRING, p.currentToken());
+                assertEquals("x", p.getString());
+
+                assertEquals(1, p.nextNameMatchAndToken(m));
+                assertToken(JsonToken.VALUE_NUMBER_INT, p.currentToken());
+                assertEquals(123, p.getIntValue());
+            }
+        }
+    }
+
+    @Test
+    void fusedMatchViaParserSequence() throws Exception
+    {
+        PropertyNameMatcher m = matcher();
+        JsonParser p1 = JSON_F.createParser(ObjectReadContext.empty(), a2q("{'a':'x'}"));
+        JsonParser p2 = JSON_F.createParser(ObjectReadContext.empty(), a2q("{'b':123}"));
+        try (JsonParser p = JsonParserSequence.createFlattened(false, p1, p2)) {
+            assertToken(JsonToken.START_OBJECT, p.nextToken());
+
+            assertEquals(0, p.nextNameMatchAndToken(m));
+            assertToken(JsonToken.VALUE_STRING, p.currentToken());
+            assertEquals("x", p.getString());
+
+            assertEquals(PropertyNameMatcher.MATCH_END_OBJECT, p.nextNameMatchAndToken(m));
+
+            // and this is where the second parser must be switched to
+            assertEquals(PropertyNameMatcher.MATCH_ODD_TOKEN, p.nextNameMatchAndToken(m));
+            assertToken(JsonToken.START_OBJECT, p.currentToken());
+
+            assertEquals(1, p.nextNameMatchAndToken(m));
+            assertToken(JsonToken.VALUE_NUMBER_INT, p.currentToken());
+            assertEquals(123, p.getIntValue());
+
+            assertEquals(PropertyNameMatcher.MATCH_END_OBJECT, p.nextNameMatchAndToken(m));
+        }
+    }
+
+    @Test
+    void fusedMatchViaFilteringDelegate() throws Exception
+    {
+        PropertyNameMatcher m = matcher();
+        JsonParser p0 = JSON_F.createParser(ObjectReadContext.empty(),
+                a2q("{'skip':1,'ob':{'a':'x','b':123}}"));
+        try (JsonParser p = new FilteringParserDelegate(p0,
+                new JsonPointerBasedFilter("/ob"),
+                TokenFilter.Inclusion.ONLY_INCLUDE_ALL, false)) {
+            assertToken(JsonToken.START_OBJECT, p.nextToken());
+
+            assertEquals(0, p.nextNameMatchAndToken(m));
+            assertToken(JsonToken.VALUE_STRING, p.currentToken());
+            assertEquals("x", p.getString());
+
+            assertEquals(1, p.nextNameMatchAndToken(m));
+            assertToken(JsonToken.VALUE_NUMBER_INT, p.currentToken());
+            assertEquals(123, p.getIntValue());
+
+            assertEquals(PropertyNameMatcher.MATCH_END_OBJECT, p.nextNameMatchAndToken(m));
+            assertToken(JsonToken.END_OBJECT, p.currentToken());
+            assertNull(p.nextToken());
         }
     }
 }

--- a/src/test/java/tools/jackson/core/unittest/read/NextNameMatchAndTokenTest.java
+++ b/src/test/java/tools/jackson/core/unittest/read/NextNameMatchAndTokenTest.java
@@ -1,0 +1,113 @@
+package tools.jackson.core.unittest.read;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import tools.jackson.core.JsonParser;
+import tools.jackson.core.JsonToken;
+import tools.jackson.core.json.JsonFactory;
+import tools.jackson.core.sym.PropertyNameMatcher;
+import tools.jackson.core.util.Named;
+import tools.jackson.core.unittest.JacksonCoreTestBase;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for {@code JsonParser.nextNameMatchAndToken()}: on a non-negative
+ * match the current token must be the property's value token; negative
+ * results must leave the stream exactly as {@code nextNameMatch()} does.
+ */
+class NextNameMatchAndTokenTest extends JacksonCoreTestBase
+{
+    private static final String DOC = a2q(
+            "{'a':'x','b':123,'c':true,'d':null,'e':[7],'f':{'g':2},'zz':5}");
+
+    private final JsonFactory JSON_F = newStreamFactory();
+
+    private PropertyNameMatcher matcher() {
+        List<Named> names = Arrays.asList(
+                Named.fromString("a"), Named.fromString("b"), Named.fromString("c"),
+                Named.fromString("d"), Named.fromString("e"), Named.fromString("f"));
+        return JSON_F.constructNameMatcher(names, true);
+    }
+
+    @Test
+    void fusedMatchLeavesValueTokenCurrent() throws Exception
+    {
+        for (int mode : ALL_MODES) {
+            PropertyNameMatcher m = matcher();
+            try (JsonParser p = createParser(JSON_F, mode, DOC)) {
+                assertToken(JsonToken.START_OBJECT, p.nextToken());
+
+                assertEquals(0, p.nextNameMatchAndToken(m));
+                assertToken(JsonToken.VALUE_STRING, p.currentToken());
+                assertEquals("x", p.getString());
+
+                assertEquals(1, p.nextNameMatchAndToken(m));
+                assertToken(JsonToken.VALUE_NUMBER_INT, p.currentToken());
+                assertEquals(123, p.getIntValue());
+
+                assertEquals(2, p.nextNameMatchAndToken(m));
+                assertToken(JsonToken.VALUE_TRUE, p.currentToken());
+
+                assertEquals(3, p.nextNameMatchAndToken(m));
+                assertToken(JsonToken.VALUE_NULL, p.currentToken());
+
+                assertEquals(4, p.nextNameMatchAndToken(m));
+                assertToken(JsonToken.START_ARRAY, p.currentToken());
+                assertToken(JsonToken.VALUE_NUMBER_INT, p.nextToken());
+                assertEquals(7, p.getIntValue());
+                assertToken(JsonToken.END_ARRAY, p.nextToken());
+
+                assertEquals(5, p.nextNameMatchAndToken(m));
+                assertToken(JsonToken.START_OBJECT, p.currentToken());
+                p.skipChildren();
+
+                assertEquals(PropertyNameMatcher.MATCH_UNKNOWN_NAME,
+                        p.nextNameMatchAndToken(m));
+                assertToken(JsonToken.PROPERTY_NAME, p.currentToken());
+                assertEquals("zz", p.currentName());
+                p.nextToken();
+                p.skipChildren();
+
+                assertEquals(PropertyNameMatcher.MATCH_END_OBJECT,
+                        p.nextNameMatchAndToken(m));
+                assertToken(JsonToken.END_OBJECT, p.currentToken());
+            }
+        }
+    }
+
+    @Test
+    void fusedEquivalentToTwoCallSequence() throws Exception
+    {
+        for (int mode : ALL_MODES) {
+            PropertyNameMatcher m1 = matcher();
+            PropertyNameMatcher m2 = matcher();
+            try (JsonParser fused = createParser(JSON_F, mode, DOC);
+                    JsonParser twoCall = createParser(JSON_F, mode, DOC)) {
+                fused.nextToken();
+                twoCall.nextToken();
+                while (true) {
+                    int ixF = fused.nextNameMatchAndToken(m1);
+                    int ixT = twoCall.nextNameMatch(m2);
+                    if (ixT >= 0) {
+                        twoCall.nextToken();
+                    }
+                    assertEquals(ixT, ixF);
+                    if (ixF == PropertyNameMatcher.MATCH_END_OBJECT) {
+                        break;
+                    }
+                    if (ixF == PropertyNameMatcher.MATCH_UNKNOWN_NAME) {
+                        fused.nextToken();
+                        twoCall.nextToken();
+                    }
+                    assertToken(twoCall.currentToken(), fused.currentToken());
+                    fused.skipChildren();
+                    twoCall.skipChildren();
+                }
+            }
+        }
+    }
+}

--- a/src/test/java/tools/jackson/core/unittest/read/NextNameMatchAndTokenTest.java
+++ b/src/test/java/tools/jackson/core/unittest/read/NextNameMatchAndTokenTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
 import tools.jackson.core.JsonParser;
 import tools.jackson.core.JsonToken;
 import tools.jackson.core.ObjectReadContext;
+import tools.jackson.core.async.ByteArrayFeeder;
 import tools.jackson.core.filter.FilteringParserDelegate;
 import tools.jackson.core.filter.JsonPointerBasedFilter;
 import tools.jackson.core.filter.TokenFilter;
@@ -189,6 +190,28 @@ class NextNameMatchAndTokenTest extends JacksonCoreTestBase
             assertEquals(PropertyNameMatcher.MATCH_END_OBJECT, p.nextNameMatchAndToken(m));
             assertToken(JsonToken.END_OBJECT, p.currentToken());
             assertNull(p.nextToken());
+        }
+    }
+
+    // Non-blocking parsers cannot guarantee the value token is available even
+    // on a match: verify the documented `NOT_AVAILABLE` behavior
+    @Test
+    void fusedMatchWithNonBlockingParser() throws Exception
+    {
+        PropertyNameMatcher m = matcher();
+        final byte[] doc = utf8Bytes(a2q("{'b':1234}"));
+        try (JsonParser p = JSON_F.createNonBlockingByteArrayParser(ObjectReadContext.empty())) {
+            ByteArrayFeeder feeder = (ByteArrayFeeder) p.nonBlockingInputFeeder();
+            // just `{"b":`, that is, name but no value yet
+            feeder.feedInput(doc, 0, 5);
+            assertToken(JsonToken.START_OBJECT, p.nextToken());
+
+            assertEquals(1, p.nextNameMatchAndToken(m));
+            assertToken(JsonToken.NOT_AVAILABLE, p.currentToken());
+
+            feeder.feedInput(doc, 5, doc.length);
+            assertToken(JsonToken.VALUE_NUMBER_INT, p.nextToken());
+            assertEquals(1234, p.getIntValue());
         }
     }
 }


### PR DESCRIPTION
Combined form of nextNameMatch() and nextToken(): on a non-negative match the current token is the property's value token; negative results leave the stream exactly as nextNameMatch() does. Default implementation is the two-call sequence; UTF8StreamJsonParser commits the value token it already classified during name matching, saving the second dispatch and the nextToken() prologue per property. Motivation: generated per-bean deserializers dispatch on the match index and then read the value; nextNameMatch (597 bytes) never inlines into such callers, so each property pays two out-of-line parser calls today.

This improvement is a wash with vanilla deserialization, as it's not measurable behind megamorphic dispatches into value deserializers.
However, upcoming Blackbird rewrite will use this feature when code-generating Jackson codecs, and in that work I measure a +5% to +13% performance boost

PR designed with help from Claude Fable 5.