### PR TITLE
Validate name length in `UTF8DataInputJsonParser` before quad buffer growth

### DIFF
--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -58,6 +58,9 @@ Revanth Meesala (@revanthmeesala)
 Lee Dongnyoung (@DongNyoung)
  * Contributed #1651: Fix object context handling for buffered `INCLUDE_NON_NULL` tokens
   (3.1.6)
+ * Reported, fixed #1703: Validate name length in `UTF8DataInputJsonParser` before
+   quad buffer growth
+  (3.1.7)
 
 @hdimitrieski
  * Reported #1668: `WriterBasedJsonGenerator` AIOOBE when a zero-length custom

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -26,6 +26,8 @@ JSON library.
 #1673: `readString(Writer)` AIOOBE when an escape or multi-byte character
   lands at the output buffer boundary
  (fix by @pjfanning)
+#1703: Validate name length in `UTF8DataInputJsonParser` before quad buffer growth
+ (reported, fix by DongNyoung L)
 
 3.1.6 (14-Aug-2026)
 

--- a/src/main/java/tools/jackson/core/json/UTF8DataInputJsonParser.java
+++ b/src/main/java/tools/jackson/core/json/UTF8DataInputJsonParser.java
@@ -1560,7 +1560,7 @@ public class UTF8DataInputJsonParser
                         ++currQuadBytes;
                         if (currQuadBytes >= 4) {
                             if (qlen >= quads.length) {
-                                _quadBuffer = quads = growArrayBy(quads, quads.length);
+                                _quadBuffer = quads = _growNameDecodeBuffer(quads, quads.length);
                             }
                             quads[qlen++] = currQuad;
                             currQuad = 0;
@@ -1570,7 +1570,7 @@ public class UTF8DataInputJsonParser
                         ++currQuadBytes;
                         if (currQuadBytes >= 4) {
                             if (qlen >= quads.length) {
-                                _quadBuffer = quads = growArrayBy(quads, quads.length);
+                                _quadBuffer = quads = _growNameDecodeBuffer(quads, quads.length);
                             }
                             quads[qlen++] = currQuad;
                             currQuad = 0;
@@ -1767,7 +1767,7 @@ public class UTF8DataInputJsonParser
                         ++currQuadBytes;
                         if (currQuadBytes >= 4) {
                             if (qlen >= quads.length) {
-                                _quadBuffer = quads = growArrayBy(quads, quads.length);
+                                _quadBuffer = quads = _growNameDecodeBuffer(quads, quads.length);
                             }
                             quads[qlen++] = currQuad;
                             currQuad = 0;
@@ -1777,7 +1777,7 @@ public class UTF8DataInputJsonParser
                         ++currQuadBytes;
                         if (currQuadBytes >= 4) {
                             if (qlen >= quads.length) {
-                                _quadBuffer = quads = growArrayBy(quads, quads.length);
+                                _quadBuffer = quads = _growNameDecodeBuffer(quads, quads.length);
                             }
                             quads[qlen++] = currQuad;
                             currQuad = 0;

--- a/src/main/java/tools/jackson/core/json/UTF8StreamJsonParser.java
+++ b/src/main/java/tools/jackson/core/json/UTF8StreamJsonParser.java
@@ -1591,7 +1591,7 @@ public class UTF8StreamJsonParser
         while ((qptr + 4) <= _inputEnd) {
             // [core#1516]: Need to check buffer space BEFORE any writes in this iteration
             if (qlen >= _quadBuffer.length) {
-                _quadBuffer = growArrayBy(_quadBuffer, qlen);
+                _quadBuffer = _growNameDecodeBuffer(_quadBuffer, qlen);
             }
             int i = input[qptr++] & 0xFF;
             if (codes[i] != 0) {

--- a/src/test/java/tools/jackson/core/unittest/constraints/LargeNameReadTest.java
+++ b/src/test/java/tools/jackson/core/unittest/constraints/LargeNameReadTest.java
@@ -1,26 +1,32 @@
 package tools.jackson.core.unittest.constraints;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.junit.jupiter.api.Test;
 
 import tools.jackson.core.JsonParser;
+import tools.jackson.core.JsonToken;
 import tools.jackson.core.ObjectReadContext;
 import tools.jackson.core.StreamReadConstraints;
 import tools.jackson.core.async.ByteArrayFeeder;
 import tools.jackson.core.exc.StreamConstraintsException;
 import tools.jackson.core.json.JsonFactory;
 import tools.jackson.core.json.JsonReadFeature;
+import tools.jackson.core.sym.PropertyNameMatcher;
 import tools.jackson.core.unittest.*;
 import tools.jackson.core.util.JsonRecyclerPools;
+import tools.jackson.core.util.Named;
 
 import static org.junit.jupiter.api.Assertions.fail;
 
 // [core#1047]: Add max-name-length constraints
 class LargeNameReadTest extends JacksonCoreTestBase
 {
+    private final static int UTF8_INITIAL_QUAD_BUFFER_QUADS = 16;
+
     private final JsonFactory JSON_F_DEFAULT = newStreamFactory();
 
     private final JsonFactory JSON_F_NAME_100 = JsonFactory.builder()
@@ -170,6 +176,91 @@ class LargeNameReadTest extends JacksonCoreTestBase
         }
     }
 
+    @Test
+    void largeEscapedSupplementaryNameWithSmallLimitDataInputFailsDuringQuadBufferGrowth() throws Exception {
+        _testLargeEscapedSupplementaryNameWithSmallLimitDataInput(JSON_F_NAME_100, "\"");
+        _testLargeEscapedSupplementaryNameWithSmallLimitDataInput(JSON_F_NAME_100_ODD, "'");
+    }
+
+    private void _testLargeEscapedSupplementaryNameWithSmallLimitDataInput(JsonFactory jf,
+            String nameQuote) throws Exception
+    {
+        final int pairCount = 1_000;
+        // Decoded supplementary code point is stored as 4 UTF-8 bytes in the quad buffer.
+        final int fullNameLen = 1 + (pairCount << 2);
+        _testEscapedSupplementaryNameAtDataInputQuadGrowBoundary(jf,
+                generateEscapedSupplementaryNameJSON(pairCount, nameQuote), fullNameLen);
+
+        // These prefixes force the two flush points inside the supplementary
+        // character branch to grow the quad buffer.
+        _testEscapedSupplementaryNameAtDataInputQuadGrowBoundary(jf,
+                generateEscapedSupplementaryNameJSON(pairCount, nameQuote, 2),
+                2 + (pairCount << 2));
+        _testEscapedSupplementaryNameAtDataInputQuadGrowBoundary(jf,
+                generateEscapedSupplementaryNameJSON(pairCount, nameQuote, 3),
+                3 + (pairCount << 2));
+    }
+
+    @Test
+    void largeNameWithSmallLimitAndMatcherFailsDuringQuadBufferGrowth() throws Exception {
+        final int nameLen = 1_000;
+        final String name = generateName(nameLen);
+        final String doc = "{\"" + name + "\":\"value\"}";
+        final PropertyNameMatcher matcher = JSON_F_NAME_100.constructNameMatcher(
+                List.of(Named.fromString(name)), false);
+
+        try (JsonParser p = createParser(JSON_F_NAME_100, MODE_INPUT_STREAM, doc)) {
+            assertToken(JsonToken.START_OBJECT, p.nextToken());
+            p.nextNameMatch(matcher);
+            fail("expected StreamConstraintsException");
+        } catch (StreamConstraintsException e) {
+            verifyException(e, "Name length");
+            verifyNameLengthFailedAtUtf8QuadGrowBoundary(e,
+                    JSON_F_NAME_100.streamReadConstraints().getMaxNameLength(), nameLen);
+        }
+    }
+
+    private void _testEscapedSupplementaryNameAtDataInputQuadGrowBoundary(JsonFactory jf,
+            String doc, int fullNameLen) throws Exception
+    {
+        try (JsonParser p = createParser(jf, MODE_DATA_INPUT, doc)) {
+            consumeTokens(p);
+            fail("expected StreamConstraintsException");
+        } catch (StreamConstraintsException e) {
+            verifyException(e, "Name length");
+            verifyNameLengthFailedAtUtf8QuadGrowBoundary(e,
+                    jf.streamReadConstraints().getMaxNameLength(), fullNameLen);
+        }
+    }
+
+    private void verifyNameLengthFailedAtUtf8QuadGrowBoundary(StreamConstraintsException e,
+            int maxNameLength, int fullNameLen) {
+        final int reportedLen = _reportedNameLength(e);
+        final int expectedFailingGrowBoundary = _utf8QuadGrowBoundaryAbove(maxNameLength);
+
+        if (reportedLen <= maxNameLength) {
+            fail("Expected reported name length to exceed maxNameLength "+maxNameLength
+                    +", but reported length was: "+reportedLen);
+        }
+        if (reportedLen >= fullNameLen) {
+            fail("Should have failed while growing the quad buffer, before buffering the full "
+                    +"decoded UTF-8 name length "+fullNameLen
+                    +", but reported length was: "+reportedLen);
+        }
+        if (reportedLen != expectedFailingGrowBoundary) {
+            fail("Expected failure at UTF-8 quad-buffer grow boundary "
+                    +expectedFailingGrowBoundary+", but reported length was: "+reportedLen);
+        }
+    }
+
+    private int _utf8QuadGrowBoundaryAbove(int maxNameLength) {
+        int quadBufferLen = UTF8_INITIAL_QUAD_BUFFER_QUADS;
+        while ((quadBufferLen << 2) <= maxNameLength) {
+            quadBufferLen += quadBufferLen;
+        }
+        return quadBufferLen << 2;
+    }
+
     private void consumeTokens(JsonParser p) throws IOException {
         while (p.nextToken() != null) {
             ;
@@ -186,6 +277,32 @@ class LargeNameReadTest extends JacksonCoreTestBase
         sb.append("{").append(nameQuote);
         for (int i = 0; i < nameLen; i++) {
             sb.append("a");
+        }
+        sb.append(nameQuote).append(":\"value\"}");
+        return sb.toString();
+    }
+
+    private String generateName(final int nameLen) {
+        final StringBuilder sb = new StringBuilder(nameLen);
+        for (int i = 0; i < nameLen; i++) {
+            sb.append("a");
+        }
+        return sb.toString();
+    }
+
+    private String generateEscapedSupplementaryNameJSON(final int pairCount, String nameQuote) {
+        return generateEscapedSupplementaryNameJSON(pairCount, nameQuote, 1);
+    }
+
+    private String generateEscapedSupplementaryNameJSON(final int pairCount, String nameQuote,
+            int asciiPrefixLen) {
+        final StringBuilder sb = new StringBuilder();
+        sb.append("{").append(nameQuote);
+        for (int i = 0; i < asciiPrefixLen; i++) {
+            sb.append("a");
+        }
+        for (int i = 0; i < pairCount; i++) {
+            sb.append("\\ud83d\\udc4d");
         }
         sb.append(nameQuote).append(":\"value\"}");
         return sb.toString();


### PR DESCRIPTION
Re-creation of #1691 (by @Dongnyoung) targeting `3.1` instead of `3.x`: the unvalidated grow sites exist since 3.1.0 (#1541), so the fix goes to 3.1 and merges forward to 3.2 / 3.x.

## Summary

Validate `maxNameLength` before growing quad buffers in UTF-8 field name decoding and matching paths.

This replaces direct `growArrayBy(...)` calls with the name-aware `_growNameDecodeBuffer(...)` helper where needed, avoiding unnecessary buffering before oversized names are rejected.

Regression tests cover both the DataInput escaped supplementary path and the `PropertyNameMatcher` long-name path.

Release notes added under 3.1.7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ADdsc11y5LUUxQDVCqyYad
