### PR TITLE
Lower BigDecimal fast parser cutoff from 500 to 200

### DIFF
--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -69,6 +69,9 @@ DongNyoung Lee (@Dongnyoung)
   (3.3.0)
  * Reported #1654: Stale symbol table child can replace a newer root table
   (3.3.0)
+ * Reported, fixed #1685: Lower `BigDecimalParser` FastDoubleParser cutoff from
+   500 to 200 characters
+  (3.3.0)
 
 seonwoojung (@seonwooj0810)
  * Contributed #707: Add `JsonReadFeature.ALLOW_HEXADECIMAL_NUMBERS`

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -27,6 +27,8 @@ JSON library.
 #1664: UTF-8 byte-backed parsers report raw byte instead of decoded character
   for invalid root-value separator
  (reported, fix by DongNyoung L)
+#1685: Lower `BigDecimalParser` FastDoubleParser cutoff from 500 to 200 characters
+ (reported, fix by DongNyoung L)
 
 3.2.3 (not yet released)
 

--- a/src/main/java/tools/jackson/core/StreamReadFeature.java
+++ b/src/main/java/tools/jackson/core/StreamReadFeature.java
@@ -109,6 +109,11 @@ public enum StreamReadFeature
      *<p>
      * This setting is enabled by default (since 3.0) so that {@code FastDoubleParser}
      * implementation is used.
+     *<p>
+     * NOTE: disabling this feature does not fully avoid {@code FastDoubleParser} for
+     * {@code BigDecimal}: values of 200 characters or longer (500 before Jackson 3.3)
+     * are always decoded with it, since the JDK parser is much slower for such values.
+     * {@code BigInteger} decoding has no such exception.
      */
     USE_FAST_BIG_NUMBER_PARSER(true),
 

--- a/src/main/java/tools/jackson/core/io/BigDecimalParser.java
+++ b/src/main/java/tools/jackson/core/io/BigDecimalParser.java
@@ -22,7 +22,7 @@ import ch.randelshofer.fastdoubleparser.JavaBigDecimalParser;
 public final class BigDecimalParser
 {
     final static int MAX_CHARS_TO_REPORT = 1000;
- 
+
     // 200 since Jackson 3.3 (see [core#1685])
     private final static int SIZE_FOR_SWITCH_TO_FASTDOUBLEPARSER = 200;
 

--- a/src/main/java/tools/jackson/core/io/BigDecimalParser.java
+++ b/src/main/java/tools/jackson/core/io/BigDecimalParser.java
@@ -6,7 +6,7 @@ import ch.randelshofer.fastdoubleparser.JavaBigDecimalParser;
 
 /**
  * Internal Jackson Helper class used to implement more optimized parsing of
- * {@link BigDecimal} for REALLY big values (over 500 characters).
+ * {@link BigDecimal} for REALLY big values (200 characters or longer).
  *<p>
  * This class is not meant to be used directly. It is designed to be used by Jackson JSON parsers (and parsers
  * for other Jackson supported data formats). The parsers check for invalid characters and the length of the number.
@@ -22,7 +22,7 @@ import ch.randelshofer.fastdoubleparser.JavaBigDecimalParser;
 public final class BigDecimalParser
 {
     final static int MAX_CHARS_TO_REPORT = 1000;
-    private final static int SIZE_FOR_SWITCH_TO_FASTDOUBLEPARSER = 500;
+    private final static int SIZE_FOR_SWITCH_TO_FASTDOUBLEPARSER = 200;
 
     private BigDecimalParser() {}
 

--- a/src/main/java/tools/jackson/core/io/BigDecimalParser.java
+++ b/src/main/java/tools/jackson/core/io/BigDecimalParser.java
@@ -23,7 +23,7 @@ public final class BigDecimalParser
 {
     final static int MAX_CHARS_TO_REPORT = 1000;
  
-    // 200 since Jackson 3.3 (see [core#1689])
+    // 200 since Jackson 3.3 (see [core#1685])
     private final static int SIZE_FOR_SWITCH_TO_FASTDOUBLEPARSER = 200;
 
     private BigDecimalParser() {}

--- a/src/main/java/tools/jackson/core/io/BigDecimalParser.java
+++ b/src/main/java/tools/jackson/core/io/BigDecimalParser.java
@@ -6,7 +6,7 @@ import ch.randelshofer.fastdoubleparser.JavaBigDecimalParser;
 
 /**
  * Internal Jackson Helper class used to implement more optimized parsing of
- * {@link BigDecimal} for REALLY big values (200 characters or longer).
+ * {@link BigDecimal} for REALLY big values (200 characters or longer as of Jackson 3.3).
  *<p>
  * This class is not meant to be used directly. It is designed to be used by Jackson JSON parsers (and parsers
  * for other Jackson supported data formats). The parsers check for invalid characters and the length of the number.
@@ -22,6 +22,8 @@ import ch.randelshofer.fastdoubleparser.JavaBigDecimalParser;
 public final class BigDecimalParser
 {
     final static int MAX_CHARS_TO_REPORT = 1000;
+ 
+    // 200 since Jackson 3.3 (see [core#1689])
     private final static int SIZE_FOR_SWITCH_TO_FASTDOUBLEPARSER = 200;
 
     private BigDecimalParser() {}

--- a/src/test/java/tools/jackson/core/unittest/io/BigDecimalParserTest.java
+++ b/src/test/java/tools/jackson/core/unittest/io/BigDecimalParserTest.java
@@ -45,6 +45,17 @@ class BigDecimalParserTest extends JacksonCoreTestBase
     }
 
     @Test
+    void validLongDecimalParse() {
+        final int length = 250;
+        String num = genLongValidString(length -3);
+        final BigDecimal exp = new BigDecimal(num);
+
+        assertEquals(length, num.length());
+        assertEquals(exp, BigDecimalParser.parse(num));
+        assertEquals(exp, BigDecimalParser.parse(num.toCharArray(), 0, num.length()));
+    }
+
+    @Test
     void longValidStringFastParse() {
         String num = genLongValidString(500);
         final BigDecimal EXP = new BigDecimal(num);


### PR DESCRIPTION
Fixes #1685 
## Summary

Lower `BigDecimalParser.SIZE_FOR_SWITCH_TO_FASTDOUBLEPARSER` from 500 to 200.

The existing 500-character cutoff was a conservative estimate rather than a measured crossover point. Benchmarks comparing the JDK `BigDecimal` parser against FastDoubleParser (FDP) were run across JDK 17, 21, and 25.

The benchmarks covered both `String` and `char[]` inputs with integer and fractional values. Integer inputs favored FDP throughout the measured range, while fractional inputs were the limiting case and showed a later crossover.

Across JDK 17, 21, and 25, FDP was faster for all tested input forms at 150 characters and remained faster at the larger sampled lengths. The latest JDK-winning sampled point was observed with JDK 21 `String` fractional input, where the JDK path was still faster at 125 characters, while FDP was faster from 150 onward.

Rather than setting the cutoff directly at the observed boundary, this change uses 200 to leave additional margin.

## Benchmark results

For fractional inputs, the last sampled JDK-winning points were:

| JDK | Input | Last JDK-winning sampled length | FDP remained faster from |
|---|---|---:|---:|
| 17 | String | 60 | 75 |
| 17 | char[] | 60 | 75 |
| 21 | String | 125 | 150 |
| 21 | char[] | 75 | 100 |
| 25 | String | 60 | 75 |
| 25 | char[] | 60 | 75 |

At the proposed 200-character cutoff:

| JDK | Input | JDK ns/op | FDP ns/op | Parsing time reduction |
|---|---|---:|---:|---:|
| 17 | String | 2132 | 1435 | 32.7% |
| 17 | char[] | 2095 | 1418 | 32.3% |
| 21 | String | 2023 | 600 | 70.4% |
| 21 | char[] | 2017 | 1482 | 26.5% |
| 25 | String | 944 | 621 | 34.2% |
| 25 | char[] | 939 | 501 | 46.6% |

FDP does have higher temporary allocation for these long fractional inputs. At 200 characters, FDP allocated about 1.8 KB/op compared with roughly 0.6–1.0 KB/op for the JDK paths.

Profiling confirmed that this allocation difference was not caused by Jackson integration or input copying. The additional allocation primarily comes from FDP's internal `BigInteger` operations used for power-of-ten computation, such as `BigInteger.pow()`, `squareToLen()`, and `shiftLeft()`.

The resulting `BigDecimal` values were equivalent between the two paths.

Given that the parsing-time improvement at 200 characters was substantial across every tested JDK/input combination, 200 provides additional margin above the measured crossover while still substantially lowering the previous cutoff of 500.

## Changes

- Lower the BigDecimal fast-parser cutoff from 500 to 200.
- Add a long-decimal correctness test covering both `String` and `char[]` parsing.

## Tests

- `.\mvnw.cmd "-Dtest=tools.jackson.core.unittest.io.BigDecimalParserTest" "-Dsurefire.useModulePath=false" test`
- `.\mvnw.cmd "-Dsurefire.useModulePath=false" test`

Result: 1833 tests run, 0 failures, 0 errors, 2 skipped.