### PR TITLE
Replace regexp in NumberInput.looksLikeValidNumber() with single-pass scan

### DIFF
--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -20,6 +20,8 @@ a pure JSON library.
   lands at the output buffer boundary
  (reported by @hdimitrieski)
  (fix by @kalayciburak)
+#1699: Replace regexp in `NumberInput.looksLikeValidNumber()` with single-pass
+  scan, to avoid quadratic backtracking on long input
 
 2.21.6 (14-Aug-2026)
 

--- a/src/main/java/com/fasterxml/jackson/core/io/NumberInput.java
+++ b/src/main/java/com/fasterxml/jackson/core/io/NumberInput.java
@@ -2,7 +2,6 @@ package com.fasterxml.jackson.core.io;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.util.regex.Pattern;
 
 import ch.randelshofer.fastdoubleparser.JavaDoubleParser;
 import ch.randelshofer.fastdoubleparser.JavaFloatParser;
@@ -32,25 +31,6 @@ public final class NumberInput
     final static String MIN_LONG_STR_NO_SIGN = String.valueOf(Long.MIN_VALUE).substring(1);
     final static String MAX_LONG_STR = String.valueOf(Long.MAX_VALUE);
 
-    /**
-     * Regexp used to pre-validate "Stringified Numbers": slightly looser than
-     * JSON Number definition (allows leading zeroes, positive sign).
-     *
-     * @since 2.17
-     */
-    private final static Pattern PATTERN_FLOAT = Pattern.compile(
-          "[+-]?[0-9]*[\\.]?[0-9]+([eE][+-]?[0-9]+)?");
-
-
-    /**
-     * Secondary regexp used along with {@code PATTERN_FLOAT} to cover
-     * case where number ends with dot, like {@code "+12."}
-     *
-     * @since 2.17.2
-     */
-    private final static Pattern PATTERN_FLOAT_TRAILING_DOT = Pattern.compile(
-            "[+-]?[0-9]+[\\.]");
-    
     /**
      * Fast method for parsing unsigned integers that are known to fit into
      * regular 32-bit signed int type. This means that length is
@@ -644,15 +624,73 @@ public final class NumberInput
      * @since 2.17
      */
     public static boolean looksLikeValidNumber(final String s) {
-        // While PATTERN_FLOAT handles most cases we can optimize some simple ones:
-        if (s == null || s.isEmpty()) {
+        // 10-Sep-2026, pjfanning: [core#1699] hand-rolled single-pass scan; the
+        //   equivalent regexp had adjacent `[0-9]*`/`[0-9]+` quantifiers and so
+        //   backtracked quadratically over long non-matching input.
+        if (s == null) {
             return false;
         }
-        if (s.length() == 1) {
-            char c = s.charAt(0);
-            return (c <= '9') && (c >= '0');
+        final int len = s.length();
+        if (len == 0) {
+            return false;
         }
-        return PATTERN_FLOAT.matcher(s).matches()
-                || PATTERN_FLOAT_TRAILING_DOT.matcher(s).matches();
+        int i = 0;
+        char c = s.charAt(0);
+        if ((c == '+') || (c == '-')) {
+            if (++i == len) { // sign alone
+                return false;
+            }
+        }
+        // Integer part; may be empty for values like ".5"
+        final int intStart = i;
+        while ((i < len) && _isDigitChar(s.charAt(i))) {
+            ++i;
+        }
+        final int intDigits = i - intStart;
+
+        if (i == len) { // digits only, like "125"
+            return intDigits > 0;
+        }
+        if (s.charAt(i) == '.') {
+            final int fractionStart = ++i;
+            while ((i < len) && _isDigitChar(s.charAt(i))) {
+                ++i;
+            }
+            final int fractionDigits = i - fractionStart;
+            if ((intDigits == 0) && (fractionDigits == 0)) { // "." or "-."
+                return false;
+            }
+            if (i == len) { // "1.25", ".25" -- and trailing dot, like "12."
+                return true;
+            }
+            if (fractionDigits == 0) { // dot must be followed by digits, if by anything
+                return false;
+            }
+        } else if (intDigits == 0) { // no digits and no dot, like "x" or "-x"
+            return false;
+        }
+        // Exponent, if any, must consume the remainder
+        c = s.charAt(i);
+        if ((c != 'e') && (c != 'E')) {
+            return false;
+        }
+        if (++i == len) {
+            return false;
+        }
+        c = s.charAt(i);
+        if ((c == '+') || (c == '-')) {
+            if (++i == len) {
+                return false;
+            }
+        }
+        final int expStart = i;
+        while ((i < len) && _isDigitChar(s.charAt(i))) {
+            ++i;
+        }
+        return (i > expStart) && (i == len);
+    }
+
+    private static boolean _isDigitChar(final char c) {
+        return (c >= '0') && (c <= '9');
     }
 }

--- a/src/test/java/com/fasterxml/jackson/core/io/NumberInputTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/io/NumberInputTest.java
@@ -155,6 +155,21 @@ class NumberInputTest
                 "+ 1", "1+1", "1-1");
     }
 
+    // The two documented deviations from strict JSON Number: positive sign
+    // and leading zeroes, including where they combine
+    @Test
+    void looksLikeValidNumberNonJsonLooseness()
+    {
+        // Positive sign, in every position the grammar allows one
+        _assertValid("+1", "+0.25", "+125.", "+.5", "+1e5", "+1e+5", "+1e-5", "+0e0");
+        // Leading zeroes, in integer part, fraction and exponent
+        _assertValid("00", "0000", "0001", "00.00", "00.5", ".00", "00.",
+                "0e007", "1e007", "1e+007", "1e-007", "0000000000000000001");
+        // ...and the two combined
+        _assertValid("+00", "-00", "+007", "-007", "+00.5", "-00.5",
+                "+00.", "-007.", "+.00", "-.00", "-0.0", "+0.0", "007.5e007");
+    }
+
     @Test
     void looksLikeValidNumberIntegers()
     {

--- a/src/test/java/com/fasterxml/jackson/core/io/NumberInputTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/io/NumberInputTest.java
@@ -3,6 +3,7 @@ package com.fasterxml.jackson.core.io;
 import java.math.BigInteger;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -139,5 +140,113 @@ class NumberInputTest
         assertFalse(NumberInput.looksLikeValidNumber("+."));
         assertFalse(NumberInput.looksLikeValidNumber("-E"));
         assertFalse(NumberInput.looksLikeValidNumber("+E"));
+    }
+
+    // [core#1699]: following tests exercise the branches of the hand-rolled
+    //   scanner that replaced the original regexp
+
+    @Test
+    void looksLikeValidNumberSigns()
+    {
+        _assertValid("+0", "-0", "+9", "-9", "+.5", "-.5", "+5.", "-5.",
+                "+1e5", "-1e5", "+1.5e-5", "-1.5e+5");
+        // Sign alone, repeated or misplaced
+        _assertInvalid("+", "-", "++1", "--1", "+-1", "-+1", "1+", "1-",
+                "+ 1", "1+1", "1-1");
+    }
+
+    @Test
+    void looksLikeValidNumberIntegers()
+    {
+        _assertValid("0", "9", "00", "0001", "1234567890", "9999999999999999999999");
+        _assertInvalid("", " ", "x", "1x", "x1", "1 2", "0x10", "10_000",
+                "Infinity", "-Infinity", "NaN");
+    }
+
+    @Test
+    void looksLikeValidNumberDecimals()
+    {
+        // Leading dot, trailing dot, and both sides present
+        _assertValid(".0", ".5", "0.", "5.", "0.0", "00.00", "1.5", "-0.10", "+0.25");
+        // A dot needs a digit on at least one side, and only one dot is allowed
+        _assertInvalid(".", "-.", "+.", "..", "1..2", "1.2.3", ".1.", "1..", ".." + ".");
+    }
+
+    @Test
+    void looksLikeValidNumberExponents()
+    {
+        _assertValid("1e1", "1E1", "1e+1", "1e-1", "1e0", "1e007", "0e0",
+                "1.5e10", ".5e10", "1.5E-45", "1.4e+45");
+        // Exponent marker must be followed by at least one digit, optionally signed
+        _assertInvalid("1e", "1E", "1e+", "1e-", "e10", "E10", "+e10", "e", "E",
+                "1e+x", "1ee1", "1e1e1", "1e1.5", "1e.5", "1e1.", "5e5e5");
+        // Trailing dot cannot carry an exponent: the "12." form is a separate,
+        // exponent-less case
+        _assertInvalid("1.e5", "1.e", "12.e5", "-12.E5");
+    }
+
+    @Test
+    void looksLikeValidNumberNonAsciiDigits()
+    {
+        // Only ASCII digits count, matching the original regexp's [0-9]
+        _assertInvalid("\u0661\u0662\u0663", // Arabic-Indic 123
+                "\uFF11\uFF12\uFF13", // full-width 123
+                "1\u0661", "\u06603"); // mixed
+    }
+
+    @Test
+    void looksLikeValidNumberWhitespace()
+    {
+        // No trimming is performed by this method
+        _assertInvalid(" 1", "1 ", " 1 ", "\t1", "1\t", "\n1", "1\n", "1\r", "  ");
+    }
+
+    @Test
+    void looksLikeValidNumberNull()
+    {
+        assertFalse(NumberInput.looksLikeValidNumber(null));
+    }
+
+    private void _assertValid(String... inputs) {
+        for (String input : inputs) {
+            assertTrue(NumberInput.looksLikeValidNumber(input),
+                    "Should be valid: \"" + input + "\"");
+        }
+    }
+
+    private void _assertInvalid(String... inputs) {
+        for (String input : inputs) {
+            assertFalse(NumberInput.looksLikeValidNumber(input),
+                    "Should be invalid: \"" + input + "\"");
+        }
+    }
+
+    // [core#1699]: used to backtrack quadratically on long input
+    @Test
+    void looksLikeValidNumberLongInput()
+    {
+        final int len = 1_000_000;
+        final String digits = _repeat('9', len);
+
+        assertTimeoutPreemptively(java.time.Duration.ofSeconds(10), new Executable() {
+            @Override
+            public void execute() {
+                // Valid: plain digits, and digits with fraction and exponent
+                assertTrue(NumberInput.looksLikeValidNumber(digits));
+                assertTrue(NumberInput.looksLikeValidNumber("-" + digits + "." + digits + "e" + digits));
+                // Invalid: worst case for the old regexp, a long digit run that
+                // only fails on the very last character
+                assertFalse(NumberInput.looksLikeValidNumber(digits + "x"));
+                assertFalse(NumberInput.looksLikeValidNumber(digits + "." + digits + "x"));
+            }
+        });
+    }
+
+    private String _repeat(char c, int len) {
+        StringBuilder sb = new StringBuilder(len);
+        for (int i = 0; i < len; ++i) {
+            sb.append(c);
+        }
+        return sb.toString();
     }
 }


### PR DESCRIPTION
### Problem

`NumberInput.looksLikeValidNumber()` validated with:

```java
PATTERN_FLOAT             = "[+-]?[0-9]*[\.]?[0-9]+([eE][+-]?[0-9]+)?"
PATTERN_FLOAT_TRAILING_DOT = "[+-]?[0-9]+[\.]"
```

`[0-9]*` and `[0-9]+` are adjacent, separated only by an optional dot, over the same character
class. Java's backtracking engine has no possessive quantifier or atomic group here, so on input
that does not match it must try every split point between the two groups — and for each split the
inner `[0-9]+` backtracks over its own run. That is quadratic. A failing match then runs the entire
string through `PATTERN_FLOAT_TRAILING_DOT` as well, doubling the constant factor.

Worst case is a long digit run whose only invalid character is at the very end:

| N (digits, then one non-digit) | old | new |
|---|---|---|
| 1,000 | 27 ms | 0.03 ms |
| 4,000 | 160 ms | 0.13 ms |
| 8,000 | 661 ms | 0.14 ms |
| 16,000 | 2,538 ms | 0.26 ms |
| 32,000 | 10,387 ms | 0.55 ms |

Doubling N quadruples the old time, as expected. Extrapolating the same curve to 20,000,000 — the
`maxStringLength` default that gates this path, rather than the `maxNumberLength` default of 1,000
that bounds numeric content elsewhere — puts a single call in the region of weeks. The new scan does
20M in 22 ms.

### Change

Replace both expressions with one left-to-right pass: optional sign, integer digits, optional dot
and fraction digits, optional exponent, then require the scan to have consumed the whole string. No
allocation, no backtracking, and the second pattern's trailing-dot case (`"12."`) folds into the same
walk.

### Behaviour is unchanged

Verified against the original expressions, not just re-asserted:

- **Exhaustive** over the alphabet `+-.09eEx` for every input up to length 6 — 299,593 strings, zero
  divergence.
- **Randomised**, digit-weighted, up to length 14 — 400,000 strings, zero divergence.

The new correctness tests in `NumberInputTest` were each checked to produce the same answer under the
old regexes as under the new scan, so the suite pins down preserved behaviour rather than newly
chosen behaviour. They cover sign placement, leading/trailing dots, multiple dots, exponent forms and
malformed exponents, non-ASCII digits (Arabic-Indic and full-width, which `[0-9]` never accepted),
untrimmed whitespace, and `null`.

There is also a regression test for the original complaint: a 1,000,000-character input under a 10s
`assertTimeoutPreemptively`. It fails against the old implementation (times out) and passes in ~1 ms
against the new one. Happy to drop that one if you would rather keep timing out of the suite.

Full build green: 1552 tests, 0 failures; `animal-sniffer:check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)