### PR TITLE
Fix lost output for non-UTF-8 generators, and close File/Path targets on failed construction

### DIFF
--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -24,7 +24,7 @@ JSON library.
 #1673: `readString(Writer)` AIOOBE when an escape or multi-byte character
   lands at the output buffer boundary
  (fix by @pjfanning)
-- Fix loss of buffered content when `createGenerator(OutputStream, JsonEncoding)`
+#1674: Fix loss of buffered content when `createGenerator(OutputStream, JsonEncoding)`
   is used with non-UTF-8 encoding and generator is configured to neither close
   nor flush the target
  (fix by @pjfanning)

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -24,7 +24,7 @@ JSON library.
 #1673: `readString(Writer)` AIOOBE when an escape or multi-byte character
   lands at the output buffer boundary
  (fix by @pjfanning)
-#1674: Fix loss of buffered content when `createGenerator(OutputStream, JsonEncoding)`
+#1692: Fix loss of buffered content when `createGenerator(OutputStream, JsonEncoding)`
   is used with non-UTF-8 encoding and generator is configured to neither close
   nor flush the target
  (fix by @pjfanning)

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -24,6 +24,10 @@ JSON library.
 #1673: `readString(Writer)` AIOOBE when an escape or multi-byte character
   lands at the output buffer boundary
  (fix by @pjfanning)
+- Fix loss of buffered content when `createGenerator(OutputStream, JsonEncoding)`
+  is used with non-UTF-8 encoding and generator is configured to neither close
+  nor flush the target
+ (fix by @pjfanning)
 
 3.1.6 (14-Aug-2026)
 

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -26,7 +26,8 @@ JSON library.
  (fix by @pjfanning)
 #1692: Fix loss of buffered content when `createGenerator(OutputStream, JsonEncoding)`
   is used with non-UTF-8 encoding and generator is configured to neither close
-  nor flush the target
+  nor flush the target; also close streams opened for `File`/`Path` targets when
+  generator construction fails
  (fix by @pjfanning)
 
 3.1.6 (14-Aug-2026)

--- a/src/main/java/tools/jackson/core/base/BinaryTSFactory.java
+++ b/src/main/java/tools/jackson/core/base/BinaryTSFactory.java
@@ -172,9 +172,14 @@ public abstract class BinaryTSFactory
         final OutputStream out = _fileOutputStream(f);
         // true -> yes, we have to manage the stream since we created it
         final IOContext ioCtxt = _createContext(_createContentReference(out), true, enc);
-        return _decorate(
-                _createGenerator(writeCtxt, ioCtxt, _decorate(ioCtxt, out))
-        );
+        try {
+            return _decorate(
+                    _createGenerator(writeCtxt, ioCtxt, _decorate(ioCtxt, out))
+            );
+        } catch (RuntimeException e) {
+            _closeOnFailedConstruction(out, e);
+            throw e;
+        }
     }
 
     @Override
@@ -184,9 +189,14 @@ public abstract class BinaryTSFactory
     {
         final OutputStream out = _pathOutputStream(p);
         final IOContext ioCtxt = _createContext(_createContentReference(p), true, enc);
-        return _decorate(
-                _createGenerator(writeCtxt, ioCtxt, _decorate(ioCtxt, out))
-        );
+        try {
+            return _decorate(
+                    _createGenerator(writeCtxt, ioCtxt, _decorate(ioCtxt, out))
+            );
+        } catch (RuntimeException e) {
+            _closeOnFailedConstruction(out, e);
+            throw e;
+        }
     }
 
     /*

--- a/src/main/java/tools/jackson/core/base/DecorableTSFactory.java
+++ b/src/main/java/tools/jackson/core/base/DecorableTSFactory.java
@@ -240,6 +240,32 @@ public abstract class DecorableTSFactory
     }
 
 
+    /*
+    /**********************************************************************
+    /* Helper methods for failed construction
+    /**********************************************************************
+     */
+
+    /**
+     * Method called when construction of parser or generator fails after
+     * Jackson has opened source or target itself (from {@link java.io.File} or
+     * {@link java.nio.file.Path}): closes it so that it does not get leaked.
+     * Caller-provided sources and targets are never passed here.
+     *
+     * @param toClose Source/target Jackson opened, if any ({@code null} if not yet opened)
+     * @param failure Failure to add possible secondary failure to, as suppressed
+     */
+    static void _closeOnFailedConstruction(Closeable toClose, RuntimeException failure)
+    {
+        if (toClose != null) {
+            try {
+                toClose.close();
+            } catch (Exception e) {
+                failure.addSuppressed(e);
+            }
+        }
+    }
+
     protected JsonGenerator _decorate(JsonGenerator result) {
         if (_generatorDecorators != null) {
             for(JsonGeneratorDecorator decorator : _generatorDecorators) {

--- a/src/main/java/tools/jackson/core/base/GeneratorBase.java
+++ b/src/main/java/tools/jackson/core/base/GeneratorBase.java
@@ -330,14 +330,31 @@ public abstract class GeneratorBase extends JsonGenerator
     @Override
     public void close() {
         if (!_closed) {
+            RuntimeException fail = null;
             try {
                 _closeInput();
             } catch (IOException e) {
-                throw _wrapIOFailure(e);
+                fail = _wrapIOFailure(e);
+            } catch (RuntimeException e) {
+                fail = e;
             } finally {
                 _releaseBuffers();
-                _ioContext.close();
-                _closed = true;
+                // 11-Sep-2026, tatu: [core#1692] closing context may flush pending
+                //    encoded content, and fail: must not mask earlier failure
+                try {
+                    _ioContext.close();
+                } catch (RuntimeException e) {
+                    if (fail == null) {
+                        fail = e;
+                    } else {
+                        fail.addSuppressed(e);
+                    }
+                } finally {
+                    _closed = true;
+                }
+            }
+            if (fail != null) {
+                throw fail;
             }
         }
     }

--- a/src/main/java/tools/jackson/core/base/TextualTSFactory.java
+++ b/src/main/java/tools/jackson/core/base/TextualTSFactory.java
@@ -238,15 +238,20 @@ public abstract class TextualTSFactory
     {
         final OutputStream out = _fileOutputStream(f);
         final IOContext ioCtxt = _createContext(_createContentReference(f), true, enc);
-        if (enc == JsonEncoding.UTF8) {
+        try {
+            if (enc == JsonEncoding.UTF8) {
+                return _decorate(
+                        _createUTF8Generator(writeCtxt, ioCtxt, _decorate(ioCtxt, out))
+                );
+            }
             return _decorate(
-                    _createUTF8Generator(writeCtxt, ioCtxt, _decorate(ioCtxt, out))
+                    _createGenerator(writeCtxt, ioCtxt,
+                            ioCtxt.encodingWriter(_decorate(ioCtxt, _createWriter(ioCtxt, out, enc))))
             );
+        } catch (RuntimeException e) {
+            _closeOnFailedConstruction(out, e);
+            throw e;
         }
-        return _decorate(
-                _createGenerator(writeCtxt, ioCtxt,
-                        ioCtxt.encodingWriter(_decorate(ioCtxt, _createWriter(ioCtxt, out, enc))))
-        );
     }
 
     @Override
@@ -256,15 +261,20 @@ public abstract class TextualTSFactory
     {
         final OutputStream out = _pathOutputStream(p);
         final IOContext ioCtxt = _createContext(_createContentReference(p), true, enc);
-        if (enc == JsonEncoding.UTF8) {
+        try {
+            if (enc == JsonEncoding.UTF8) {
+                return _decorate(
+                        _createUTF8Generator(writeCtxt, ioCtxt, _decorate(ioCtxt, out))
+                );
+            }
             return _decorate(
-                    _createUTF8Generator(writeCtxt, ioCtxt, _decorate(ioCtxt, out))
+                    _createGenerator(writeCtxt, ioCtxt,
+                            ioCtxt.encodingWriter(_decorate(ioCtxt, _createWriter(ioCtxt, out, enc))))
             );
+        } catch (RuntimeException e) {
+            _closeOnFailedConstruction(out, e);
+            throw e;
         }
-        return _decorate(
-                _createGenerator(writeCtxt, ioCtxt,
-                        ioCtxt.encodingWriter(_decorate(ioCtxt, _createWriter(ioCtxt, out, enc))))
-        );
     }
 
     /*

--- a/src/main/java/tools/jackson/core/base/TextualTSFactory.java
+++ b/src/main/java/tools/jackson/core/base/TextualTSFactory.java
@@ -217,7 +217,7 @@ public abstract class TextualTSFactory
         }
         return _decorate(
                 _createGenerator(writeCtxt, ioCtxt,
-                        _decorate(ioCtxt, _createWriter(ioCtxt, out, enc)))
+                        ioCtxt.encodingWriter(_decorate(ioCtxt, _createWriter(ioCtxt, out, enc))))
         );
     }
 
@@ -245,7 +245,7 @@ public abstract class TextualTSFactory
         }
         return _decorate(
                 _createGenerator(writeCtxt, ioCtxt,
-                        _decorate(ioCtxt, _createWriter(ioCtxt, out, enc)))
+                        ioCtxt.encodingWriter(_decorate(ioCtxt, _createWriter(ioCtxt, out, enc))))
         );
     }
 
@@ -263,7 +263,7 @@ public abstract class TextualTSFactory
         }
         return _decorate(
                 _createGenerator(writeCtxt, ioCtxt,
-                        _decorate(ioCtxt, _createWriter(ioCtxt, out, enc)))
+                        ioCtxt.encodingWriter(_decorate(ioCtxt, _createWriter(ioCtxt, out, enc))))
         );
     }
 

--- a/src/main/java/tools/jackson/core/io/IOContext.java
+++ b/src/main/java/tools/jackson/core/io/IOContext.java
@@ -1,8 +1,12 @@
 package tools.jackson.core.io;
 
+import java.io.FilterWriter;
+import java.io.IOException;
+import java.io.Writer;
 import java.util.Objects;
 
 import tools.jackson.core.ErrorReportConfiguration;
+import tools.jackson.core.exc.JacksonIOException;
 import tools.jackson.core.JsonEncoding;
 import tools.jackson.core.StreamReadConstraints;
 import tools.jackson.core.StreamWriteConstraints;
@@ -110,6 +114,14 @@ public class IOContext implements AutoCloseable
      */
     protected char[] _nameCopyBuffer;
 
+    /**
+     * Intermediate encoding {@link Writer} Jackson constructed itself over
+     * caller-supplied {@link java.io.OutputStream}, if any. Unlike caller-provided
+     * targets it has to be drained when this context is closed: caller has no
+     * reference with which to flush content buffered in it.
+     */
+    protected EncodingWriter _encodingWriter;
+
     private boolean _closed = false;
 
     /*
@@ -153,6 +165,28 @@ public class IOContext implements AutoCloseable
     public IOContext markBufferRecyclerReleased() {
         _releaseRecycler = false;
         return this;
+    }
+
+    /**
+     * Method factories call to register intermediate encoding {@link Writer}
+     * they constructed themselves to wrap caller-supplied
+     * {@link java.io.OutputStream}; returns Writer to actually pass to generator.
+     *<p>
+     * Content buffered by such Writer is flushed when this context is closed
+     * (that is, when generator using it gets closed), regardless of whether
+     * generator is configured to close or flush the caller-owned target:
+     * otherwise buffered output would simply be lost.
+     *
+     * @param w Encoding Writer Jackson constructed
+     *
+     * @return Writer to pass to generator
+     *
+     * @since 3.1.7
+     */
+    public Writer encodingWriter(Writer w) {
+        EncodingWriter ew = new EncodingWriter(w);
+        _encodingWriter = ew;
+        return ew;
     }
 
     /*
@@ -407,9 +441,71 @@ public class IOContext implements AutoCloseable
     public void close() {
         if (!_closed) {
             _closed = true;
-            if (_releaseRecycler) {
-                _releaseRecycler = false;
-                _bufferRecycler.releaseToPool();
+            try {
+                EncodingWriter w = _encodingWriter;
+                if (w != null) {
+                    _encodingWriter = null;
+                    w.flushPending();
+                }
+            } finally {
+                if (_releaseRecycler) {
+                    _releaseRecycler = false;
+                    _bufferRecycler.releaseToPool();
+                }
+            }
+        }
+    }
+
+    /**
+     * Wrapper for encoding {@link Writer} Jackson constructed itself, tracking
+     * whether it holds content not yet pushed to the underlying target, so that
+     * {@link IOContext#close} can drain it exactly once.
+     */
+    private final static class EncodingWriter extends FilterWriter
+    {
+        private boolean _pending;
+
+        EncodingWriter(Writer w) { super(w); }
+
+        @Override
+        public void write(int c) throws IOException {
+            _pending = true;
+            super.write(c);
+        }
+
+        @Override
+        public void write(char[] cbuf, int off, int len) throws IOException {
+            _pending = true;
+            super.write(cbuf, off, len);
+        }
+
+        @Override
+        public void write(String str, int off, int len) throws IOException {
+            _pending = true;
+            super.write(str, off, len);
+        }
+
+        @Override
+        public void flush() throws IOException {
+            _pending = false;
+            super.flush();
+        }
+
+        @Override
+        public void close() throws IOException {
+            // clear before delegating: close() may lead back to IOContext.close()
+            _pending = false;
+            super.close();
+        }
+
+        public void flushPending() {
+            if (_pending) {
+                _pending = false;
+                try {
+                    out.flush();
+                } catch (IOException e) {
+                    throw JacksonIOException.construct(e);
+                }
             }
         }
     }

--- a/src/main/java/tools/jackson/core/io/IOContext.java
+++ b/src/main/java/tools/jackson/core/io/IOContext.java
@@ -460,6 +460,8 @@ public class IOContext implements AutoCloseable
      * Wrapper for encoding {@link Writer} Jackson constructed itself, tracking
      * whether it holds content not yet pushed to the underlying target, so that
      * {@link IOContext#close} can drain it exactly once.
+     *
+     * @since 3.1.7
      */
     private final static class EncodingWriter extends FilterWriter
     {
@@ -498,6 +500,9 @@ public class IOContext implements AutoCloseable
             super.close();
         }
 
+        /**
+         * @since 3.1.7
+         */
         public void flushPending() {
             if (_pending) {
                 _pending = false;

--- a/src/test/java/tools/jackson/core/unittest/json/FailedGeneratorConstructionCloseTest.java
+++ b/src/test/java/tools/jackson/core/unittest/json/FailedGeneratorConstructionCloseTest.java
@@ -1,0 +1,85 @@
+package tools.jackson.core.unittest.json;
+
+import java.io.*;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import tools.jackson.core.*;
+import tools.jackson.core.io.IOContext;
+import tools.jackson.core.json.JsonFactory;
+import tools.jackson.core.unittest.JacksonCoreTestBase;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests to verify that streams Jackson itself opens for {@link File} /
+ * {@link java.nio.file.Path} targets get closed if construction of generator
+ * fails after opening.
+ */
+class FailedGeneratorConstructionCloseTest extends JacksonCoreTestBase
+{
+    static class CloseTrackingOutputStream extends FilterOutputStream {
+        public boolean closed;
+
+        CloseTrackingOutputStream(OutputStream out) { super(out); }
+
+        @Override
+        public void close() throws IOException {
+            closed = true;
+            super.close();
+        }
+    }
+
+    /**
+     * Factory that fails the way format backends can (say, when schema
+     * validation fails), that is, after source/target has been opened.
+     */
+    static class FailingFactory extends JsonFactory {
+        private static final long serialVersionUID = 1L;
+
+        public final List<CloseTrackingOutputStream> outputs = new ArrayList<>();
+
+        @Override
+        protected OutputStream _fileOutputStream(File f) throws JacksonException {
+            CloseTrackingOutputStream out = new CloseTrackingOutputStream(super._fileOutputStream(f));
+            outputs.add(out);
+            return out;
+        }
+
+        @Override
+        protected JsonGenerator _createGenerator(ObjectWriteContext writeCtxt,
+                IOContext ioCtxt, Writer out) throws JacksonException {
+            throw new IllegalStateException("Test-induced construction failure");
+        }
+
+        @Override
+        protected JsonGenerator _createUTF8Generator(ObjectWriteContext writeCtxt,
+                IOContext ioCtxt, OutputStream out) throws JacksonException {
+            throw new IllegalStateException("Test-induced construction failure");
+        }
+    }
+
+    private File _tempFile() throws IOException {
+        File f = File.createTempFile("jackson-core-test", ".json");
+        f.deleteOnExit();
+        Files.write(f.toPath(), utf8Bytes("{\"a\":1}"));
+        return f;
+    }
+
+    @Test
+    void closesFileOutputStreamOnFailedGeneratorConstruction() throws Exception
+    {
+        for (JsonEncoding enc : new JsonEncoding[] { JsonEncoding.UTF8, JsonEncoding.UTF16_BE }) {
+            FailingFactory f = new FailingFactory();
+            File dst = _tempFile();
+            assertThrows(IllegalStateException.class,
+                    () -> f.createGenerator(ObjectWriteContext.empty(), dst, enc));
+            assertEquals(1, f.outputs.size(), enc.toString());
+            assertTrue(f.outputs.get(0).closed,
+                    "OutputStream Jackson opened should have been closed, encoding "+enc);
+        }
+    }
+}

--- a/src/test/java/tools/jackson/core/unittest/write/GeneratorCloseTest.java
+++ b/src/test/java/tools/jackson/core/unittest/write/GeneratorCloseTest.java
@@ -210,7 +210,7 @@ class GeneratorCloseTest extends JacksonCoreTestBase
                     g.close();
 
                     String desc = enc+", autoClose="+autoClose+", flush="+flush;
-                    assertEquals("{\"a\":1}",
+                    assertEquals(a2q("{'a':1}"),
                             new String(output.toByteArray(), enc.getJavaName()), desc);
                     assertEquals(autoClose, output.isClosed(), desc);
                 }

--- a/src/test/java/tools/jackson/core/unittest/write/GeneratorCloseTest.java
+++ b/src/test/java/tools/jackson/core/unittest/write/GeneratorCloseTest.java
@@ -5,10 +5,13 @@ import java.io.*;
 
 import org.junit.jupiter.api.Test;
 
+import tools.jackson.core.JacksonException;
 import tools.jackson.core.JsonEncoding;
 import tools.jackson.core.JsonGenerator;
 import tools.jackson.core.ObjectWriteContext;
 import tools.jackson.core.StreamWriteFeature;
+import tools.jackson.core.io.IOContext;
+import tools.jackson.core.io.OutputDecorator;
 import tools.jackson.core.json.JsonFactory;
 import tools.jackson.core.unittest.*;
 import tools.jackson.core.unittest.testutil.ByteOutputStreamForTesting;
@@ -215,6 +218,63 @@ class GeneratorCloseTest extends JacksonCoreTestBase
                     assertEquals(autoClose, output.isClosed(), desc);
                 }
             }
+        }
+    }
+
+    // Failure to flush pending encoded content on close must not mask earlier
+    // failure, and generator must still be marked as closed
+    @Test
+    void nonUtf8FailingTargetKeepsOriginalFailure() throws Exception
+    {
+        JsonFactory f = JsonFactory.builder()
+                .configure(StreamWriteFeature.AUTO_CLOSE_TARGET, false)
+                .configure(StreamWriteFeature.FLUSH_PASSED_TO_STREAM, false)
+                .outputDecorator(new FailingWriterDecorator())
+                .build();
+        JsonGenerator g = f.createGenerator(ObjectWriteContext.empty(),
+                new ByteOutputStreamForTesting(), JsonEncoding.UTF16_BE);
+        g.writeStartObject();
+        g.writeEndObject();
+
+        JacksonException e = assertThrows(JacksonException.class, g::close);
+        assertEquals("write failed", e.getCause().getMessage());
+        assertEquals(1, e.getSuppressed().length);
+        assertEquals("flush failed", e.getSuppressed()[0].getCause().getMessage());
+        assertTrue(g.isClosed());
+    }
+
+    static class FailingWriterDecorator extends OutputDecorator
+    {
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public OutputStream decorate(IOContext ctxt, OutputStream out) {
+            return out;
+        }
+
+        @Override
+        public Writer decorate(IOContext ctxt, Writer w) {
+            return new FilterWriter(w) {
+                @Override
+                public void write(int c) throws IOException {
+                    throw new IOException("write failed");
+                }
+
+                @Override
+                public void write(char[] cbuf, int off, int len) throws IOException {
+                    throw new IOException("write failed");
+                }
+
+                @Override
+                public void write(String str, int off, int len) throws IOException {
+                    throw new IOException("write failed");
+                }
+
+                @Override
+                public void flush() throws IOException {
+                    throw new IOException("flush failed");
+                }
+            };
         }
     }
 }

--- a/src/test/java/tools/jackson/core/unittest/write/GeneratorCloseTest.java
+++ b/src/test/java/tools/jackson/core/unittest/write/GeneratorCloseTest.java
@@ -186,4 +186,35 @@ class GeneratorCloseTest extends JacksonCoreTestBase
         g.close();
         assertEquals(2, bytes.toByteArray().length);
     }
+
+    // Content buffered by the encoding Writer Jackson creates for non-UTF-8
+    // OutputStream targets must not be lost, even when generator is configured
+    // to neither close nor flush the caller-owned stream
+    @Test
+    void nonUtf8OutputStreamNotLosingContent() throws Exception
+    {
+        for (JsonEncoding enc : new JsonEncoding[] {
+                JsonEncoding.UTF16_BE, JsonEncoding.UTF16_LE,
+                JsonEncoding.UTF32_BE, JsonEncoding.UTF32_LE }) {
+            for (boolean autoClose : new boolean[] { true, false }) {
+                for (boolean flush : new boolean[] { true, false }) {
+                    JsonFactory f = JsonFactory.builder()
+                            .configure(StreamWriteFeature.AUTO_CLOSE_TARGET, autoClose)
+                            .configure(StreamWriteFeature.FLUSH_PASSED_TO_STREAM, flush)
+                            .build();
+                    ByteOutputStreamForTesting output = new ByteOutputStreamForTesting();
+                    JsonGenerator g = f.createGenerator(ObjectWriteContext.empty(), output, enc);
+                    g.writeStartObject();
+                    g.writeNumberProperty("a", 1);
+                    g.writeEndObject();
+                    g.close();
+
+                    String desc = enc+", autoClose="+autoClose+", flush="+flush;
+                    assertEquals("{\"a\":1}",
+                            new String(output.toByteArray(), enc.getJavaName()), desc);
+                    assertEquals(autoClose, output.isClosed(), desc);
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
Two generator-side target-handling defects. The second was originally in #1693 and moved here, since both restructure the same `createGenerator` methods.

## 1. Buffered output lost with a non-UTF-8 encoding

`createGenerator(ObjectWriteContext, OutputStream, JsonEncoding)` with a non-UTF-8 encoding routes through `TextualTSFactory._createWriter()`, which wraps the caller's stream in an `OutputStreamWriter` — a writer Jackson creates and the caller has no reference to.

`WriterBasedJsonGenerator._closeInput()` touches that writer only if `isResourceManaged() || AUTO_CLOSE_TARGET` (→ `close()`) or `FLUSH_PASSED_TO_STREAM` (→ `flush()`). With both features disabled it calls neither, so everything sitting in the encoder's buffer is dropped:

```
UTF8       autoClose=false flush=false -> bytes=7
UTF16_BE   autoClose=false flush=false -> bytes=0   <-- output lost
UTF16_LE   autoClose=false flush=false -> bytes=0
UTF32_BE   autoClose=false flush=false -> bytes=0
```

UTF-8 escapes this because the generator writes its own buffer straight to the stream in `_flushBuffer()`; the two features then only govern `close()`/`flush()` on the caller's stream, not delivery of content. Those features are about the target the caller passed, so a writer Jackson interposed has to be drained regardless — which is what the `File`/`Path` overloads already get for free via `isResourceManaged()`.

### Fix

- `IOContext` gains `encodingWriter(Writer)` (`@since 3.1.7`), which registers and wraps the writer, plus a private `EncodingWriter extends FilterWriter` tracking whether content has been written since the last `flush()`/`close()`. `IOContext.close()` flushes it if anything is pending, then releases the recycler in a `finally`.
- `TextualTSFactory` passes all three `_createWriter()` results through `ioCtxt.encodingWriter(...)`, after decoration so a replacing `OutputDecorator` is covered.

Done in `IOContext` rather than `WriterBasedJsonGenerator` because `GeneratorBase.close()` always calls `_ioContext.close()` — the one core-owned hook every backend's generator passes through, so the `TextualTSFactory` subclasses in the format backends (YAML, CSV, ...) get the fix without changes in their repos. That is where this was originally spotted.

The pending-flag keeps the behaviour change narrow: with `FLUSH_PASSED_TO_STREAM` on, `_closeInput()`'s `flush()` clears the flag; with `AUTO_CLOSE_TARGET` on, `close()` clears it. Only the both-off case drains, so the sole new side effect is one `flush()` reaching the caller's `OutputStream` on close in exactly the case that previously lost everything.

## 2. FD leak: `createGenerator(File|Path, enc)`

`TextualTSFactory:239,257` and `BinaryTSFactory:172,185` open the stream and hand it off with no `try`/`catch`, so anything that throws downstream strands it — `_decorate()` with a user `OutputDecorator`, `_createWriter()`, or a backend's `_createGenerator()` (Avro/Protobuf validate a schema there). Probe with a throwing `OutputDecorator`, 200 attempts:

```
generator(File) + failing decorator: fds 9 -> 209     (before)
generator(File) + failing decorator: fds 9 -> 9       (after)
```

### Fix

New package-private `DecorableTSFactory._closeOnFailedConstruction(Closeable, RuntimeException)`: closes the stream Jackson opened, attaching any secondary failure as suppressed. Caller-provided targets are never passed to it. The four `File`/`Path` generator paths across both base factories route failures through it; backends inherit those methods.

## Tests

- `GeneratorCloseTest.nonUtf8OutputStreamNotLosingContent`: 4 non-UTF-8 encodings × both features, asserting round-tripped content and that the stream is closed iff `AUTO_CLOSE_TARGET`. Fails without the fix with `UTF16_BE, autoClose=false, flush=false ==> expected: <{"a":1}> but was: <>`.
- New `unittest/json/FailedGeneratorConstructionCloseTest`: a `JsonFactory` subclass overrides `_fileOutputStream` with a close-tracking wrapper and fails in `_createGenerator`/`_createUTF8Generator` — the backend-schema-failure shape — so the assertion is portable rather than FD-counting.

Full `./mvnw -B -ff -ntp verify` passes (1716 tests).

## Notes

- `IOContext.encodingWriter()` is a new public method on a patch branch. It is additive and MiMa-clean, and `IOContext` isn't in the frozen-API set, but it can move to `3.2`/`3.x` unchanged if you'd rather keep 3.1.x free of API additions.
- #1693 adds the same `_closeOnFailedConstruction` helper for the parser paths, so whichever lands second conflicts on that one method — resolution is keeping a single copy of identical text. Happy to rebase.
- 2.x has the same `_createWriter()` shape, but its generators call `super.close()` first, so `GeneratorBase.close()` releases the `IOContext` before the buffer is flushed and this hook doesn't transfer as-is. Not reproduced or fixed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)