### PR TITLE
Avoid unnecessary String allocation in FilteringGeneratorDelegate

### DIFF
--- a/src/main/java/tools/jackson/core/filter/FilteringGeneratorDelegate.java
+++ b/src/main/java/tools/jackson/core/filter/FilteringGeneratorDelegate.java
@@ -451,12 +451,12 @@ public class FilteringGeneratorDelegate extends JsonGeneratorDelegate
             return this;
         }
         if (_itemFilter != TokenFilter.INCLUDE_ALL) {
-            String value = new String(text, offset, len);
             TokenFilter state = _filterContext.checkValue(_itemFilter);
             if (state == null) {
                 return this;
             }
             if (state != TokenFilter.INCLUDE_ALL) {
+                String value = new String(text, offset, len);
                 if (!state.includeString(value)) {
                     return this;
                 }


### PR DESCRIPTION
## Summary

Avoid eagerly creating a `String` in `FilteringGeneratorDelegate.writeString(char[], int, int)` before the filter state is known.

Previously, the `char[]` input was converted to a `String` even when `checkValue()` returned `null` or `TokenFilter.INCLUDE_ALL`, where the value is never inspected.

This path is also reached by `JsonGenerator.copyCurrentEvent()` and `copyCurrentStructure()` when the parser exposes its string value through `getStringCharacters()`.

## Benchmark

JMH benchmark using the `copyCurrentEvent()` path with `-prof gc`:

| Length | Before ns/op | After ns/op | Before B/op | After B/op |
|------:|-------------:|------------:|------------:|-----------:|
| 8 | 18.502 | 15.435 | 24.006 | ~0 |
| 32 | 26.796 | 24.990 | 48.012 | ~0 |
| 128 | 85.196 | 77.027 | 144.016 | ~0 |
| 512 | 306.539 | 272.744 | 528.029 | ~0 |

The change removes the temporary `String` allocation and its length-dependent character copy when the filter does not need to inspect the value.