### PR TITLE
Release resources in `UTF8Writer.close()` when flush of pending content fails

### DIFF
--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -24,6 +24,9 @@ JSON library.
 #1673: `readString(Writer)` AIOOBE when an escape or multi-byte character
   lands at the output buffer boundary
  (fix by @pjfanning)
+- Release encoding buffer and close underlying stream in `UTF8Writer.close()`
+  even if writing of pending content fails
+ (fix by @pjfanning)
 
 3.1.6 (14-Aug-2026)
 

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -24,7 +24,7 @@ JSON library.
 #1673: `readString(Writer)` AIOOBE when an escape or multi-byte character
   lands at the output buffer boundary
  (fix by @pjfanning)
-- Release encoding buffer and close underlying stream in `UTF8Writer.close()`
+#1695: Release encoding buffer and close underlying stream in `UTF8Writer.close()`
   even if writing of pending content fails
  (fix by @pjfanning)
 

--- a/src/main/java/tools/jackson/core/io/UTF8Writer.java
+++ b/src/main/java/tools/jackson/core/io/UTF8Writer.java
@@ -65,31 +65,19 @@ public final class UTF8Writer extends Writer
                 OutputStream out = _out;
                 _out = null;
 
-                IOException fail = null;
-                try {
+                // try-with-resources: stream closed on any failure (unchecked too),
+                // with close failure added as suppressed to primary one
+                try (OutputStream o = out) {
                     if (_outPtr > 0) {
-                        out.write(_outBuffer, 0, _outPtr);
-                        _outPtr = 0;
+                        o.write(_outBuffer, 0, _outPtr);
                     }
-                } catch (IOException e) {
-                    fail = e;
-                }
-                byte[] buf = _outBuffer;
-                if (buf != null) {
-                    _outBuffer = null;
-                    _context.releaseWriteEncodingBuffer(buf);
-                }
-                try {
-                    out.close();
-                } catch (IOException e) {
-                    if (fail == null) {
-                        fail = e;
-                    } else {
-                        fail.addSuppressed(e);
+                } finally {
+                    _outPtr = 0;
+                    byte[] buf = _outBuffer;
+                    if (buf != null) {
+                        _outBuffer = null;
+                        _context.releaseWriteEncodingBuffer(buf);
                     }
-                }
-                if (fail != null) {
-                    throw fail;
                 }
 
                 // Let's 'flush' orphan surrogate, no matter what; but only

--- a/src/main/java/tools/jackson/core/io/UTF8Writer.java
+++ b/src/main/java/tools/jackson/core/io/UTF8Writer.java
@@ -57,31 +57,52 @@ public final class UTF8Writer extends Writer
     public void close()
         throws IOException
     {
-        if (_out != null) {
-            if (_outPtr > 0) {
-                _out.write(_outBuffer, 0, _outPtr);
-                _outPtr = 0;
-            }
-            OutputStream out = _out;
-            _out = null;
+        // 08-Sep-2026, pjfanning: buffer and stream must be released even if
+        //   flushing of pending content fails; otherwise close() leaves both
+        //   stranded (and second call would retry the failed write)
+        try {
+            if (_out != null) {
+                OutputStream out = _out;
+                _out = null;
 
-            byte[] buf = _outBuffer;
-            if (buf != null) {
-                _outBuffer = null;
-                _context.releaseWriteEncodingBuffer(buf);
-            }
+                IOException fail = null;
+                try {
+                    if (_outPtr > 0) {
+                        out.write(_outBuffer, 0, _outPtr);
+                        _outPtr = 0;
+                    }
+                } catch (IOException e) {
+                    fail = e;
+                }
+                byte[] buf = _outBuffer;
+                if (buf != null) {
+                    _outBuffer = null;
+                    _context.releaseWriteEncodingBuffer(buf);
+                }
+                try {
+                    out.close();
+                } catch (IOException e) {
+                    if (fail == null) {
+                        fail = e;
+                    } else {
+                        fail.addSuppressed(e);
+                    }
+                }
+                if (fail != null) {
+                    throw fail;
+                }
 
-            out.close();
-
-            // Let's 'flush' orphan surrogate, no matter what; but only
-            // after cleanly closing everything else.
-            int code = _surrogate;
-            _surrogate = 0;
-            if (code > 0) {
-                illegalSurrogate(code);
+                // Let's 'flush' orphan surrogate, no matter what; but only
+                // after cleanly closing everything else.
+                int code = _surrogate;
+                _surrogate = 0;
+                if (code > 0) {
+                    illegalSurrogate(code);
+                }
             }
+        } finally {
+            _context.close();
         }
-        _context.close();
     }
 
     @Override

--- a/src/test/java/tools/jackson/core/unittest/io/UTF8WriterTest.java
+++ b/src/test/java/tools/jackson/core/unittest/io/UTF8WriterTest.java
@@ -186,9 +186,32 @@ class UTF8WriterTest
         assertEquals(1, out.writeCount);
     }
 
+    // Same for unchecked failures
+    @Test
+    void releasesResourcesOnFailedCloseUnchecked() throws Exception
+    {
+        FailingOutputStream out = new FailingOutputStream(true);
+        UTF8Writer w = new UTF8Writer(_ioContext(), out);
+        w.write("abc");
+        try {
+            w.close();
+            fail("should not pass");
+        } catch (UncheckedIOException e) {
+            verifyException(e, "write() failing");
+        }
+        assertTrue(out.closed, "Underlying stream should have been closed");
+        w.close();
+        assertEquals(1, out.writeCount);
+    }
+
     static class FailingOutputStream extends OutputStream {
+        private final boolean _unchecked;
         public int writeCount;
         public boolean closed;
+
+        public FailingOutputStream() { this(false); }
+
+        public FailingOutputStream(boolean unchecked) { _unchecked = unchecked; }
 
         @Override
         public void write(int b) throws IOException {
@@ -198,7 +221,11 @@ class UTF8WriterTest
         @Override
         public void write(byte[] b, int off, int len) throws IOException {
             ++writeCount;
-            throw new IOException("write() failing");
+            IOException e = new IOException("write() failing");
+            if (_unchecked) {
+                throw new UncheckedIOException(e);
+            }
+            throw e;
         }
 
         @Override

--- a/src/test/java/tools/jackson/core/unittest/io/UTF8WriterTest.java
+++ b/src/test/java/tools/jackson/core/unittest/io/UTF8WriterTest.java
@@ -163,6 +163,48 @@ class UTF8WriterTest
         }
     }
 
+    // Failure to write out pending content must not prevent releasing of the
+    // encoding buffer and closing of the underlying stream
+    @Test
+    void releasesResourcesOnFailedClose() throws Exception
+    {
+        FailingOutputStream out = new FailingOutputStream();
+        UTF8Writer w = new UTF8Writer(_ioContext(), out);
+        w.write("abc");
+        // nothing pushed to stream yet, so failure occurs during close():
+        assertEquals(0, out.writeCount);
+        try {
+            w.close();
+            fail("should not pass");
+        } catch (IOException e) {
+            verifyException(e, "write() failing");
+        }
+        assertTrue(out.closed, "Underlying stream should have been closed");
+
+        // and second close() is a no-op, not a retry of the failed write
+        w.close();
+        assertEquals(1, out.writeCount);
+    }
+
+    static class FailingOutputStream extends OutputStream {
+        public int writeCount;
+        public boolean closed;
+
+        @Override
+        public void write(int b) throws IOException {
+            write(new byte[] { (byte) b }, 0, 1);
+        }
+
+        @Override
+        public void write(byte[] b, int off, int len) throws IOException {
+            ++writeCount;
+            throw new IOException("write() failing");
+        }
+
+        @Override
+        public void close() { closed = true; }
+    }
+
     private IOContext _ioContext() {
         return testIOContext();
     }

--- a/src/test/java/tools/jackson/core/unittest/io/UTF8WriterTest.java
+++ b/src/test/java/tools/jackson/core/unittest/io/UTF8WriterTest.java
@@ -4,8 +4,14 @@ import java.io.*;
 
 import org.junit.jupiter.api.Test;
 
+import tools.jackson.core.ErrorReportConfiguration;
+import tools.jackson.core.JsonEncoding;
+import tools.jackson.core.StreamReadConstraints;
+import tools.jackson.core.StreamWriteConstraints;
+import tools.jackson.core.io.ContentReference;
 import tools.jackson.core.io.IOContext;
 import tools.jackson.core.io.UTF8Writer;
+import tools.jackson.core.util.BufferRecycler;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -168,48 +174,58 @@ class UTF8WriterTest
     @Test
     void releasesResourcesOnFailedClose() throws Exception
     {
-        FailingOutputStream out = new FailingOutputStream();
-        UTF8Writer w = new UTF8Writer(_ioContext(), out);
-        w.write("abc");
-        // nothing pushed to stream yet, so failure occurs during close():
-        assertEquals(0, out.writeCount);
-        try {
-            w.close();
-            fail("should not pass");
-        } catch (IOException e) {
-            verifyException(e, "write() failing");
-        }
-        assertTrue(out.closed, "Underlying stream should have been closed");
-
-        // and second close() is a no-op, not a retry of the failed write
-        w.close();
-        assertEquals(1, out.writeCount);
+        _verifyReleaseOnFailedClose(false);
     }
 
     // Same for unchecked failures
     @Test
     void releasesResourcesOnFailedCloseUnchecked() throws Exception
     {
-        FailingOutputStream out = new FailingOutputStream(true);
-        UTF8Writer w = new UTF8Writer(_ioContext(), out);
+        _verifyReleaseOnFailedClose(true);
+    }
+
+    private void _verifyReleaseOnFailedClose(boolean unchecked) throws Exception
+    {
+        TrackingBufferRecycler br = new TrackingBufferRecycler();
+        FailingOutputStream out = new FailingOutputStream(unchecked);
+        UTF8Writer w = new UTF8Writer(new IOContext(StreamReadConstraints.defaults(),
+                StreamWriteConstraints.defaults(), ErrorReportConfiguration.defaults(),
+                br, ContentReference.unknown(), false, JsonEncoding.UTF8),
+                out);
         w.write("abc");
+        // nothing pushed to stream yet, so failure occurs during close():
+        assertEquals(0, out.writeCount);
         try {
             w.close();
             fail("should not pass");
-        } catch (UncheckedIOException e) {
+        } catch (IOException | UncheckedIOException e) {
             verifyException(e, "write() failing");
         }
         assertTrue(out.closed, "Underlying stream should have been closed");
+        assertEquals(1, br.encodingBufferReleases, "Encoding buffer should have been released");
+
+        // and second close() is a no-op, not a retry of the failed write
         w.close();
         assertEquals(1, out.writeCount);
+        assertEquals(1, br.encodingBufferReleases);
+    }
+
+    static class TrackingBufferRecycler extends BufferRecycler {
+        public int encodingBufferReleases;
+
+        @Override
+        public void releaseByteBuffer(int ix, byte[] buffer) {
+            if (ix == BYTE_WRITE_ENCODING_BUFFER) {
+                ++encodingBufferReleases;
+            }
+            super.releaseByteBuffer(ix, buffer);
+        }
     }
 
     static class FailingOutputStream extends OutputStream {
         private final boolean _unchecked;
         public int writeCount;
         public boolean closed;
-
-        public FailingOutputStream() { this(false); }
 
         public FailingOutputStream(boolean unchecked) { _unchecked = unchecked; }
 


### PR DESCRIPTION
Third of three PRs from the resource-handling sweep that followed #1692 (see also #1693 for the file-descriptor leaks and #1694 for the `IOContext` lease). Independent of the other two — touches only `UTF8Writer`.

`UTF8Writer.close()` (`io/UTF8Writer.java:57`) starts by writing out whatever is pending in the encoding buffer. If that write throws:

- `_out` is never nulled
- the encoding buffer is never returned via `releaseWriteEncodingBuffer()`
- `out.close()` never runs — the underlying stream stays open
- `_context.close()` is skipped, so the `BufferRecycler` lease is dropped too

and because `_out` is still set, a second `close()` (try-with-resources plus an explicit close, say) retries the failed write rather than being a no-op.

### Fix

The write of pending content now happens inside try-with-resources on the underlying stream, with the encoding buffer released in `finally`; `_context.close()` also moves into a `finally`. So on any failure — checked or unchecked — the stream is closed, the buffer released and the context closed; a close failure is attached as suppressed to the primary one. `_out` is nulled up front, so a second `close()` is a no-op.

Ordering is unchanged on the happy path, including the deliberate "flush orphan surrogate only after cleanly closing everything else" step (only difference: buffer is released after, rather than before, `out.close()`).

### Tests

`UTF8WriterTest.releasesResourcesOnFailedClose` / `releasesResourcesOnFailedCloseUnchecked`: an `OutputStream` that throws (`IOException` / `UncheckedIOException`) from `write()`, with content buffered but not yet pushed. Asserts the exception propagates, the stream still got closed, the encoding buffer was returned to the `BufferRecycler`, and a second `close()` neither retries the write nor re-releases the buffer. Fails without the fix:

```
UTF8WriterTest.releasesResourcesOnFailedClose->_verifyReleaseOnFailedClose Underlying stream should have been closed ==> expected: <true> but was: <false>
```

Full `./mvnw -B -ff -ntp verify` passes (1721 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ADdsc11y5LUUxQDVCqyYad
