### PR TITLE
Release IOContext when parser/generator construction fails

### DIFF
--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -24,6 +24,9 @@ JSON library.
 #1673: `readString(Writer)` AIOOBE when an escape or multi-byte character
   lands at the output buffer boundary
  (fix by @pjfanning)
+- Release `IOContext` (and `BufferRecycler` lease it holds) when construction of
+  parser or generator fails
+ (fix by @pjfanning)
 
 3.1.6 (14-Aug-2026)
 

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -24,7 +24,7 @@ JSON library.
 #1673: `readString(Writer)` AIOOBE when an escape or multi-byte character
   lands at the output buffer boundary
  (fix by @pjfanning)
-- Release `IOContext` (and `BufferRecycler` lease it holds) when construction of
+#1694: Release `IOContext` (and `BufferRecycler` lease it holds) when construction of
   parser or generator fails
  (fix by @pjfanning)
 

--- a/src/main/java/tools/jackson/core/base/BinaryTSFactory.java
+++ b/src/main/java/tools/jackson/core/base/BinaryTSFactory.java
@@ -72,8 +72,13 @@ public abstract class BinaryTSFactory
         final InputStream in = _fileInputStream(f);
         // true, since we create InputStream from File
         final IOContext ioCtxt = _createContext(_createContentReference(f), true);
-        return _createParser(readCtxt, ioCtxt,
-                _decorate(ioCtxt, in));
+        try {
+            return _createParser(readCtxt, ioCtxt,
+                    _decorate(ioCtxt, in));
+        } catch (RuntimeException e) {
+            _releaseOnFailedConstruction(ioCtxt, e);
+            throw e;
+        }
     }
 
     @Override
@@ -82,14 +87,24 @@ public abstract class BinaryTSFactory
     {
         // true, since we create InputStream from Path
         IOContext ioCtxt = _createContext(_createContentReference(p), true);
-        return _createParser(readCtxt, ioCtxt,
-                _decorate(ioCtxt, _pathInputStream(p)));
+        try {
+            return _createParser(readCtxt, ioCtxt,
+                    _decorate(ioCtxt, _pathInputStream(p)));
+        } catch (RuntimeException e) {
+            _releaseOnFailedConstruction(ioCtxt, e);
+            throw e;
+        }
     }
 
     @Override
     public JsonParser createParser(ObjectReadContext readCtxt, InputStream in) throws JacksonException {
         IOContext ioCtxt = _createContext(_createContentReference(in), false);
-        return _createParser(readCtxt, ioCtxt, _decorate(ioCtxt, in));
+        try {
+            return _createParser(readCtxt, ioCtxt, _decorate(ioCtxt, in));
+        } catch (RuntimeException e) {
+            _releaseOnFailedConstruction(ioCtxt, e);
+            throw e;
+        }
     }
 
     @Override
@@ -103,13 +118,18 @@ public abstract class BinaryTSFactory
     {
         IOContext ioCtxt = _createContext(_createContentReference(data, offset, len),
                 true, null);
-        if (_inputDecorator != null) {
-            InputStream in = _inputDecorator.decorate(ioCtxt, data, offset, len);
-            if (in != null) {
-                return _createParser(readCtxt, ioCtxt, in);
+        try {
+            if (_inputDecorator != null) {
+                InputStream in = _inputDecorator.decorate(ioCtxt, data, offset, len);
+                if (in != null) {
+                    return _createParser(readCtxt, ioCtxt, in);
+                }
             }
+            return _createParser(readCtxt, ioCtxt, data, offset, len);
+        } catch (RuntimeException e) {
+            _releaseOnFailedConstruction(ioCtxt, e);
+            throw e;
         }
-        return _createParser(readCtxt, ioCtxt, data, offset, len);
     }
 
     @Override
@@ -128,7 +148,12 @@ public abstract class BinaryTSFactory
     public JsonParser createParser(ObjectReadContext readCtxt,
             DataInput in) throws JacksonException {
         IOContext ioCtxt = _createContext(_createContentReference(in), false);
-        return _createParser(readCtxt, ioCtxt, _decorate(ioCtxt, in));
+        try {
+            return _createParser(readCtxt, ioCtxt, _decorate(ioCtxt, in));
+        } catch (RuntimeException e) {
+            _releaseOnFailedConstruction(ioCtxt, e);
+            throw e;
+        }
     }
 
     protected abstract JsonParser _createParser(ObjectReadContext readCtxt,
@@ -153,9 +178,14 @@ public abstract class BinaryTSFactory
     {
         // false -> we won't manage the stream unless explicitly directed to
         IOContext ioCtxt = _createContext(_createContentReference(out), false, enc);
-        return _decorate(
-                _createGenerator(writeCtxt, ioCtxt, _decorate(ioCtxt, out))
-        );
+        try {
+            return _decorate(
+                    _createGenerator(writeCtxt, ioCtxt, _decorate(ioCtxt, out))
+            );
+        } catch (RuntimeException e) {
+            _releaseOnFailedConstruction(ioCtxt, e);
+            throw e;
+        }
     }
 
     @Override
@@ -172,9 +202,14 @@ public abstract class BinaryTSFactory
         final OutputStream out = _fileOutputStream(f);
         // true -> yes, we have to manage the stream since we created it
         final IOContext ioCtxt = _createContext(_createContentReference(out), true, enc);
-        return _decorate(
-                _createGenerator(writeCtxt, ioCtxt, _decorate(ioCtxt, out))
-        );
+        try {
+            return _decorate(
+                    _createGenerator(writeCtxt, ioCtxt, _decorate(ioCtxt, out))
+            );
+        } catch (RuntimeException e) {
+            _releaseOnFailedConstruction(ioCtxt, e);
+            throw e;
+        }
     }
 
     @Override
@@ -184,9 +219,14 @@ public abstract class BinaryTSFactory
     {
         final OutputStream out = _pathOutputStream(p);
         final IOContext ioCtxt = _createContext(_createContentReference(p), true, enc);
-        return _decorate(
-                _createGenerator(writeCtxt, ioCtxt, _decorate(ioCtxt, out))
-        );
+        try {
+            return _decorate(
+                    _createGenerator(writeCtxt, ioCtxt, _decorate(ioCtxt, out))
+            );
+        } catch (RuntimeException e) {
+            _releaseOnFailedConstruction(ioCtxt, e);
+            throw e;
+        }
     }
 
     /*

--- a/src/main/java/tools/jackson/core/base/DecorableTSFactory.java
+++ b/src/main/java/tools/jackson/core/base/DecorableTSFactory.java
@@ -255,6 +255,8 @@ public abstract class DecorableTSFactory
      *
      * @param ioCtxt Context to release
      * @param failure Failure to add possible secondary failure to, as suppressed
+     *
+     * @since 3.1.7
      */
     static void _releaseOnFailedConstruction(IOContext ioCtxt, RuntimeException failure)
     {

--- a/src/main/java/tools/jackson/core/base/DecorableTSFactory.java
+++ b/src/main/java/tools/jackson/core/base/DecorableTSFactory.java
@@ -240,6 +240,31 @@ public abstract class DecorableTSFactory
     }
 
 
+    /*
+    /**********************************************************************
+    /* Helper methods for failed construction
+    /**********************************************************************
+     */
+
+    /**
+     * Method called when construction of parser or generator fails: releases
+     * {@link IOContext} so that {@link tools.jackson.core.util.BufferRecycler}
+     * it leased gets returned to the pool. Without this the lease is simply
+     * dropped, since context is otherwise only released when parser or
+     * generator that owns it gets closed.
+     *
+     * @param ioCtxt Context to release
+     * @param failure Failure to add possible secondary failure to, as suppressed
+     */
+    static void _releaseOnFailedConstruction(IOContext ioCtxt, RuntimeException failure)
+    {
+        try {
+            ioCtxt.close();
+        } catch (Exception e) {
+            failure.addSuppressed(e);
+        }
+    }
+
     protected JsonGenerator _decorate(JsonGenerator result) {
         if (_generatorDecorators != null) {
             for(JsonGeneratorDecorator decorator : _generatorDecorators) {

--- a/src/main/java/tools/jackson/core/base/TextualTSFactory.java
+++ b/src/main/java/tools/jackson/core/base/TextualTSFactory.java
@@ -94,8 +94,13 @@ public abstract class TextualTSFactory
     {
         // true, since we create InputStream from File
         IOContext ioCtxt = _createContext(_createContentReference(f), true);
-        return _createParser(readCtxt, ioCtxt,
-                _decorate(ioCtxt, _fileInputStream(f)));
+        try {
+            return _createParser(readCtxt, ioCtxt,
+                    _decorate(ioCtxt, _fileInputStream(f)));
+        } catch (RuntimeException e) {
+            _releaseOnFailedConstruction(ioCtxt, e);
+            throw e;
+        }
     }
 
     @Override
@@ -104,8 +109,13 @@ public abstract class TextualTSFactory
     {
         // true, since we create InputStream from Path
         IOContext ioCtxt = _createContext(_createContentReference(p), true);
-        return _createParser(readCtxt, ioCtxt,
-                _decorate(ioCtxt, _pathInputStream(p)));
+        try {
+            return _createParser(readCtxt, ioCtxt,
+                    _decorate(ioCtxt, _pathInputStream(p)));
+        } catch (RuntimeException e) {
+            _releaseOnFailedConstruction(ioCtxt, e);
+            throw e;
+        }
     }
 
     @Override
@@ -113,7 +123,12 @@ public abstract class TextualTSFactory
         throws JacksonException
     {
         IOContext ioCtxt = _createContext(_createContentReference(in), false);
-        return _createParser(readCtxt, ioCtxt, _decorate(ioCtxt, in));
+        try {
+            return _createParser(readCtxt, ioCtxt, _decorate(ioCtxt, in));
+        } catch (RuntimeException e) {
+            _releaseOnFailedConstruction(ioCtxt, e);
+            throw e;
+        }
     }
 
     @Override
@@ -122,7 +137,12 @@ public abstract class TextualTSFactory
     {
         // false -> we do NOT own Reader (did not create it)
         IOContext ioCtxt = _createContext(_createContentReference(r), false);
-        return _createParser(readCtxt, ioCtxt, _decorate(ioCtxt, r));
+        try {
+            return _createParser(readCtxt, ioCtxt, _decorate(ioCtxt, r));
+        } catch (RuntimeException e) {
+            _releaseOnFailedConstruction(ioCtxt, e);
+            throw e;
+        }
     }
 
     @Override
@@ -131,13 +151,18 @@ public abstract class TextualTSFactory
         throws JacksonException
     {
         IOContext ioCtxt = _createContext(_createContentReference(data, offset, len), true);
-        if (_inputDecorator != null) {
-            InputStream in = _inputDecorator.decorate(ioCtxt, data, offset, len);
-            if (in != null) {
-                return _createParser(readCtxt, ioCtxt, in);
+        try {
+            if (_inputDecorator != null) {
+                InputStream in = _inputDecorator.decorate(ioCtxt, data, offset, len);
+                if (in != null) {
+                    return _createParser(readCtxt, ioCtxt, in);
+                }
             }
+            return _createParser(readCtxt, ioCtxt, data, offset, len);
+        } catch (RuntimeException e) {
+            _releaseOnFailedConstruction(ioCtxt, e);
+            throw e;
         }
-        return _createParser(readCtxt, ioCtxt, data, offset, len);
     }
 
     @Override
@@ -152,9 +177,14 @@ public abstract class TextualTSFactory
             return createParser(readCtxt, new StringReader(content));
         }
         IOContext ioCtxt = _createContext(_createContentReference(content), true);
-        char[] buf = ioCtxt.allocTokenBuffer(strLen);
-        content.getChars(0, strLen, buf, 0);
-        return _createParser(readCtxt, ioCtxt, buf, 0, strLen, true);
+        try {
+            char[] buf = ioCtxt.allocTokenBuffer(strLen);
+            content.getChars(0, strLen, buf, 0);
+            return _createParser(readCtxt, ioCtxt, buf, 0, strLen, true);
+        } catch (RuntimeException e) {
+            _releaseOnFailedConstruction(ioCtxt, e);
+            throw e;
+        }
     }
 
     @Override
@@ -165,11 +195,16 @@ public abstract class TextualTSFactory
         if (_inputDecorator != null) { // easier to just wrap in a Reader than extend InputDecorator
             return createParser(readCtxt, new CharArrayReader(content, offset, len));
         }
-        return _createParser(readCtxt,
-                _createContext(_createContentReference(content, offset, len), true),
-                content, offset, len,
-                // important: buffer is NOT recyclable, as it's from caller
-                false);
+        IOContext ioCtxt = _createContext(_createContentReference(content, offset, len), true);
+        try {
+            return _createParser(readCtxt, ioCtxt,
+                    content, offset, len,
+                    // important: buffer is NOT recyclable, as it's from caller
+                    false);
+        } catch (RuntimeException e) {
+            _releaseOnFailedConstruction(ioCtxt, e);
+            throw e;
+        }
     }
 
     @Override
@@ -177,7 +212,12 @@ public abstract class TextualTSFactory
             DataInput in) throws JacksonException
     {
         IOContext ioCtxt = _createContext(_createContentReference(in), false);
-        return _createParser(readCtxt, ioCtxt, _decorate(ioCtxt, in));
+        try {
+            return _createParser(readCtxt, ioCtxt, _decorate(ioCtxt, in));
+        } catch (RuntimeException e) {
+            _releaseOnFailedConstruction(ioCtxt, e);
+            throw e;
+        }
     }
 
     protected abstract JsonParser _createParser(ObjectReadContext readCtxt,
@@ -210,15 +250,20 @@ public abstract class TextualTSFactory
     {
         // false -> we won't manage the stream unless explicitly directed to
         IOContext ioCtxt = _createContext(_createContentReference(out), false, enc);
-        if (enc == JsonEncoding.UTF8) {
+        try {
+            if (enc == JsonEncoding.UTF8) {
+                return _decorate(
+                        _createUTF8Generator(writeCtxt, ioCtxt, _decorate(ioCtxt, out))
+                );
+            }
             return _decorate(
-                    _createUTF8Generator(writeCtxt, ioCtxt, _decorate(ioCtxt, out))
+                    _createGenerator(writeCtxt, ioCtxt,
+                            _decorate(ioCtxt, _createWriter(ioCtxt, out, enc)))
             );
+        } catch (RuntimeException e) {
+            _releaseOnFailedConstruction(ioCtxt, e);
+            throw e;
         }
-        return _decorate(
-                _createGenerator(writeCtxt, ioCtxt,
-                        _decorate(ioCtxt, _createWriter(ioCtxt, out, enc)))
-        );
     }
 
     @Override
@@ -226,9 +271,14 @@ public abstract class TextualTSFactory
         throws JacksonException
     {
         IOContext ioCtxt = _createContext(_createContentReference(w), false);
-        return _decorate(
-                _createGenerator(writeCtxt, ioCtxt, _decorate(ioCtxt, w))
-        );
+        try {
+            return _decorate(
+                    _createGenerator(writeCtxt, ioCtxt, _decorate(ioCtxt, w))
+            );
+        } catch (RuntimeException e) {
+            _releaseOnFailedConstruction(ioCtxt, e);
+            throw e;
+        }
     }
 
     @Override
@@ -238,15 +288,20 @@ public abstract class TextualTSFactory
     {
         final OutputStream out = _fileOutputStream(f);
         final IOContext ioCtxt = _createContext(_createContentReference(f), true, enc);
-        if (enc == JsonEncoding.UTF8) {
+        try {
+            if (enc == JsonEncoding.UTF8) {
+                return _decorate(
+                        _createUTF8Generator(writeCtxt, ioCtxt, _decorate(ioCtxt, out))
+                );
+            }
             return _decorate(
-                    _createUTF8Generator(writeCtxt, ioCtxt, _decorate(ioCtxt, out))
+                    _createGenerator(writeCtxt, ioCtxt,
+                            _decorate(ioCtxt, _createWriter(ioCtxt, out, enc)))
             );
+        } catch (RuntimeException e) {
+            _releaseOnFailedConstruction(ioCtxt, e);
+            throw e;
         }
-        return _decorate(
-                _createGenerator(writeCtxt, ioCtxt,
-                        _decorate(ioCtxt, _createWriter(ioCtxt, out, enc)))
-        );
     }
 
     @Override
@@ -256,15 +311,20 @@ public abstract class TextualTSFactory
     {
         final OutputStream out = _pathOutputStream(p);
         final IOContext ioCtxt = _createContext(_createContentReference(p), true, enc);
-        if (enc == JsonEncoding.UTF8) {
+        try {
+            if (enc == JsonEncoding.UTF8) {
+                return _decorate(
+                        _createUTF8Generator(writeCtxt, ioCtxt, _decorate(ioCtxt, out))
+                );
+            }
             return _decorate(
-                    _createUTF8Generator(writeCtxt, ioCtxt, _decorate(ioCtxt, out))
+                    _createGenerator(writeCtxt, ioCtxt,
+                            _decorate(ioCtxt, _createWriter(ioCtxt, out, enc)))
             );
+        } catch (RuntimeException e) {
+            _releaseOnFailedConstruction(ioCtxt, e);
+            throw e;
         }
-        return _decorate(
-                _createGenerator(writeCtxt, ioCtxt,
-                        _decorate(ioCtxt, _createWriter(ioCtxt, out, enc)))
-        );
     }
 
     /*

--- a/src/test/java/tools/jackson/core/unittest/json/FailedConstructionRecyclerTest.java
+++ b/src/test/java/tools/jackson/core/unittest/json/FailedConstructionRecyclerTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 
 import tools.jackson.core.*;
 import tools.jackson.core.exc.StreamConstraintsException;
+import tools.jackson.core.exc.StreamReadException;
 import tools.jackson.core.io.IOContext;
 import tools.jackson.core.json.JsonFactory;
 import tools.jackson.core.json.JsonFactoryBuilder;
@@ -86,7 +87,7 @@ class FailedConstructionRecyclerTest extends JacksonCoreTestBase
         assertEquals(0, pool.pooledCount());
 
         byte[] doc = utf8Bytes("{\"a\":1}");
-        assertThrows(RuntimeException.class,
+        assertThrows(StreamReadException.class,
                 () -> f.createParser(ObjectReadContext.empty(), doc, 5, 100));
         assertEquals(1, pool.pooledCount());
     }

--- a/src/test/java/tools/jackson/core/unittest/json/FailedConstructionRecyclerTest.java
+++ b/src/test/java/tools/jackson/core/unittest/json/FailedConstructionRecyclerTest.java
@@ -1,0 +1,121 @@
+package tools.jackson.core.unittest.json;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.Writer;
+
+import org.junit.jupiter.api.Test;
+
+import tools.jackson.core.*;
+import tools.jackson.core.exc.StreamConstraintsException;
+import tools.jackson.core.io.IOContext;
+import tools.jackson.core.json.JsonFactory;
+import tools.jackson.core.json.JsonFactoryBuilder;
+import tools.jackson.core.unittest.JacksonCoreTestBase;
+import tools.jackson.core.util.BufferRecycler;
+import tools.jackson.core.util.JsonRecyclerPools;
+import tools.jackson.core.util.RecyclerPool;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests to verify that {@link BufferRecycler} leased by {@link IOContext} gets
+ * returned to the pool even if no parser or generator ends up being constructed:
+ * context is otherwise only released when parser/generator that owns it is closed.
+ */
+class FailedConstructionRecyclerTest extends JacksonCoreTestBase
+{
+    /**
+     * Factory that fails the way format backends can (say, when schema
+     * validation fails), that is, after {@link IOContext} has been created.
+     */
+    static class FailingFactory extends JsonFactory {
+        private static final long serialVersionUID = 1L;
+
+        public FailingFactory(JsonFactoryBuilder b) { super(b); }
+
+        @Override
+        protected JsonParser _createParser(ObjectReadContext readCtxt, IOContext ioCtxt,
+                InputStream in) throws JacksonException {
+            throw new IllegalStateException("Test-induced construction failure");
+        }
+
+        @Override
+        protected JsonGenerator _createGenerator(ObjectWriteContext writeCtxt,
+                IOContext ioCtxt, Writer out) throws JacksonException {
+            throw new IllegalStateException("Test-induced construction failure");
+        }
+
+        @Override
+        protected JsonGenerator _createUTF8Generator(ObjectWriteContext writeCtxt,
+                IOContext ioCtxt, OutputStream out) throws JacksonException {
+            throw new IllegalStateException("Test-induced construction failure");
+        }
+    }
+
+    // Constraint violation trips before parser gets constructed
+    @Test
+    void releasesRecyclerOnFailedParserConstruction() throws Exception
+    {
+        RecyclerPool<BufferRecycler> pool = JsonRecyclerPools.newBoundedPool(5);
+        JsonFactory f = JsonFactory.builder()
+                .recyclerPool(pool)
+                .streamReadConstraints(StreamReadConstraints.builder().maxDocumentLength(2).build())
+                .build();
+        assertEquals(0, pool.pooledCount());
+
+        byte[] doc = utf8Bytes("{\"a\":1}");
+        assertThrows(StreamConstraintsException.class,
+                () -> f.createParser(ObjectReadContext.empty(), doc));
+        assertEquals(1, pool.pooledCount());
+
+        char[] chars = "{\"a\":1}".toCharArray();
+        assertThrows(StreamConstraintsException.class,
+                () -> f.createParser(ObjectReadContext.empty(), chars, 0, chars.length));
+        assertEquals(1, pool.pooledCount());
+    }
+
+    // Caller-supplied bounds checked before parser gets constructed
+    @Test
+    void releasesRecyclerOnInvalidBounds() throws Exception
+    {
+        RecyclerPool<BufferRecycler> pool = JsonRecyclerPools.newBoundedPool(5);
+        JsonFactory f = JsonFactory.builder().recyclerPool(pool).build();
+        assertEquals(0, pool.pooledCount());
+
+        byte[] doc = utf8Bytes("{\"a\":1}");
+        assertThrows(RuntimeException.class,
+                () -> f.createParser(ObjectReadContext.empty(), doc, 5, 100));
+        assertEquals(1, pool.pooledCount());
+    }
+
+    @Test
+    void releasesRecyclerOnFailedParserConstructionFromStream() throws Exception
+    {
+        RecyclerPool<BufferRecycler> pool = JsonRecyclerPools.newBoundedPool(5);
+        FailingFactory f = new FailingFactory(JsonFactory.builder().recyclerPool(pool));
+        assertEquals(0, pool.pooledCount());
+
+        assertThrows(IllegalStateException.class,
+                () -> f.createParser(ObjectReadContext.empty(),
+                        new ByteArrayInputStream(utf8Bytes("{\"a\":1}"))));
+        assertEquals(1, pool.pooledCount());
+    }
+
+    @Test
+    void releasesRecyclerOnFailedGeneratorConstruction() throws Exception
+    {
+        for (JsonEncoding enc : new JsonEncoding[] { JsonEncoding.UTF8, JsonEncoding.UTF16_BE }) {
+            RecyclerPool<BufferRecycler> pool = JsonRecyclerPools.newBoundedPool(5);
+            FailingFactory f = new FailingFactory(JsonFactory.builder().recyclerPool(pool));
+            assertEquals(0, pool.pooledCount(), enc.toString());
+
+            assertThrows(IllegalStateException.class,
+                    () -> f.createGenerator(ObjectWriteContext.empty(),
+                            new ByteArrayOutputStream(), enc));
+            assertEquals(1, pool.pooledCount(), enc.toString());
+        }
+    }
+}


### PR DESCRIPTION
Second of three PRs from the resource-handling sweep that followed #1692 (see also #1693 for the file-descriptor leaks).

`TokenStreamFactory._createContext()` (`TokenStreamFactory.java:1218`) leases a `BufferRecycler` from the configured pool, and the only thing that returns it is `IOContext.close()` — which requires a parser or generator that was successfully constructed **and** later closed. So any failure between the two drops the lease:

- invalid `byte[]` / `char[]` offsets (`_checkRangeBoundsForByteArray`)
- a `maxDocumentLength` violation, validated up front for fixed buffers
- a missing file, or a throwing `InputDecorator` / `OutputDecorator`
- a backend's `_createParser` / `_createGenerator` rejecting a schema

The [core#763] guard in `JsonFactory._createParser(ObjectReadContext, IOContext, InputStream)` closes a managed stream but does not release the context.

```
pooled recyclers after 10 failed createParser(byte[]): 0     (before)
pooled recyclers after 10 failed createParser(byte[]): 1     (after)
```

Severity is modest — the recycler is garbage-collected and `BoundedPool` simply holds fewer entries, so this is lost recycling rather than exhaustion — but under a workload that rejects input regularly (constraint limits doing their job) the pool stays cold.

### Fix

- New package-private `DecorableTSFactory._releaseOnFailedConstruction(IOContext, RuntimeException)`: closes the context, attaching any secondary failure as suppressed. No public API change.
- Every `createParser` / `createGenerator` path in `TextualTSFactory` and `BinaryTSFactory` routes failures through it. Since these methods are inherited, the format backends get the fix too.

### Tests

New `unittest/json/FailedConstructionRecyclerTest` (4 tests) drives a bounded pool through the failure shapes above — constraint violation, invalid bounds, and a `JsonFactory` subclass that throws from `_createParser`/`_createGenerator` the way a schema-validating backend does — asserting `pooledCount()` afterwards. All four fail without the main-source change (`expected: <1> but was: <0>`).

Full `./mvnw -B -ff -ntp verify` passes (1718 tests).

### Note

Branched off `3.1`, and it wraps the same create methods as #1692 and #1693, so expect merge conflicts. The two helpers have distinct names and signatures (`_closeOnFailedConstruction` vs `_releaseOnFailedConstruction`), so resolution is keeping both calls in the shared `catch` blocks. Happy to rebase whichever lands later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)