### PR TITLE
Write number text directly as ASCII bytes in `UTF8JsonGenerator`

### DIFF
--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -44,6 +44,8 @@ JSON library.
 #1704: Add `NumberOutput.outputDouble/outputFloat(char[])`, use in
   `WriterBasedJsonGenerator` with `USE_FAST_DOUBLE_WRITER`
  (contributed by @pjfanning, w/ Claude code)
+#1706: Write number text directly as ASCII bytes in `UTF8JsonGenerator`
+ (contributed by @pjfanning, w/ Claude code)
 
 3.2.3 (not yet released)
 

--- a/src/main/java/tools/jackson/core/json/UTF8JsonGenerator.java
+++ b/src/main/java/tools/jackson/core/json/UTF8JsonGenerator.java
@@ -1058,9 +1058,9 @@ public class UTF8JsonGenerator
         if (value == null) {
             _writeNull();
         } else if (_cfgNumbersAsStrings) {
-            _writeQuotedRaw(value.toString());
+            _writeQuotedAscii(value.toString());
         } else {
-            writeRaw(value.toString());
+            _writeRawAscii(value.toString());
         }
         return this;
     }
@@ -1083,7 +1083,8 @@ public class UTF8JsonGenerator
             _outputTail = NumberOutput.outputDouble(d, _outputBuffer, _outputTail);
             return this;
         }
-        return writeRaw(NumberOutput.toString(d, false));
+        _writeRawAscii(NumberOutput.toString(d, false));
+        return this;
     }
 
     // Number text is all ASCII and needs no escaping, so write it out raw, same as
@@ -1093,7 +1094,7 @@ public class UTF8JsonGenerator
     {
         _verifyValueWrite(WRITE_STRING);
         if (!useFast) {
-            _writeQuotedRaw(NumberOutput.toString(d, false));
+            _writeQuotedAscii(NumberOutput.toString(d, false));
             return;
         }
         if ((_outputTail + NumberOutput.MAX_DOUBLE_BYTES + 2) > _outputEnd) {
@@ -1122,14 +1123,15 @@ public class UTF8JsonGenerator
             _outputTail = NumberOutput.outputFloat(f, _outputBuffer, _outputTail);
             return this;
         }
-        return writeRaw(NumberOutput.toString(f, false));
+        _writeRawAscii(NumberOutput.toString(f, false));
+        return this;
     }
 
     private final void _writeQuotedFloat(float f, boolean useFast) throws JacksonException
     {
         _verifyValueWrite(WRITE_STRING);
         if (!useFast) {
-            _writeQuotedRaw(NumberOutput.toString(f, false));
+            _writeQuotedAscii(NumberOutput.toString(f, false));
             return;
         }
         if ((_outputTail + NumberOutput.MAX_FLOAT_BYTES + 2) > _outputEnd) {
@@ -1148,9 +1150,9 @@ public class UTF8JsonGenerator
         if (value == null) {
             _writeNull();
         } else  if (_cfgNumbersAsStrings) {
-            _writeQuotedRaw(_asString(value));
+            _writeQuotedAscii(_asString(value));
         } else {
-            writeRaw(_asString(value));
+            _writeRawAscii(_asString(value));
         }
         return this;
     }
@@ -1178,6 +1180,51 @@ public class UTF8JsonGenerator
             writeRaw(encodedValueBuffer, offset, length);
         }
         return this;
+    }
+
+    // Number text is pure ASCII: copy straight into the output byte[] instead of
+    // going through writeRaw(String), which first copies into _charBuffer and then
+    // runs the UTF-8 encoding loop (with 3x room reservation) over it.
+    private final void _writeRawAscii(String text) throws JacksonException
+    {
+        int offset = 0;
+        int len = text.length();
+        while (true) {
+            int room = _outputEnd - _outputTail;
+            if (room >= len) {
+                break;
+            }
+            // Chunk: only reachable for very long BigInteger/BigDecimal text
+            _copyAscii(text, offset, room);
+            offset += room;
+            len -= room;
+            _flushBuffer();
+        }
+        _copyAscii(text, offset, len);
+    }
+
+    private final void _copyAscii(String text, int offset, int len)
+    {
+        final byte[] buf = _outputBuffer;
+        int ptr = _outputTail;
+        final int end = offset + len;
+        for (int i = offset; i < end; ++i) {
+            buf[ptr++] = (byte) text.charAt(i);
+        }
+        _outputTail = ptr;
+    }
+
+    private final void _writeQuotedAscii(String value) throws JacksonException
+    {
+        if (_outputTail >= _outputEnd) {
+            _flushBuffer();
+        }
+        _outputBuffer[_outputTail++] = _quoteChar;
+        _writeRawAscii(value);
+        if (_outputTail >= _outputEnd) {
+            _flushBuffer();
+        }
+        _outputBuffer[_outputTail++] = _quoteChar;
     }
 
     private final void _writeQuotedRaw(String value) throws JacksonException

--- a/src/main/java/tools/jackson/core/json/UTF8JsonGenerator.java
+++ b/src/main/java/tools/jackson/core/json/UTF8JsonGenerator.java
@@ -1183,35 +1183,30 @@ public class UTF8JsonGenerator
     }
 
     // Number text is pure ASCII: copy straight into the output byte[] instead of
-    // going through writeRaw(String), which first copies into _charBuffer and then
-    // runs the UTF-8 encoding loop (with 3x room reservation) over it.
+    // going through writeRaw(String), which runs the UTF-8 encoding loop (with 3x
+    // room reservation) over it. Content is copied via String.getChars() (an
+    // intrinsic) rather than scanned with String.charAt(), whose JVM-wide branch
+    // profile is polluted by any non-Latin1 String use elsewhere (see [core#1680]).
     private final void _writeRawAscii(String text) throws JacksonException
     {
+        final char[] cbuf = _charBuffer;
+        final int totalLen = text.length();
         int offset = 0;
-        int len = text.length();
-        while (true) {
-            int room = _outputEnd - _outputTail;
-            if (room >= len) {
-                break;
+        while (offset < totalLen) {
+            if (_outputTail >= _outputEnd) {
+                _flushBuffer();
             }
-            // Chunk: only reachable for very long BigInteger/BigDecimal text
-            _copyAscii(text, offset, room);
-            offset += room;
-            len -= room;
-            _flushBuffer();
+            // Chunking only ever kicks in for very long BigInteger/BigDecimal text
+            int len = Math.min(totalLen - offset, Math.min(cbuf.length, _outputEnd - _outputTail));
+            text.getChars(offset, offset + len, cbuf, 0);
+            final byte[] buf = _outputBuffer;
+            int ptr = _outputTail;
+            for (int i = 0; i < len; ++i) {
+                buf[ptr++] = (byte) cbuf[i];
+            }
+            _outputTail = ptr;
+            offset += len;
         }
-        _copyAscii(text, offset, len);
-    }
-
-    private final void _copyAscii(String text, int offset, int len)
-    {
-        final byte[] buf = _outputBuffer;
-        int ptr = _outputTail;
-        final int end = offset + len;
-        for (int i = offset; i < end; ++i) {
-            buf[ptr++] = (byte) text.charAt(i);
-        }
-        _outputTail = ptr;
     }
 
     private final void _writeQuotedAscii(String value) throws JacksonException

--- a/src/test/java/tools/jackson/core/unittest/write/GeneratorBasicTest.java
+++ b/src/test/java/tools/jackson/core/unittest/write/GeneratorBasicTest.java
@@ -15,6 +15,8 @@ import tools.jackson.core.ObjectReadContext;
 import tools.jackson.core.ObjectWriteContext;
 import tools.jackson.core.TokenStreamContext;
 import tools.jackson.core.TokenStreamFactory;
+import tools.jackson.core.json.JsonFactory;
+import tools.jackson.core.json.JsonWriteFeature;
 import tools.jackson.core.unittest.*;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -217,6 +219,44 @@ public class GeneratorBasicTest
 
         assertEquals("{\"short\":3,\"int\":3,\"long\":3,\"big\":1707,\"double\":0.25,\"float\":-0.25,\"decimal\":17.07}",
                 docStr.trim());
+    }
+
+    // Number text longer than the output buffer must be chunked across flushes,
+    // both plain and quoted (WRITE_NUMBERS_AS_STRINGS), for all number types
+    // written via their String form
+    @Test
+    void longNumberTextAcrossBufferBoundary() throws Exception
+    {
+        final StringBuilder sb = new StringBuilder(20_000);
+        sb.append('7');
+        for (int i = 0; i < 19_999; ++i) {
+            sb.append((char) ('0' + (i % 10)));
+        }
+        final String digits = sb.toString();
+        final BigInteger bigInt = new BigInteger(digits);
+        final BigDecimal bigDec = new BigDecimal(digits + ".5");
+
+        for (boolean quoted : new boolean[] { false, true }) {
+            TokenStreamFactory f = JsonFactory.builder()
+                    .configure(JsonWriteFeature.WRITE_NUMBERS_AS_STRINGS, quoted)
+                    .build();
+            for (boolean useBytes : new boolean[] { false, true }) {
+                StringWriter sw = new StringWriter();
+                ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+                JsonGenerator gen = useBytes
+                        ? f.createGenerator(ObjectWriteContext.empty(), bytes)
+                        : f.createGenerator(ObjectWriteContext.empty(), sw);
+                gen.writeStartArray();
+                gen.writeNumber(bigInt);
+                gen.writeNumber(bigDec);
+                gen.writeEndArray();
+                gen.close();
+
+                String q = quoted ? "\"" : "";
+                String exp = "[" + q + digits + q + "," + q + digits + ".5" + q + "]";
+                assertEquals(exp, useBytes ? utf8String(bytes) : sw.toString());
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
`UTF8JsonGenerator.writeNumber()` for `double`/`float` (when `USE_FAST_DOUBLE_WRITER` is off), `BigInteger` and `BigDecimal` went through `writeRaw(String)`, which copies the text into `_charBuffer` via `getChars()` and then runs the general UTF-8 encoding loop (with 3x room reservation) over it. Number text is always ASCII, so this adds `_writeRawAscii()` / `_writeQuotedAscii()` helpers that copy straight into the output `byte[]`, chunking across buffer flushes for very long text.

`writeNumber(String)` is left as-is since its text is caller-supplied. `WriterBasedJsonGenerator` already writes with `getChars()` directly into its output `char[]`, so nothing to do there.

### Numbers

Hand-rolled harness, JDK 17, 5 JVM forks, 2000 values x 300 reps per round, `USE_FAST_DOUBLE_WRITER` off:

| case | base median | new median | base min | new min |
|---|---|---|---|---|
| BigDecimal (`toString` cached, isolates the copy path) | 31.7 ms | 15.9 ms | 23.7 | 15.2 |
| double | 276 | 246 | 229 | 229 |
| float | 128 | 111 | 101 | 105 |
| BigInteger (200-bit) | 994 | 916 | 831 | 840 |
| double, quoted | 266 | 248 | 228 | 228 |
| BigInteger, quoted | 999 | 938 | 849 | 889 |

The copy path itself is roughly halved; for `double`/`float`/`BigInteger` the `toString()` cost dominates so the gain there is modest. Tried the deprecated `String.getBytes(int,int,byte[],int)` instead of a `charAt` loop: no measurable difference. The loop was later changed to copy via `String.getChars()` into `_charBuffer` and narrow from there, avoiding `charAt()` branch-profile pollution from non-Latin1 Strings elsewhere (see #1680); numbers above were measured with the `charAt` version.

Adds `GeneratorBasicTest.longNumberTextAcrossBufferBoundary` covering 20,000-digit `BigInteger`/`BigDecimal` through both generators, plain and quoted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
