### PR TITLE
Backport #1649 fix to 2.18: optimize "NumberInput.looksLikeValidNumber()"

### DIFF
--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -14,6 +14,11 @@ a pure JSON library.
 === Releases ===
 ------------------------------------------------------------------------
 
+2.18.11 (not yet released)
+
+#1649: Optimize `NumberInput.looksLikeValidNumber`
+ (fix by @cowtowncoder, w/ Claude code)
+
 2.18.10 (15-Aug-2026)
 
 #1642: Fix maxDocumentLength bypass in async parser single-feedInput() case

--- a/src/main/java/com/fasterxml/jackson/core/io/NumberInput.java
+++ b/src/main/java/com/fasterxml/jackson/core/io/NumberInput.java
@@ -5,7 +5,6 @@ import ch.randelshofer.fastdoubleparser.JavaFloatParser;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.util.regex.Pattern;
 
 /**
  * Helper class for efficient parsing of various JSON numbers.
@@ -32,25 +31,6 @@ public final class NumberInput
     final static String MIN_LONG_STR_NO_SIGN = String.valueOf(Long.MIN_VALUE).substring(1);
     final static String MAX_LONG_STR = String.valueOf(Long.MAX_VALUE);
 
-    /**
-     * Regexp used to pre-validate "Stringified Numbers": slightly looser than
-     * JSON Number definition (allows leading zeroes, positive sign).
-     *
-     * @since 2.17
-     */
-    private final static Pattern PATTERN_FLOAT = Pattern.compile(
-          "[+-]?[0-9]*[\\.]?[0-9]+([eE][+-]?[0-9]+)?");
-
-
-    /**
-     * Secondary regexp used along with {@code PATTERN_FLOAT} to cover
-     * case where number ends with dot, like {@code "+12."}
-     *
-     * @since 2.17.2
-     */
-    private final static Pattern PATTERN_FLOAT_TRAILING_DOT = Pattern.compile(
-            "[+-]?[0-9]+[\\.]");
-    
     /**
      * Fast method for parsing unsigned integers that are known to fit into
      * regular 32-bit signed int type. This means that length is
@@ -636,23 +616,86 @@ public final class NumberInput
      *<p>
      * Note: this method returning {@code true} DOES NOT GUARANTEE String is valid
      * number but just that it looks close enough.
+     *<p>
+     * Note: method rewritten in 2.18.11 to avoid use of JDK regexp functionality.
      *
      * @param s String to validate
      *
      * @return True if String looks like valid Java number; false otherwise.
      *
-     * @since 2.17
+     * @since 2.17 (rewritten in 2.18.11)
      */
     public static boolean looksLikeValidNumber(final String s) {
-        // While PATTERN_FLOAT handles most cases we can optimize some simple ones:
-        if (s == null || s.isEmpty()) {
+        // 08-Aug-2026, tatu: [core#1649] Hand-rolled scan; matches (union of)
+        //    "[+-]?[0-9]*[.]?[0-9]+([eE][+-]?[0-9]+)?" and "[+-]?[0-9]+[.]"
+        if (s == null) {
             return false;
         }
-        if (s.length() == 1) {
-            char c = s.charAt(0);
-            return (c <= '9') && (c >= '0');
+        final int len = s.length();
+        if (len == 0) {
+            return false;
         }
-        return PATTERN_FLOAT.matcher(s).matches()
-                || PATTERN_FLOAT_TRAILING_DOT.matcher(s).matches();
+        int i = 0;
+        char c = s.charAt(i);
+
+        // Optional sign
+        if (c == '+' || c == '-') {
+            if (++i == len) { // sign alone
+                return false;
+            }
+            c = s.charAt(i);
+        }
+
+        // Integer part, if any
+        final int intStart = i;
+        while (c >= '0' && c <= '9') {
+            if (++i == len) { // "[+-]?[0-9]+"
+                return true;
+            }
+            c = s.charAt(i);
+        }
+        final int intDigits = i - intStart;
+
+        if (c == '.') {
+            if (++i == len) { // trailing dot only allowed after digit(s)
+                return intDigits > 0;
+            }
+            c = s.charAt(i);
+            final int fractStart = i;
+            while (c >= '0' && c <= '9') {
+                if (++i == len) {
+                    return true;
+                }
+                c = s.charAt(i);
+            }
+            if (i == fractStart) { // "1.x": no fraction digits, and not trailing dot
+                return false;
+            }
+        } else if (intDigits == 0) { // no mantissa digits at all
+            return false;
+        }
+
+        // Only an exponent may follow
+        if (c != 'e' && c != 'E') {
+            return false;
+        }
+        if (++i == len) {
+            return false;
+        }
+        c = s.charAt(i);
+        if (c == '+' || c == '-') {
+            if (++i == len) {
+                return false;
+            }
+            c = s.charAt(i);
+        }
+        while (c >= '0' && c <= '9') {
+            if (++i == len) {
+                return true;
+            }
+            c = s.charAt(i);
+        }
+        // Either no exponent digits, or trailing garbage
+        return false;
     }
 }

--- a/src/test/java/com/fasterxml/jackson/core/io/NumberInputTest.java
+++ b/src/test/java/com/fasterxml/jackson/core/io/NumberInputTest.java
@@ -1,6 +1,7 @@
 package com.fasterxml.jackson.core.io;
 
 import java.math.BigInteger;
+import java.util.regex.Pattern;
 
 import org.junit.jupiter.api.Test;
 
@@ -105,6 +106,10 @@ class NumberInputTest
         assertTrue(NumberInput.looksLikeValidNumber("1.4E-45"));
         assertTrue(NumberInput.looksLikeValidNumber("1.4e+45"));
 
+        // Fully populated form: sign, integer part, fraction, signed exponent
+        assertTrue(NumberInput.looksLikeValidNumber("+1.2e+3"));
+        assertTrue(NumberInput.looksLikeValidNumber("-12.34E-56"));
+
         // https://github.com/FasterXML/jackson-core/issues/1308
         assertTrue(NumberInput.looksLikeValidNumber("0."));
         assertTrue(NumberInput.looksLikeValidNumber("6."));
@@ -139,5 +144,49 @@ class NumberInputTest
         assertFalse(NumberInput.looksLikeValidNumber("+."));
         assertFalse(NumberInput.looksLikeValidNumber("-E"));
         assertFalse(NumberInput.looksLikeValidNumber("+E"));
+
+        assertFalse(NumberInput.looksLikeValidNumber("1.2.3"));
+        assertFalse(NumberInput.looksLikeValidNumber("1.e5"));
+        assertFalse(NumberInput.looksLikeValidNumber("1e"));
+        assertFalse(NumberInput.looksLikeValidNumber("1e+"));
+        assertFalse(NumberInput.looksLikeValidNumber("1e5x"));
+        assertFalse(NumberInput.looksLikeValidNumber("1e5.0"));
+        assertFalse(NumberInput.looksLikeValidNumber("--1"));
+        assertFalse(NumberInput.looksLikeValidNumber("1 "));
+        assertFalse(NumberInput.looksLikeValidNumber(" 1"));
+        assertFalse(NumberInput.looksLikeValidNumber("0x1F"));
+    }
+
+    // [core#1649]: hand-rolled implementation must accept exactly what the
+    // original Regexp-based one did
+    @Test
+    void looksLikeValidNumberMatchesLegacyRegexps()
+    {
+        final Pattern patternFloat = Pattern.compile("[+-]?[0-9]*[\\.]?[0-9]+([eE][+-]?[0-9]+)?");
+        final Pattern patternTrailingDot = Pattern.compile("[+-]?[0-9]+[\\.]");
+        // Digit-class bounds ('0', '9') plus the chars just outside it ('/', ':')
+        // to catch off-by-one in digit checks; rest are the structural characters
+        final char[] alphabet = new char[] { '0', '9', '/', ':', '+', '-', '.', 'e', 'E' };
+
+        // Length 5 needed to reach forms combining both signs ("+1e+1") or
+        // integer + fraction + exponent ("1.2e3"); ~66k inputs, runs in ~50 msec
+        _verifyAgainstRegexps(patternFloat, patternTrailingDot, alphabet, "", 5);
+    }
+
+    private void _verifyAgainstRegexps(Pattern patternFloat, Pattern patternTrailingDot,
+            char[] alphabet, String prefix, int remainingLength)
+    {
+        if (!prefix.isEmpty()) {
+            boolean exp = patternFloat.matcher(prefix).matches()
+                    || patternTrailingDot.matcher(prefix).matches();
+            assertEquals(exp, NumberInput.looksLikeValidNumber(prefix),
+                    "Mismatch for input '"+prefix+"'");
+        }
+        if (remainingLength > 0) {
+            for (char c : alphabet) {
+                _verifyAgainstRegexps(patternFloat, patternTrailingDot, alphabet,
+                        prefix + c, remainingLength - 1);
+            }
+        }
     }
 }


### PR DESCRIPTION
Backport of https://github.com/FasterXML/jackson-core/pull/1650 [GHSA-p6pp-m3f8-5c89]: replaces the two regexps with a hand-rolled single-pass scan.
