### PR TITLE
Validate oversized decimal numbers before full buffering

### DIFF
--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -69,6 +69,9 @@ DongNyoung Lee (@Dongnyoung)
   (3.3.0)
  * Reported #1654: Stale symbol table child can replace a newer root table
   (3.3.0)
+ * Reported, fixed #1686: Synchronous decimal integer parsing buffers oversized
+   values before `maxNumberLength` validation
+  (3.3.0)
 
 seonwoojung (@seonwooj0810)
  * Contributed #707: Add `JsonReadFeature.ALLOW_HEXADECIMAL_NUMBERS`

--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -71,6 +71,7 @@ DongNyoung Lee (@Dongnyoung)
   (3.3.0)
  * Reported, fixed #1685: Lower `BigDecimalParser` FastDoubleParser cutoff from
    500 to 200 characters
+  (3.3.0)
  * Reported, fixed #1686: Synchronous decimal number parsing buffers oversized
    values before `maxNumberLength` validation
   (3.3.0)

--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -69,7 +69,7 @@ DongNyoung Lee (@Dongnyoung)
   (3.3.0)
  * Reported #1654: Stale symbol table child can replace a newer root table
   (3.3.0)
- * Reported, fixed #1686: Synchronous decimal integer parsing buffers oversized
+ * Reported, fixed #1686: Synchronous decimal number parsing buffers oversized
    values before `maxNumberLength` validation
   (3.3.0)
 

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -27,6 +27,9 @@ JSON library.
 #1664: UTF-8 byte-backed parsers report raw byte instead of decoded character
   for invalid root-value separator
  (reported, fix by DongNyoung L)
+#1686: Synchronous decimal integer parsing buffers oversized values before
+  `maxNumberLength` validation
+ (reported, fix by DongNyoung L)
 
 3.2.3 (not yet released)
 

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -27,7 +27,7 @@ JSON library.
 #1664: UTF-8 byte-backed parsers report raw byte instead of decoded character
   for invalid root-value separator
  (reported, fix by DongNyoung L)
-#1686: Synchronous decimal integer parsing buffers oversized values before
+#1686: Synchronous decimal number parsing buffers oversized values before
   `maxNumberLength` validation
  (reported, fix by DongNyoung L)
 

--- a/src/main/java/tools/jackson/core/json/ReaderBasedJsonParser.java
+++ b/src/main/java/tools/jackson/core/json/ReaderBasedJsonParser.java
@@ -1644,6 +1644,9 @@ public class ReaderBasedJsonParser
                 }
                 ++fractLen;
                 if (outPtr >= outBuf.length) {
+                    // 07-Sep-2026, tatu: [core#1686] Check length before growing buffer;
+                    //   `expLen` still -1 ("none") here so must not over-estimate
+                    _streamReadConstraints.validateFPLength(intLen + fractLen - 1);
                     outBuf = _textBuffer.finishCurrentSegment();
                     outPtr = 0;
                 }
@@ -1686,6 +1689,7 @@ public class ReaderBasedJsonParser
             while (c <= INT_9 && c >= INT_0) {
                 ++expLen;
                 if (outPtr >= outBuf.length) {
+                    _streamReadConstraints.validateFPLength(intLen + fractLen + expLen);
                     outBuf = _textBuffer.finishCurrentSegment();
                     outPtr = 0;
                 }

--- a/src/main/java/tools/jackson/core/json/ReaderBasedJsonParser.java
+++ b/src/main/java/tools/jackson/core/json/ReaderBasedJsonParser.java
@@ -1601,6 +1601,7 @@ public class ReaderBasedJsonParser
         while (c >= '0' && c <= '9') {
             ++intLen;
             if (outPtr >= outBuf.length) {
+                _streamReadConstraints.validateIntegerLength(intLen);
                 outBuf = _textBuffer.finishCurrentSegment();
                 outPtr = 0;
             }

--- a/src/main/java/tools/jackson/core/json/UTF8DataInputJsonParser.java
+++ b/src/main/java/tools/jackson/core/json/UTF8DataInputJsonParser.java
@@ -1082,6 +1082,7 @@ public class UTF8DataInputJsonParser
         while (c <= INT_9 && c >= INT_0) {
             ++intLen;
             if (outPtr >= outBuf.length) {
+                _streamReadConstraints.validateIntegerLength(intLen);
                 outBuf = _textBuffer.finishCurrentSegment();
                 outPtr = 0;
             }
@@ -1150,6 +1151,7 @@ public class UTF8DataInputJsonParser
         while (c <= INT_9 && c >= INT_0) {
             ++intLen;
             if (outPtr >= outBuf.length) {
+                _streamReadConstraints.validateIntegerLength(intLen);
                 outBuf = _textBuffer.finishCurrentSegment();
                 outPtr = 0;
             }

--- a/src/main/java/tools/jackson/core/json/UTF8DataInputJsonParser.java
+++ b/src/main/java/tools/jackson/core/json/UTF8DataInputJsonParser.java
@@ -1267,6 +1267,8 @@ public class UTF8DataInputJsonParser
                 }
                 ++fractLen;
                 if (outPtr >= outBuf.length) {
+                    // 07-Sep-2026, tatu: [core#1686] Check length before growing buffer
+                    _streamReadConstraints.validateFPLength(integerPartLength + fractLen);
                     outBuf = _textBuffer.finishCurrentSegment();
                     outPtr = 0;
                 }
@@ -1302,6 +1304,7 @@ public class UTF8DataInputJsonParser
             while (c <= INT_9 && c >= INT_0) {
                 ++expLen;
                 if (outPtr >= outBuf.length) {
+                    _streamReadConstraints.validateFPLength(integerPartLength + fractLen + expLen);
                     outBuf = _textBuffer.finishCurrentSegment();
                     outPtr = 0;
                 }

--- a/src/main/java/tools/jackson/core/json/UTF8StreamJsonParser.java
+++ b/src/main/java/tools/jackson/core/json/UTF8StreamJsonParser.java
@@ -1956,12 +1956,13 @@ public class UTF8StreamJsonParser
                 }
                 break;
             }
+            ++intPartLength;
             if (outPtr >= outBuf.length) {
+                _streamReadConstraints.validateIntegerLength(intPartLength);
                 outBuf = _textBuffer.finishCurrentSegment();
                 outPtr = 0;
             }
             outBuf[outPtr++] = (char) c;
-            ++intPartLength;
         }
         --_inputPtr; // to push back trailing char (comma etc)
         _textBuffer.setCurrentLength(outPtr);

--- a/src/main/java/tools/jackson/core/json/UTF8StreamJsonParser.java
+++ b/src/main/java/tools/jackson/core/json/UTF8StreamJsonParser.java
@@ -2098,6 +2098,8 @@ public class UTF8StreamJsonParser
                 }
                 ++fractLen;
                 if (outPtr >= outBuf.length) {
+                    // 07-Sep-2026, tatu: [core#1686] Check length before growing buffer
+                    _streamReadConstraints.validateFPLength(integerPartLength + fractLen);
                     outBuf = _textBuffer.finishCurrentSegment();
                     outPtr = 0;
                 }
@@ -2143,6 +2145,7 @@ public class UTF8StreamJsonParser
             while (c >= INT_0 && c <= INT_9) {
                 ++expLen;
                 if (outPtr >= outBuf.length) {
+                    _streamReadConstraints.validateFPLength(integerPartLength + fractLen + expLen);
                     outBuf = _textBuffer.finishCurrentSegment();
                     outPtr = 0;
                 }

--- a/src/test/java/tools/jackson/core/unittest/constraints/LargeNumberReadTest.java
+++ b/src/test/java/tools/jackson/core/unittest/constraints/LargeNumberReadTest.java
@@ -9,8 +9,13 @@ import tools.jackson.core.JsonToken;
 import tools.jackson.core.StreamReadConstraints;
 import tools.jackson.core.exc.StreamConstraintsException;
 import tools.jackson.core.json.JsonFactory;
+import tools.jackson.core.util.JsonRecyclerPools;
 
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 /**
@@ -21,6 +26,9 @@ import static org.junit.jupiter.api.Assertions.fail;
 class LargeNumberReadTest
     extends tools.jackson.core.unittest.JacksonCoreTestBase
 {
+    private final static int STRICT_MAX_NUM_LEN = 1_000;
+    private final static int OVERSIZED_INT_LEN = 100_000;
+
     private final JsonFactory JSON_F = newStreamFactory();
 
     /*
@@ -87,6 +95,29 @@ class LargeNumberReadTest
         _testBigBigDecimals(MODE_DATA_INPUT, true);
     }
 
+    @Test
+    void tooLongDecimalIntegerFailsBeforeFullBuffering() throws Exception
+    {
+        assertAll(
+                () -> _testTooLongDecimalIntegerFailsBeforeFullBuffering("InputStream", MODE_INPUT_STREAM),
+                () -> _testTooLongDecimalIntegerFailsBeforeFullBuffering("Reader", MODE_READER),
+                () -> _testTooLongDecimalIntegerFailsBeforeFullBuffering("DataInput", MODE_DATA_INPUT)
+        );
+    }
+
+    @Test
+    void decimalIntegerAtMaxLengthStillPasses() throws Exception
+    {
+        assertAll(
+                () -> _testDecimalIntegerAtMaxLengthStillPasses(MODE_INPUT_STREAM, false),
+                () -> _testDecimalIntegerAtMaxLengthStillPasses(MODE_INPUT_STREAM, true),
+                () -> _testDecimalIntegerAtMaxLengthStillPasses(MODE_READER, false),
+                () -> _testDecimalIntegerAtMaxLengthStillPasses(MODE_READER, true),
+                () -> _testDecimalIntegerAtMaxLengthStillPasses(MODE_DATA_INPUT, false),
+                () -> _testDecimalIntegerAtMaxLengthStillPasses(MODE_DATA_INPUT, true)
+        );
+    }
+
     private void _testBigBigDecimals(final int mode, final boolean enableUnlimitedNumberLen) throws Exception
     {
         final String BASE_FRACTION =
@@ -136,6 +167,91 @@ class LargeNumberReadTest
                 final BigDecimal exp = new BigDecimal(asText);
                 assertEquals(exp, p.getDecimalValue());
             }
+        }
+    }
+
+    private void _testTooLongDecimalIntegerFailsBeforeFullBuffering(String modeDesc, final int mode)
+        throws Exception
+    {
+        RecordingStreamReadConstraints constraints =
+                new RecordingStreamReadConstraints(STRICT_MAX_NUM_LEN);
+
+        try (JsonParser p = createParserForLongDecimalInteger(mode, constraints)) {
+            StreamConstraintsException e = assertThrows(StreamConstraintsException.class,
+                    () -> p.nextToken());
+            verifyException(e, "Number value length (");
+            verifyException(e, "exceeds the maximum allowed");
+        }
+
+        int failingIntegerLength = constraints.failingIntegerLength();
+        assertTrue(failingIntegerLength > 0,
+                modeDesc + " did not record failing integer length validation");
+        assertTrue(failingIntegerLength < (OVERSIZED_INT_LEN / 10),
+                modeDesc + " integer length validation occurred too late: "
+                        + failingIntegerLength + " digits for "
+                        + OVERSIZED_INT_LEN + "-digit input");
+    }
+
+    private void _testDecimalIntegerAtMaxLengthStillPasses(final int mode, boolean negative)
+        throws Exception
+    {
+        final String digits = repeatDigit('7', STRICT_MAX_NUM_LEN);
+        final String value = negative ? ("-" + digits) : digits;
+        JsonFactory f = JsonFactory.builder()
+                .recyclerPool(JsonRecyclerPools.nonRecyclingPool())
+                .streamReadConstraints(StreamReadConstraints.builder()
+                        .maxNumberLength(STRICT_MAX_NUM_LEN)
+                        .build())
+                .build();
+
+        try (JsonParser p = createParser(f, mode, value + " ")) {
+            assertToken(JsonToken.VALUE_NUMBER_INT, p.nextToken());
+            assertEquals(value, p.getString());
+            assertNull(p.nextToken());
+        }
+    }
+
+    private JsonParser createParserForLongDecimalInteger(final int mode,
+            RecordingStreamReadConstraints constraints)
+    {
+        final String doc = repeatDigit('1', OVERSIZED_INT_LEN) + " ";
+        final JsonFactory f = JsonFactory.builder()
+                .recyclerPool(JsonRecyclerPools.nonRecyclingPool())
+                .streamReadConstraints(constraints)
+                .build();
+        return createParser(f, mode, doc);
+    }
+
+    private static String repeatDigit(char digit, int count) {
+        char[] chars = new char[count];
+        for (int i = 0; i < count; ++i) {
+            chars[i] = digit;
+        }
+        return new String(chars);
+    }
+
+    private static final class RecordingStreamReadConstraints
+        extends StreamReadConstraints
+    {
+        private int _failingIntegerLength;
+
+        RecordingStreamReadConstraints(int maxNumLen) {
+            super(DEFAULT_MAX_DEPTH, DEFAULT_MAX_DOC_LEN, DEFAULT_MAX_TOKEN_COUNT,
+                    maxNumLen, DEFAULT_MAX_STRING_LEN, DEFAULT_MAX_NAME_LEN);
+        }
+
+        @Override
+        public void validateIntegerLength(int length) throws StreamConstraintsException {
+            try {
+                super.validateIntegerLength(length);
+            } catch (StreamConstraintsException e) {
+                _failingIntegerLength = length;
+                throw e;
+            }
+        }
+
+        int failingIntegerLength() {
+            return _failingIntegerLength;
         }
     }
 }

--- a/src/test/java/tools/jackson/core/unittest/constraints/LargeNumberReadTest.java
+++ b/src/test/java/tools/jackson/core/unittest/constraints/LargeNumberReadTest.java
@@ -118,6 +118,36 @@ class LargeNumberReadTest
         );
     }
 
+    @Test
+    void tooLongDecimalFloatFailsBeforeFullBuffering() throws Exception
+    {
+        assertAll(
+                () -> _testTooLongDecimalFPFailsBeforeFullBuffering("InputStream/fraction", MODE_INPUT_STREAM, false),
+                () -> _testTooLongDecimalFPFailsBeforeFullBuffering("InputStream/fraction (throttled)", MODE_INPUT_STREAM_THROTTLED, false),
+                () -> _testTooLongDecimalFPFailsBeforeFullBuffering("Reader/fraction", MODE_READER, false),
+                () -> _testTooLongDecimalFPFailsBeforeFullBuffering("Reader/fraction (throttled)", MODE_READER_THROTTLED, false),
+                () -> _testTooLongDecimalFPFailsBeforeFullBuffering("DataInput/fraction", MODE_DATA_INPUT, false),
+                () -> _testTooLongDecimalFPFailsBeforeFullBuffering("InputStream/exponent", MODE_INPUT_STREAM, true),
+                () -> _testTooLongDecimalFPFailsBeforeFullBuffering("Reader/exponent", MODE_READER, true),
+                () -> _testTooLongDecimalFPFailsBeforeFullBuffering("DataInput/exponent", MODE_DATA_INPUT, true)
+        );
+    }
+
+    @Test
+    void decimalFloatAtMaxLengthStillPasses() throws Exception
+    {
+        assertAll(
+                () -> _testDecimalFloatAtMaxLengthStillPasses(MODE_INPUT_STREAM, false),
+                () -> _testDecimalFloatAtMaxLengthStillPasses(MODE_INPUT_STREAM, true),
+                () -> _testDecimalFloatAtMaxLengthStillPasses(MODE_INPUT_STREAM_THROTTLED, false),
+                () -> _testDecimalFloatAtMaxLengthStillPasses(MODE_READER, false),
+                () -> _testDecimalFloatAtMaxLengthStillPasses(MODE_READER, true),
+                () -> _testDecimalFloatAtMaxLengthStillPasses(MODE_READER_THROTTLED, false),
+                () -> _testDecimalFloatAtMaxLengthStillPasses(MODE_DATA_INPUT, false),
+                () -> _testDecimalFloatAtMaxLengthStillPasses(MODE_DATA_INPUT, true)
+        );
+    }
+
     private void _testBigBigDecimals(final int mode, final boolean enableUnlimitedNumberLen) throws Exception
     {
         final String BASE_FRACTION =
@@ -211,6 +241,55 @@ class LargeNumberReadTest
         }
     }
 
+    // [core#1686]: oversized fraction/exponent must be caught while buffering, not after
+    private void _testTooLongDecimalFPFailsBeforeFullBuffering(String modeDesc, final int mode,
+            boolean exponent)
+        throws Exception
+    {
+        RecordingStreamReadConstraints constraints =
+                new RecordingStreamReadConstraints(STRICT_MAX_NUM_LEN);
+        final String doc = (exponent ? "1e" : "1.") + repeatDigit('1', OVERSIZED_INT_LEN) + " ";
+        final JsonFactory f = JsonFactory.builder()
+                .recyclerPool(JsonRecyclerPools.nonRecyclingPool())
+                .streamReadConstraints(constraints)
+                .build();
+
+        try (JsonParser p = createParser(f, mode, doc)) {
+            StreamConstraintsException e = assertThrows(StreamConstraintsException.class,
+                    () -> p.nextToken());
+            verifyException(e, "Number value length (");
+            verifyException(e, "exceeds the maximum allowed");
+        }
+
+        int failingLength = constraints.failingFPLength();
+        assertTrue(failingLength > 0,
+                modeDesc + " did not record failing FP length validation");
+        assertTrue(failingLength < (OVERSIZED_INT_LEN / 10),
+                modeDesc + " FP length validation occurred too late: "
+                        + failingLength + " digits for "
+                        + OVERSIZED_INT_LEN + "-digit input");
+    }
+
+    private void _testDecimalFloatAtMaxLengthStillPasses(final int mode, boolean negative)
+        throws Exception
+    {
+        // Total length (int + fraction) exactly at maximum:
+        final String digits = "1." + repeatDigit('7', STRICT_MAX_NUM_LEN - 1);
+        final String value = negative ? ("-" + digits) : digits;
+        JsonFactory f = JsonFactory.builder()
+                .recyclerPool(JsonRecyclerPools.nonRecyclingPool())
+                .streamReadConstraints(StreamReadConstraints.builder()
+                        .maxNumberLength(STRICT_MAX_NUM_LEN)
+                        .build())
+                .build();
+
+        try (JsonParser p = createParser(f, mode, value + " ")) {
+            assertToken(JsonToken.VALUE_NUMBER_FLOAT, p.nextToken());
+            assertEquals(new BigDecimal(value), p.getDecimalValue());
+            assertNull(p.nextToken());
+        }
+    }
+
     private JsonParser createParserForLongDecimalInteger(final int mode,
             RecordingStreamReadConstraints constraints)
     {
@@ -234,6 +313,7 @@ class LargeNumberReadTest
         extends StreamReadConstraints
     {
         private int _failingIntegerLength;
+        private int _failingFPLength;
 
         RecordingStreamReadConstraints(int maxNumLen) {
             super(DEFAULT_MAX_DEPTH, DEFAULT_MAX_DOC_LEN, DEFAULT_MAX_TOKEN_COUNT,
@@ -250,8 +330,22 @@ class LargeNumberReadTest
             }
         }
 
+        @Override
+        public void validateFPLength(int length) throws StreamConstraintsException {
+            try {
+                super.validateFPLength(length);
+            } catch (StreamConstraintsException e) {
+                _failingFPLength = length;
+                throw e;
+            }
+        }
+
         int failingIntegerLength() {
             return _failingIntegerLength;
+        }
+
+        int failingFPLength() {
+            return _failingFPLength;
         }
     }
 }


### PR DESCRIPTION
Fixes #1686 
## Summary

- Add early `validateIntegerLength()` checks while parsing long decimal integer tokens in reader, UTF-8 stream, and data-input parsers.
- Reject oversized decimal integers at an intermediate buffer boundary instead of waiting until nearly the full token has been buffered.
- Add regression coverage for a 100,000-digit decimal integer with `maxNumberLength = 1,000`.
- Verify that positive and negative decimal integers exactly at `maxNumberLength` still parse successfully across `InputStream`, `Reader`, and `DataInput`.

## Test Coverage

The regression test records the integer length when `validateIntegerLength()` fails and verifies that an oversized integer is rejected well before the full 100,000-digit input has been buffered.

The assertion intentionally does not depend on an exact internal buffer size or `TextBuffer` growth policy.

## Tests

- `.\mvnw.cmd "-Dtest=LargeNumberReadTest" "-Dsurefire.useModulePath=false" test`
- `.\mvnw.cmd "-Dsurefire.useModulePath=false" test`

Both pass.